### PR TITLE
Treebrowser fixes

### DIFF
--- a/treebrowser/src/treebrowser.c
+++ b/treebrowser/src/treebrowser.c
@@ -1371,18 +1371,6 @@ on_treeview_mouseclick(GtkWidget *widget, GdkEventButton *event, GtkTreeSelectio
 	GtkTreePath *path;
 	gchar 			*name = "", *uri = "";
 
-	// Get tree path for row that was clicked
-	if (gtk_tree_view_get_path_at_pos(GTK_TREE_VIEW(treeview),
-																	 (gint) event->x, 
-																	 (gint) event->y,
-																	 &path, NULL, NULL, NULL))
-	{
-		// Unselect current selection; select clicked row from path
-		gtk_tree_selection_unselect_all(selection);
-		gtk_tree_selection_select_path(selection, path);
-		gtk_tree_path_free(path);
-	}
-
 	if (gtk_tree_selection_get_selected(selection, &model, &iter))
 		/* FIXME: name and uri should be freed, but they are passed to create_popup_menu()
 		 * that pass them directly to some callbacks, so we can't free them here for now.
@@ -1394,6 +1382,17 @@ on_treeview_mouseclick(GtkWidget *widget, GdkEventButton *event, GtkTreeSelectio
 
 	if (event->button == 3)
 	{
+		// Get tree path for row that was clicked
+		if (gtk_tree_view_get_path_at_pos(GTK_TREE_VIEW(treeview),
+																		 (gint) event->x, 
+																		 (gint) event->y,
+																		 &path, NULL, NULL, NULL))
+		{
+			// Unselect current selection; select clicked row from path
+			gtk_tree_selection_unselect_all(selection);
+			gtk_tree_selection_select_path(selection, path);
+			gtk_tree_path_free(path);
+		}
 		gtk_menu_popup(GTK_MENU(create_popup_menu(name, uri)), NULL, NULL, NULL, NULL, event->button, event->time);
 		return TRUE;
 	}


### PR DESCRIPTION
Fixed four issues for the Treebrowser plugin. See the commits in parantheses for details.
1. When right-clicking on a file or directory, that file or directory should become selected before the context menu is shown. Previously, the user had to left-click first, before right-clicking. (46e40edc + 67c7ad1f)
2. When renaming a file, you should not show the 'do you really want to replace it?' warning message if the filename has not changed. (d8059a4d)
3. If I create an empty directory, then highlight '(Empty)' and right click it, the 'Create new directory' and 'Create new file' commands do nothing. (7c55f34)
4. Files were created with 0755 (-rwxr-xr-x) permissions when they should be 0644 (-rw-r--r--). (f2e9232e)
#### Here are the corresponding SourceForge tickets:
- [Issues 1, 2 & 3](http://sourceforge.net/tracker/?func=detail&aid=3452174&group_id=222729&atid=1056532)
- [Issue 1](http://sourceforge.net/tracker/?func=detail&aid=3440602&group_id=222729&atid=1056532)
- [Issue 4](http://sourceforge.net/tracker/?func=detail&aid=3415045&group_id=222729&atid=1056532)

Cheers,
Nathan
