### PR TITLE
Bugfix

### DIFF
--- a/geanypg/ChangeLog
+++ b/geanypg/ChangeLog
@@ -1,0 +1,90 @@
+2012-06-04 Hans Alves  <alves(dot)h88(at)gmail(dot)com>
+
+* Fixed a bug that caused an error message to appear if one of the
+  keys used to encrypt are not trusted.
+
+2011-10-20 Colomban Wendling  <colomban(at)geany(dot)org>
+
+* Fix a typo that broke the build
+
+2011-09-01 Hans Alves  <alves(dot)h88(at)gmail(dot)com>
+
+* Adding documentation
+
+2011-09-01 Hans Alves  <alves(dot)h88(at)gmail(dot)com>
+
+* Applied patch by sardenmff7 to fix bug 3344648
+
+2011-08-15 Hans Alves  <alves(dot)h88(at)gmail(dot)com>
+
+* Removed leading whitespace from a translatable string in pinentry.c
+  updated po/ChangeLog, some minor changes to the spanish translation
+  of geanypg and added a dutch translation
+
+2011-08-14 Hans Alves  <alves(dot)h88(at)gmail(dot)com>
+
+* Added everything necessary for translation of geanypg and a spanish
+  translation. Also fixed a bug, when decrypting don't give an error
+  if no signatures are found.
+
+2011-08-14 Hans Alves  <alves(dot)h88(at)gmail(dot)com>
+
+* changed Makefile.am to work with renamed aux.c
+
+2011-08-14 Hans Alves  <alves(dot)h88(at)gmail(dot)com>
+
+* changed aux.c filename for windows compatibility
+
+2011-08-13 Hans Alves  <alves(dot)h88(at)gmail(dot)com>
+
+* Fixed a bunch of compiler warnings about shadowing the global index
+  variable and discarding const qualifiers (string literals are const)
+  and fixed a function definition (geanypg_validity)  which had a wrong
+  parameter type(gpgme_summary_t instead of gpgme_validity_t).
+
+2011-05-29 Enrico Tröger  <enrico(dot)troeger(at)uvena(dot)de>
+
+* Set eol-style property globally
+
+2011-05-03 Enrico Tröger  <enrico(dot)troeger(at)uvena(dot)de>
+
+* add check for large file support which is necessary for GPGME on 32bit
+  systems
+
+2011-04-14 Hans Alves  <alves(dot)h88(at)gmail(dot)com>
+
+* Don't clear the document if encryption is cancelled.
+
+2011-04-06 Hans Alves  <alves(dot)h88(at)gmail(dot)com>
+
+* Made the README file a bit more useful, and changed the COPYING file
+  to gpl version 2 instead of 3, so it is compatible with what the
+  source refers to and with the rest of the geany-plugins.
+
+2011-03-14 Colomban Wendling  <colomban(at)geany(dot)org>
+
+* Statically analyze source code with cppcheck on `make check`
+
+2011-03-06 Chow Loong Jin  <hyperair(at)ubuntu(dot)com>
+
+* Add ChangeLog, NEWS and README stubs for geanypg
+
+2011-03-06 Chow Loong Jin  <hyperair(at)ubuntu(dot)com>
+
+* Integrate geanypg into build system
+
+2011-03-05 Enrico Tröger  <enrico(dot)troeger(at)uvena(dot)de>
+
+* add Waf build support for new GeanyPG plugin
+
+2011-02-28 Hans Alves  <alves(dot)h88(at)gmail(dot)com>
+
+ * Moved geanypg to the geany-plugins/ directory
+
+2011-02-27 Hans Alves  <alves(dot)h88(at)gmail(dot)com>
+
+ * Added autoconf and automake files and some cleanup
+
+2011-02-26 Hans Alves  <alves(dot)h88(at)gmail(dot)com>
+
+ * Initial commit.

--- a/geanypg/src/geanypg.h
+++ b/geanypg/src/geanypg.h
@@ -53,7 +53,7 @@ extern GeanyPlugin     *geany_plugin;
 extern GeanyData       *geany_data;
 extern GeanyFunctions  *geany_functions;
 
-// auxiliary functions (aux.c)
+// auxiliary functions (helper_functions.c)
 void geanypg_init_ed(encrypt_data * ed);
 int geanypg_get_keys(encrypt_data * ed);
 int geanypg_get_secret_keys(encrypt_data * ed);
@@ -64,6 +64,7 @@ void geanypg_write_file(FILE * file);
 // some more auxiliary functions (verify_aux.c)
 void geanypg_handle_signatures(encrypt_data * ed, int need_error);
 void geanypg_check_sig(encrypt_data * ed, gpgme_signature_t sig);
+const char * geanypg_validity(gpgme_validity_t validity);
 
 // dialogs
 int geanypg_encrypt_selection_dialog(encrypt_data * ed, gpgme_key_t ** selected, int * sign);

--- a/geanypg/src/helper_functions.c
+++ b/geanypg/src/helper_functions.c
@@ -35,14 +35,22 @@ int geanypg_get_keys(encrypt_data * ed)
     //initialize idx to 0
     unsigned long idx = 0;
     //allocate array of size 1N
+    gpgme_key_t * key;
     ed->key_array = (gpgme_key_t*) malloc(SIZE * sizeof(gpgme_key_t));
     err = gpgme_op_keylist_start(ed->ctx, NULL, 0);
     while (!err)
     {
-        err = gpgme_op_keylist_next(ed->ctx, ed->key_array + idx);
+        key = ed->key_array + idx;
+        err = gpgme_op_keylist_next(ed->ctx, key);
         if (err)
             break;
-        ++idx;
+        if ((*key)->revoked  || // key cannot be used
+            (*key)->expired  ||
+            (*key)->disabled ||
+            (*key)->invalid)
+           gpgme_key_unref(*key);
+        else // key is valid
+            ++idx;
         if (idx >= size)
         {
             size += SIZE;
@@ -65,14 +73,22 @@ int geanypg_get_secret_keys(encrypt_data * ed)
     //initialize idx to 0
     unsigned long idx = 0;
     //allocate array of size 1N
+    gpgme_key_t * key;
     ed->skey_array = (gpgme_key_t*) malloc(SIZE * sizeof(gpgme_key_t));
     err = gpgme_op_keylist_start(ed->ctx, NULL, 1);
     while (!err)
     {
-        err = gpgme_op_keylist_next(ed->ctx, ed->skey_array + idx);
+        key = ed->skey_array + idx;
+        err = gpgme_op_keylist_next(ed->ctx, key);
         if (err)
             break;
-        ++idx;
+        if ((*key)->revoked  || // key cannot be used
+            (*key)->expired  ||
+            (*key)->disabled ||
+            (*key)->invalid)
+           gpgme_key_unref(*key);
+        else // key is valid
+            ++idx;
         if (idx >= size)
         {
             size += SIZE;

--- a/geanypg/src/verify_aux.c
+++ b/geanypg/src/verify_aux.c
@@ -58,7 +58,7 @@ void geanypg_get_keys_with_fp(encrypt_data * ed, char * buffer)
     }
 }
 
-static const char * geanypg_validity(gpgme_validity_t validity)
+const char * geanypg_validity(gpgme_validity_t validity)
 {
     switch (validity)
     {


### PR DESCRIPTION
Fixed a bug noticed by Goran Andric which caused an error message to appear when encrypting to an untrusted public key. 
Now the user will be warned and asked if thon wants to continue. If so, untrusted encryption is forced.
