### PR TITLE
GeniusPaste fixes

### DIFF
--- a/geniuspaste/src/geniuspaste.c
+++ b/geniuspaste/src/geniuspaste.c
@@ -359,7 +359,7 @@ static void paste(GeanyDocument * doc, const gchar * website)
             p_url = g_strdup_printf("http://%s/%s", websites[TINYPASTE_COM], tokens_array[6]);
             
             g_free(temp_body);
-            g_free(tokens_array);
+            g_strfreev(tokens_array);
         }
             
         else if(website_selected == DPASTE_DE)


### PR DESCRIPTION
Replace `getenv ()` function with `g_getenv ()` since it returns plain UTF-8 on Windows (Thanks to Enrico Tröger).

The other fix is about the `pastebin.com` service that now use new API (which requires a api key) and so the old API are officially deprecated. `pastebin.com` has been replaced by `tinypaste.com`.
