### PR TITLE
GeanyLua: explicitly link GModule

### DIFF
--- a/build/geanylua.m4
+++ b/build/geanylua.m4
@@ -16,6 +16,7 @@ AC_DEFUN([GP_CHECK_GEANYLUA],
     LUA_VERSION=5.1
     GP_CHECK_PLUGIN_DEPS([GeanyLua], [LUA],
                          [${LUA_PKG_NAME} >= ${LUA_VERSION}])
+    GP_CHECK_PLUGIN_DEPS([GeanyLua], [GMODULE], [gmodule-2.0])
     GP_STATUS_PLUGIN_ADD([GeanyLua], [$enable_geanylua])
 
     AC_CONFIG_FILES([

--- a/geanylua/Makefile.am
+++ b/geanylua/Makefile.am
@@ -38,10 +38,12 @@ libgeanylua_la_SOURCES = \
 
 geanylua_la_CFLAGS = \
 	$(AM_CFLAGS) \
+	$(GMODULE_CFLAGS) \
 	$(LUA_CFLAGS)
 
 geanylua_la_LIBADD = \
 	$(COMMONLIBS) \
+	$(GMODULE_LIBS) \
 	$(LUA_LIBS)
 
 libgeanylua_la_CFLAGS = $(geanylua_la_CFLAGS)

--- a/geanylua/wscript_build
+++ b/geanylua/wscript_build
@@ -28,7 +28,7 @@ sources = ['geanylua.c']
 lua_sources = [ 'glspi_init.c', 'glspi_app.c', 'glspi_dlg.c',
                 'glspi_doc.c', 'glspi_kfile.c', 'glspi_run.c',
                 'glspi_sci.c', 'gsdlg_lua.c' ]
-libraries = ['LUA']
+libraries = ['LUA', 'GMODULE']
 
 build_plugin(bld, name, sources=sources, libraries=libraries)
 

--- a/geanylua/wscript_configure
+++ b/geanylua/wscript_configure
@@ -42,3 +42,9 @@ def try_to_find_lua_package():
 found_lua_package = try_to_find_lua_package()
 if not found_lua_package:
     raise ConfigurationError('You need Lua 5.1 for the GeanyLua plugin')
+
+check_cfg_cached(conf,
+    package='gmodule-2.0',
+    mandatory=True,
+    uselib_store='GMODULE',
+    args='--cflags --libs')


### PR DESCRIPTION
Explicit linking of GModule is now required since GIO stopped publicly
depending on it.
