### PR TITLE
geniuspaste: Fix an invalid memory free

### DIFF
--- a/geniuspaste/src/geniuspaste.c
+++ b/geniuspaste/src/geniuspaste.c
@@ -377,9 +377,8 @@ static void paste(GeanyDocument * doc, const gchar * website)
              * e.g. sprunge.us/xxxx?c
              */
             gchar *ft_tmp = g_ascii_strdown(f_type, -1);
-            gchar *temp_body = g_strstrip(p_url);
-            SETPTR(p_url, g_strdup_printf("%s?%s", temp_body, ft_tmp));
-            g_free(temp_body);
+            g_strstrip(p_url);
+            SETPTR(p_url, g_strdup_printf("%s?%s", p_url, ft_tmp));
             g_free(ft_tmp);
         }
 


### PR DESCRIPTION
g_strstrip() doesn't allocate memory, so one must note free it's return value.

@Enrix835: looks ok to you?  BTW, you could update your fork so it's more up-to-date and it's easier to PR against it? :)
