### PR TITLE
[Geany-Plugins: Debugger: FIX] Plugin was not loaded in Geany.

### DIFF
--- a/debugger/wscript_build
+++ b/debugger/wscript_build
@@ -23,7 +23,10 @@
 from build.wafutils import build_plugin
 
 name = 'Debugger'
-includes = ['debugger/src']
+
+includes = ['debugger/src', 'debugger/src/cell_renderers', 
+            'debugger/src/xpm']
+
 libraries = ['VTE', 'UTIL']
 
 pludin_datadir = '${PKGDATADIR}/debugger'


### PR DESCRIPTION
Buildtool: WAF
OS: ArchLinux
Reason: Could not find symbol from src/cell_renderers sources.

When I tried to load "Debugger" plugin from Tools -> Plugin Manager I did not get the plugin in the list, but encountered debug message:

00:23:45: Geany INFO        : Can't load plugin: /usr/local/lib/geany/debugger.so: undefined symbol: cell_renderer_frame_icon_new

So, here is the fix.
BUT please check someone in case of getting same issue.
