### PR TITLE
Debugger

### DIFF
--- a/debugger/src/dbm_gdb.c
+++ b/debugger/src/dbm_gdb.c
@@ -88,7 +88,7 @@ static GPid gdb_pid = 0;
 static GPid target_pid = 0;
 
 /* GSource to watch GDB exit */
-static GSource *gdb_src;
+static guint gdb_src_id;
 
 /* channels for GDB input/output */
 static gint gdb_in;
@@ -192,7 +192,7 @@ static void on_gdb_exit(GPid pid, gint status, gpointer data)
 	g_list_free(files);
 	files = NULL;
 	
-	g_source_destroy(gdb_src);
+	g_source_remove(gdb_src_id);
 	
 	dbg_cbs->set_exited(0);
 }
@@ -744,8 +744,7 @@ static gboolean run(const gchar* file, const gchar* commandline, GList* env, GLi
 	setpgid(gdb_pid, 0);
 	
 	/* set handler for gdb process exit event */ 
-	g_child_watch_add(gdb_pid, on_gdb_exit, NULL);
-	gdb_src = g_child_watch_source_new(gdb_pid);
+	gdb_src_id = g_child_watch_add(gdb_pid, on_gdb_exit, NULL);
 
 	/* create GDB GIO chanels */
 	gdb_ch_in = g_io_channel_unix_new(gdb_in);


### PR DESCRIPTION
1. removed odd main loop attach call
2. added new thread group creation message format, that was unhandled previously and caused crash on newer versions of gdb
