### PR TITLE
geanyminiscript: Add headers to _SOURCES so they get distributed

### DIFF
--- a/geanyminiscript/src/Makefile.am
+++ b/geanyminiscript/src/Makefile.am
@@ -6,7 +6,7 @@ else
 EXTRA_LTLIBRARIES = geanyminiscript.la
 endif
 
-geanyminiscript_la_SOURCES = gms.c gms_gui.c
+geanyminiscript_la_SOURCES = gms.c gms.h gms_gui.c gms_gui.h gms_debug.h
 geanyminiscript_la_LIBADD = $(COMMONLIBS)
 
 include $(top_srcdir)/build/cppcheck.mk


### PR DESCRIPTION
Building from tarball made with `make dist` wasn't working until I made this change because of missing GMS headers.
