### PR TITLE
Devhelp: Add support for GTK3

### DIFF
--- a/build/devhelp.m4
+++ b/build/devhelp.m4
@@ -2,21 +2,25 @@ AC_DEFUN([GP_CHECK_DEVHELP],
 [
     GP_ARG_DISABLE([devhelp], [auto])
 
-    GTK_VERSION=2.16
-    WEBKIT_VERSION=1.1.13
-    GCONF_VERSION=2.6.0
-    LIBWNCK_VERSION=2.10.0
-
     AC_PATH_PROG(GLIB_GENMARSHAL, glib-genmarshal)
     AC_PATH_PROG(GLIB_MKENUMS, glib-mkenums)
 
-    GP_CHECK_PLUGIN_DEPS([devhelp], [DEVHELP],
-                         [gtk+-2.0 >= ${GTK_VERSION}
-                          webkit-1.0 >= ${WEBKIT_VERSION}
-                          libwnck-1.0 >= ${LIBWNCK_VERSION}
-                          gconf-2.0 >= ${GCONF_VERSION}
-                          gthread-2.0
-                          zlib])
+    GP_CHECK_GTK3(
+      [
+        AC_DEFINE([HAVE_DEVHELP_GTK3], [1], [Define if using GTK3 Devhelp plugin])
+        GP_CHECK_PLUGIN_DEPS([devhelp], [DEVHELP], [webkitgtk-3.0 libdevhelp-3.0])
+      ], [
+        WEBKIT_VERSION=1.1.13
+        GCONF_VERSION=2.6.0
+        LIBWNCK_VERSION=2.10.0
+        GP_CHECK_PLUGIN_DEPS([devhelp], [DEVHELP],
+                             [webkit-1.0 >= ${WEBKIT_VERSION}
+                             gconf-2.0 >= ${GCONF_VERSION}
+                             libwnck-1.0 >= ${LIBWNCK_VERSION}
+                             gthread-2.0
+                             zlib])
+      ]
+    )
 
     GP_COMMIT_PLUGIN_STATUS([DevHelp])
 

--- a/devhelp/Makefile.am
+++ b/devhelp/Makefile.am
@@ -1,4 +1,9 @@
 include $(top_srcdir)/build/vars.auxfiles.mk
 
+if GP_GTK3
+SUBDIRS = src data
+else
 SUBDIRS = devhelp src data
+endif
+
 plugin = devhelp

--- a/devhelp/src/Makefile.am
+++ b/devhelp/src/Makefile.am
@@ -16,15 +16,23 @@ noinst_HEADERS = \
 	dhp.h \
 	dhp-plugin.h
 
+if GP_GTK3
+DEVHELP_LOCAL_CFLAGS =
+DEVHELP_LOCAL_LDFLAGS =
+else !GP_GTK3
+DEVHELP_LOCAL_CFLAGS = -I$(top_srcdir)/devhelp
+DEVHELP_LOCAL_LDFLAGS = $(top_builddir)/devhelp/devhelp/libdevhelp-2.la
+endif !GP_GTK3
+
 devhelp_la_CFLAGS = \
 	$(AM_CFLAGS) \
-	-I$(top_srcdir)/devhelp \
 	$(DEVHELP_CFLAGS) \
 	-DDHPLUG_DATA_DIR=\"$(plugindatadir)\" \
-	-DHAVE_BOOK_MANAGER=1
+	-DHAVE_BOOK_MANAGER=1 \
+	$(DEVHELP_LOCAL_CFLAGS)
 
 devhelp_la_LIBADD = \
 	$(DEVHELP_LIBS) \
-	$(top_builddir)/devhelp/devhelp/libdevhelp-2.la
+	$(DEVHELP_LOCAL_LDFLAGS)
 
 include $(top_srcdir)/build/cppcheck.mk

--- a/devhelp/src/dhp-plugin.c
+++ b/devhelp/src/dhp-plugin.c
@@ -156,8 +156,10 @@ void plugin_init(GeanyData *data)
 
 	plugin_module_make_resident(geany_plugin);
 
+#if !GTK_CHECK_VERSION(2, 32, 0)
 	if (!g_thread_supported())
 		g_thread_init(NULL);
+#endif
 
 	memset(&plugin, 0, sizeof(struct PluginData));
 


### PR DESCRIPTION
This PR includes Autotools build system adjustments as well as new libdevhelp API and other miscellaneous deprecated or obsolete GTK3(-stack) changes.

When using GTK+3 finally we can depend on Debian-based (and other) distros providing a needed libdevhelp again so don't use the embedded version, rather using the system's `libdevhelp-3.0` when compiling against GTK3 Geany.

TODO: Waf build system support for GTK3

Please test, improve and/or approve.
