### PR TITLE
GeanyVC: Add support for a custom external diff viewer.

### DIFF
--- a/geanyvc/src/externdiff.c
+++ b/geanyvc/src/externdiff.c
@@ -28,6 +28,7 @@ extern GeanyFunctions *geany_functions;
 
 enum
 {
+	EXTERNAL_DIFF_CUSTOM,
 	EXTERNAL_DIFF_MELD,
 	EXTERNAL_DIFF_KOMPARE,
 	EXTERNAL_DIFF_KDIFF3,
@@ -37,7 +38,7 @@ enum
 };
 
 
-static const gchar *viewers[EXTERNAL_DIFF_COUNT] = { "meld", "kompare", "kdiff3", "diffuse", "tkdiff" };
+static const gchar *viewers[EXTERNAL_DIFF_COUNT] = { "geany_external_diff", "meld", "kompare", "kdiff3", "diffuse", "tkdiff" };
 
 static gchar *extern_diff_viewer = NULL;
 const gchar *


### PR DESCRIPTION
If "geany_external_diff" is found in the path, it is run as
the diff viewer. It can be a script or symbolic link to any
custom diff tool, easily modifiable by the user.
Otherwise the usual diff tools are tried as previously.

Also useful to add some command line arguments to the diff command.
