### PR TITLE
Fix bug 3557458 and some compiler warnings

### DIFF
--- a/geanypg/ChangeLog
+++ b/geanypg/ChangeLog
@@ -1,3 +1,9 @@
+2012-08-24 Hans Alves  <alves(dot)h88(at)gmail(dot)com>
+
+* Fixed bug 3557458 which caused a 0 byte to be added to the text
+  when encrypting a selection.
+  Fixed some compiler warnings.
+
 2012-06-04 Hans Alves  <alves(dot)h88(at)gmail(dot)com>
 
 * Fixed a bug that caused an error message to appear if one of the

--- a/geanypg/src/encrypt_cb.c
+++ b/geanypg/src/encrypt_cb.c
@@ -24,8 +24,6 @@
 static void geanypg_encrypt(encrypt_data * ed, gpgme_key_t * recp, int sign, int flags)
 {   /* FACTORIZE */
     gpgme_data_t plain, cipher;
-    gpgme_encrypt_result_t result;
-    gpgme_invalid_key_t recipient;
     gpgme_error_t err;
     FILE * tempfile;
     tempfile = tmpfile();
@@ -75,7 +73,7 @@ void geanypg_encrypt_cb(GtkMenuItem * menuitem, gpointer user_data)
         if (geanypg_encrypt_selection_dialog(&ed, &recp, &sign))
         {
             int flags = 0;
-            int abort = 0;
+            int stop = 0;
             gpgme_key_t * key = recp;
             while (*key)
             {
@@ -89,13 +87,13 @@ void geanypg_encrypt_cb(GtkMenuItem * menuitem, gpointer user_data)
                         (*key)->uids->uid, geanypg_validity((*key)->owner_trust)))
                         flags = GPGME_ENCRYPT_ALWAYS_TRUST;
                     else
-                        abort = 1;
+                        stop = 1;
                 }
                 ++key;
             }
-            if (*recp && !abort)
+            if (*recp && !stop)
                 geanypg_encrypt(&ed, recp, sign, flags);
-            else if (!abort && dialogs_show_question(_("No recipients were selected,\nuse symetric cipher?")))
+            else if (!stop && dialogs_show_question(_("No recipients were selected,\nuse symetric cipher?")))
                 geanypg_encrypt(&ed, NULL, sign, flags);
         }
         if (recp)

--- a/geanypg/src/helper_functions.c
+++ b/geanypg/src/helper_functions.c
@@ -165,7 +165,6 @@ void geanypg_write_file(FILE * file)
     {   /* replace selected text
          * clear selection, cursor should be at the end or beginneng of the selection */
         scintilla_send_message(doc->editor->sci, SCI_REPLACESEL, 0, (sptr_t)"");
-
         while ((size = fread(buffer, 1, BUFSIZE, file)))
             /* add at the cursor */
             scintilla_send_message(doc->editor->sci, SCI_ADDTEXT, (uptr_t) size, (sptr_t) buffer);

--- a/geanypg/src/verify_aux.c
+++ b/geanypg/src/verify_aux.c
@@ -160,13 +160,11 @@ static char * geanypg_result(gpgme_signature_t sig)
 void geanypg_check_sig(encrypt_data * ed, gpgme_signature_t sig)
 {
     GtkWidget * dialog;
-    gpgme_sigsum_t summary;
     char buffer[512] = {0};
     char * result;
     strncpy(buffer, sig->fpr, 40);
     buffer[40] = 0;
     geanypg_get_keys_with_fp(ed, buffer);
-    summary = sig->summary;
     result = geanypg_result(sig);
 
     dialog = gtk_message_dialog_new_with_markup(GTK_WINDOW(geany->main_widgets->window),


### PR DESCRIPTION
SCI_GETSELTEXT also reserves space for a terminating 0 byte, this should not be written to the gpg buffer.
warnings:
verify_aux.c:163:20: warning: variable 'summary' set but not used [-Wunused-but-set-variable]
and
encrypt_cb.c:76:17: warning: declaration of 'abort' shadows a global declaration [-Wshadow]
have been fixed.
