### PR TITLE
GeniusPaste fixes

### DIFF
--- a/geniuspaste/src/geniuspaste.c
+++ b/geniuspaste/src/geniuspaste.c
@@ -33,6 +33,10 @@
 
 #include <geanyplugin.h>
 
+
+#define PLUGIN_NAME "GeniusPaste"
+#define PLUGIN_VERSION "0.2"
+
 #ifdef G_OS_WIN32
 #define USERNAME        getenv("USERNAME")
 #else
@@ -84,9 +88,9 @@ static gint website_selected;
 static gboolean check_button_is_checked = FALSE;
 
 PLUGIN_VERSION_CHECK(147)
-PLUGIN_SET_TRANSLATABLE_INFO(LOCALEDIR, GETTEXT_PACKAGE, "GeniusPaste",
+PLUGIN_SET_TRANSLATABLE_INFO(LOCALEDIR, GETTEXT_PACKAGE, PLUGIN_NAME,
                              _("Paste your code on your favorite pastebin"),
-                             "0.2", "Enrico Trotta");
+                             PLUGIN_VERSION, "Enrico Trotta");
 
 static gint indexof(const gchar * string, gchar c)
 {
@@ -160,7 +164,7 @@ static gchar *get_paste_text(GeanyDocument *doc, gsize *text_len)
 
 static void paste(GeanyDocument * doc, const gchar * website)
 {
-    SoupSession *session = soup_session_async_new();
+    SoupSession *session;
     SoupMessage *msg = NULL;
 
     gchar *f_content;
@@ -168,6 +172,7 @@ static void paste(GeanyDocument * doc, const gchar * website)
     gchar *f_title;
     gchar *p_url;
     gchar *formdata = NULL;
+    gchar *user_agent = NULL;
     gchar *temp_body;
     gchar **tokens_array;
 
@@ -273,6 +278,10 @@ static void paste(GeanyDocument * doc, const gchar * website)
 
     }
 
+    user_agent = g_strconcat(PLUGIN_NAME, " ", PLUGIN_VERSION, " / Geany ", GEANY_VERSION, NULL);
+    session = soup_session_async_new_with_options(SOUP_SESSION_USER_AGENT, user_agent, NULL);
+    g_free(user_agent);
+
     soup_message_set_request(msg, "application/x-www-form-urlencoded",
                              SOUP_MEMORY_COPY, formdata, strlen(formdata));
 
@@ -362,6 +371,7 @@ static void paste(GeanyDocument * doc, const gchar * website)
 
     g_free(f_content);
     g_free(p_url);
+    g_object_unref(session);
 }
 
 static void item_activate(GtkMenuItem * menuitem, gpointer gdata)


### PR DESCRIPTION
Using `utils_get_setting_*` instead of `g_key_file_get_*` will get rid of some GTK critical errors on startup.
The second commit sets a user agent for the HTTP request and fixes other small things.

Thanks to Enrico Tröger.
