### PR TITLE
Fixed error in building Spoce Plugins.

### DIFF
--- a/scope/src/debug.c
+++ b/scope/src/debug.c
@@ -22,7 +22,7 @@
 #include <string.h>
 #include <unistd.h>
 
-#include <glibconfig.h>
+#include <glib.h>
 
 #ifdef G_OS_UNIX
 #include <sys/types.h>


### PR DESCRIPTION
Fixed error in building Spoce Plugins (/usr/include/glib-2.0/glib/gmacros.h:32:2: error: #error "Only <glib.h> can be included directly.").
