### PR TITLE
disable the geanygdb plugin by default

### DIFF
--- a/build/geanygdb.m4
+++ b/build/geanygdb.m4
@@ -1,6 +1,6 @@
 AC_DEFUN([GP_CHECK_GEANYGDB],
 [
-    GP_ARG_DISABLE([GeanyGDB], [yes])
+    GP_ARG_DISABLE([GeanyGDB], [no])
     GP_STATUS_PLUGIN_ADD([GeanyGDB], [$enable_geanygdb])
     AC_CHECK_HEADERS([elf.h])
     AC_CHECK_HEADERS([elf_abi.h])


### PR DESCRIPTION
The plugin is deprecated and may be removed in further versions.
Please use the debugger plugin instead.
