### PR TITLE
Fix various treebrowser things

### DIFF
--- a/treebrowser/src/treebrowser.c
+++ b/treebrowser/src/treebrowser.c
@@ -486,7 +486,8 @@ treebrowser_browse(gchar *directory, gpointer parent)
 		treebrowser_bookmarks_set_state();
 	}
 
-	gtk_tree_store_iter_clear_nodes(parent, FALSE);
+	if (parent)
+		gtk_tree_store_iter_clear_nodes(parent, FALSE);
 
 	list = utils_get_file_list(directory, NULL, NULL);
 	if (list != NULL)


### PR DESCRIPTION
The first patch, although it looks large, is actually a simple `if()`, check with `--ignore-space-changes`.
