### PR TITLE
WebHelper: Remember inspector docking state

### DIFF
--- a/webhelper/src/gwh-plugin.c
+++ b/webhelper/src/gwh-plugin.c
@@ -339,6 +339,12 @@ load_config (void)
     "400x300",
     G_PARAM_READWRITE));
   gwh_settings_install_property (G_settings, g_param_spec_boolean (
+    "inspector-detached",
+    _("Inspector detached"),
+    _("Whether the inspector is in a separate window or docked in the browser"),
+    FALSE,
+    G_PARAM_READWRITE));
+  gwh_settings_install_property (G_settings, g_param_spec_boolean (
     "wm-secondary-windows-skip-taskbar",
     _("Secondary windows skip task bar"),
     _("Whether to tell the window manager not to show the secondary windows in the task bar"),


### PR DESCRIPTION
Although this commit introduces 2 new translatable strings, they are not displayed anywhere in the UI (yet, may change in the future) and so should be fine to go even in 1.22 branch.

The commit message says pretty much everything: this commit makes the plugin save and restore the inspector docking state (in a separate window or next to the browser).
