### PR TITLE
Markdown: Add support for GTK3

### DIFF
--- a/build/markdown.m4
+++ b/build/markdown.m4
@@ -49,9 +49,12 @@ AC_DEFUN([GP_CHECK_MARKDOWN],
     GTK_VERSION=2.16
     WEBKIT_VERSION=1.1.13
 
+    GP_CHECK_GTK3([webkit_package=webkitgtk-3.0],
+                  [webkit_package=webkit-1.0])
+
     GP_CHECK_PLUGIN_DEPS([markdown], [MARKDOWN],
-                         [gtk+-2.0 >= ${GTK_VERSION}
-                          webkit-1.0 >= ${WEBKIT_VERSION}
+                         [$GP_GTK_PACKAGE >= ${GTK_VERSION}
+                          $webkit_package >= ${WEBKIT_VERSION}
                           gthread-2.0])
 
     GP_COMMIT_PLUGIN_STATUS([Markdown])

--- a/markdown/src/Makefile.am
+++ b/markdown/src/Makefile.am
@@ -7,11 +7,13 @@ geanyplugins_LTLIBRARIES = markdown.la
 markdown_la_SOURCES = \
 	conf.c \
 	plugin.c \
-	viewer.c
+	viewer.c \
+	markdown-gtk-compat.c
 
 noinst_HEADERS = \
 	conf.h \
-	viewer.h
+	viewer.h \
+	markdown-gtk-compat.h
 
 markdown_la_CFLAGS = \
 	$(AM_CFLAGS) \

--- a/markdown/src/conf.c
+++ b/markdown/src/conf.c
@@ -26,6 +26,7 @@
 #include <gtk/gtk.h>
 #include <geanyplugin.h>
 #include "conf.h"
+#include "markdown-gtk-compat.h"
 
 #define FONT_NAME_MAX  256
 #define COLOR_CODE_MAX 8
@@ -470,18 +471,11 @@ markdown_config_save(MarkdownConfig *conf)
 static gchar *
 color_button_get_color(GtkColorButton *color_button)
 {
-  GdkColor color;
-  guint r, g, b;
-  gchar *color_str;
+  MarkdownColor color;
 
-  gtk_color_button_get_color(color_button, &color);
+  markdown_gtk_color_button_get_color(color_button, &color);
 
-  r = color.red / 256;
-  g = color.green / 256;
-  b = color.blue / 256;
-  color_str = g_strdup_printf("#%02x%02x%02x", r, g, b);
-
-  return color_str;
+  return g_strdup_printf("#%02x%02x%02x", color.red, color.green, color.blue);
 }
 
 static gboolean
@@ -563,15 +557,16 @@ GtkWidget *markdown_config_gui(MarkdownConfig *conf, GtkDialog *dialog)
                "template-file", &tmpl_file,
                NULL);
 
-  table = gtk_table_new(6, 2, FALSE);
-  gtk_table_set_col_spacings(GTK_TABLE(table), 6);
-  gtk_table_set_row_spacings(GTK_TABLE(table), 6);
+  table = markdown_gtk_table_new(6, 2, FALSE);
+  markdown_gtk_table_set_col_spacing(MARKDOWN_GTK_TABLE(table), 6);
+  markdown_gtk_table_set_row_spacing(MARKDOWN_GTK_TABLE(table), 6);
+
   conf->priv->widgets.table = table;
 
   { /* POSITION OF VIEW */
     label = gtk_label_new(_("Position:"));
     gtk_misc_set_alignment(GTK_MISC(label), 0.0, 0.5);
-    gtk_table_attach(GTK_TABLE(table), label, 0, 1, 0, 1, GTK_FILL, GTK_FILL, 0, 0);
+    markdown_gtk_table_attach(MARKDOWN_GTK_TABLE(table), label, 0, 1, 0, 1, GTK_FILL, GTK_FILL);
 
     hbox = gtk_hbox_new(FALSE, 6);
 
@@ -591,7 +586,7 @@ GtkWidget *markdown_config_gui(MarkdownConfig *conf, GtkDialog *dialog)
       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(wid), TRUE);
     }
 
-    gtk_table_attach(GTK_TABLE(table), hbox, 1, 2, 0, 1, GTK_FILL, GTK_FILL, 0, 0);
+    markdown_gtk_table_attach(MARKDOWN_GTK_TABLE(table), hbox, 1, 2, 0, 1, GTK_FILL, GTK_FILL);
   }
 
   { /* FONT BUTTON */
@@ -599,15 +594,14 @@ GtkWidget *markdown_config_gui(MarkdownConfig *conf, GtkDialog *dialog)
 
     label = gtk_label_new(_("Font:"));
     gtk_misc_set_alignment(GTK_MISC(label), 0.0, 0.5);
-    gtk_table_attach(GTK_TABLE(table), label, 0, 1, 1, 2, GTK_FILL, GTK_FILL, 0, 0);
+    markdown_gtk_table_attach(MARKDOWN_GTK_TABLE(table), label, 0, 1, 1, 2, GTK_FILL, GTK_FILL);
 
     font_desc = g_strdup_printf("%s %d", fnt, fnt_sz);
     wid = gtk_font_button_new_with_font(font_desc);
     conf->priv->widgets.font_button = wid;
     g_free(font_desc);
 
-    gtk_table_attach(GTK_TABLE(table), wid, 1, 2, 1, 2, GTK_FILL | GTK_EXPAND,
-      GTK_FILL, 0, 0);
+    markdown_gtk_table_attach(MARKDOWN_GTK_TABLE(table), wid, 1, 2, 1, 2, GTK_FILL | GTK_EXPAND, GTK_FILL);
 
     g_free(fnt);
   }
@@ -617,49 +611,46 @@ GtkWidget *markdown_config_gui(MarkdownConfig *conf, GtkDialog *dialog)
 
     label = gtk_label_new(_("Code Font:"));
     gtk_misc_set_alignment(GTK_MISC(label), 0.0, 0.5);
-    gtk_table_attach(GTK_TABLE(table), label, 0, 1, 2, 3, GTK_FILL, GTK_FILL, 0, 0);
+    markdown_gtk_table_attach(MARKDOWN_GTK_TABLE(table), label, 0, 1, 2, 3, GTK_FILL, GTK_FILL);
 
     font_desc = g_strdup_printf("%s %d", code_fnt, code_fnt_sz);
     wid = gtk_font_button_new_with_font(font_desc);
     conf->priv->widgets.code_font_button = wid;
     g_free(font_desc);
 
-    gtk_table_attach(GTK_TABLE(table), wid, 1, 2, 2, 3, GTK_FILL | GTK_EXPAND,
-      GTK_FILL, 0, 0);
+    markdown_gtk_table_attach(MARKDOWN_GTK_TABLE(table), wid, 1, 2, 2, 3, GTK_FILL | GTK_EXPAND, GTK_FILL);
 
     g_free(code_fnt);
   }
 
   { /* BG COLOR */
-    GdkColor bgclr;
+    MarkdownColor bgclr;
 
     label = gtk_label_new(_("BG Color:"));
     gtk_misc_set_alignment(GTK_MISC(label), 0.0, 0.5);
-    gtk_table_attach(GTK_TABLE(table), label, 0, 1, 3, 4, GTK_FILL, GTK_FILL, 0, 0);
+    markdown_gtk_table_attach(MARKDOWN_GTK_TABLE(table), label, 0, 1, 3, 4, GTK_FILL, GTK_FILL);
 
-    gdk_color_parse(bg, &bgclr);
+    markdown_color_parse(bg, &bgclr);
 
-    wid = gtk_color_button_new_with_color(&bgclr);
+    wid = markdown_gtk_color_button_new_with_color(&bgclr);
     conf->priv->widgets.bg_color_button = wid;
-    gtk_table_attach(GTK_TABLE(table), wid, 1, 2, 3, 4, GTK_FILL | GTK_EXPAND,
-      GTK_FILL, 0, 0);
+    markdown_gtk_table_attach(MARKDOWN_GTK_TABLE(table), wid, 1, 2, 3, 4, GTK_FILL | GTK_EXPAND, GTK_FILL);
 
     g_free(bg);
   }
 
   { /* FG COLOR */
-    GdkColor fgclr;
+    MarkdownColor fgclr;
 
     label = gtk_label_new(_("FG Color:"));
     gtk_misc_set_alignment(GTK_MISC(label), 0.0, 0.5);
-    gtk_table_attach(GTK_TABLE(table), label, 0, 1, 4, 5, GTK_FILL, GTK_FILL, 0, 0);
+    markdown_gtk_table_attach(MARKDOWN_GTK_TABLE(table), label, 0, 1, 4, 5, GTK_FILL, GTK_FILL);
 
-    gdk_color_parse(fg, &fgclr);
+    markdown_color_parse(fg, &fgclr);
 
-    wid = gtk_color_button_new_with_color(&fgclr);
+    wid = markdown_gtk_color_button_new_with_color(&fgclr);
     conf->priv->widgets.fg_color_button = wid;
-    gtk_table_attach(GTK_TABLE(table), wid, 1, 2, 4, 5, GTK_FILL | GTK_EXPAND,
-      GTK_FILL, 0, 0);
+    markdown_gtk_table_attach(MARKDOWN_GTK_TABLE(table), wid, 1, 2, 4, 5, GTK_FILL | GTK_EXPAND, GTK_FILL);
 
     g_free(fg);
   }
@@ -667,7 +658,7 @@ GtkWidget *markdown_config_gui(MarkdownConfig *conf, GtkDialog *dialog)
   { /* TEMPLATE FILE */
     label = gtk_label_new(_("Template:"));
     gtk_misc_set_alignment(GTK_MISC(label), 0.0, 0.5);
-    gtk_table_attach(GTK_TABLE(table), label, 0, 1, 5, 6, GTK_FILL, GTK_FILL, 0, 0);
+    markdown_gtk_table_attach(MARKDOWN_GTK_TABLE(table), label, 0, 1, 5, 6, GTK_FILL, GTK_FILL);
 
     wid = gtk_file_chooser_button_new(_("Select Template File"),
       GTK_FILE_CHOOSER_ACTION_OPEN);
@@ -676,8 +667,7 @@ GtkWidget *markdown_config_gui(MarkdownConfig *conf, GtkDialog *dialog)
     if (tmpl_file && tmpl_file[0]) {
       gtk_file_chooser_set_filename(GTK_FILE_CHOOSER(wid), tmpl_file);
     }
-    gtk_table_attach(GTK_TABLE(table), wid, 1, 2, 5, 6, GTK_FILL | GTK_EXPAND,
-      GTK_FILL, 0, 0);
+    markdown_gtk_table_attach(MARKDOWN_GTK_TABLE(table), wid, 1, 2, 5, 6, GTK_FILL | GTK_EXPAND, GTK_FILL);
 
     g_free(tmpl_file);
   }

--- a/markdown/src/markdown-gtk-compat.c
+++ b/markdown/src/markdown-gtk-compat.c
@@ -1,0 +1,147 @@
+/*
+ * markdown-gtk-compat.c - Part of the Geany Markdown plugin
+ *
+ * Copyright 2012 Matthew Brush <mbrush@codebrainz.ca>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ *
+ *
+ */
+
+#include <gtk/gtk.h>
+#include "markdown-gtk-compat.h"
+
+GtkWidget *markdown_gtk_table_new(guint rows, guint columns, gboolean homogeneous)
+{
+  GtkWidget *table;
+
+#if !GTK_CHECK_VERSION(3, 4, 0)
+  table = gtk_table_new(rows, columns, homogeneous);
+#else
+  guint row_cnt, col_cnt;
+
+  table = gtk_grid_new();
+
+  gtk_grid_set_row_homogeneous(MARKDOWN_GTK_TABLE(table), homogeneous);
+  gtk_grid_set_column_homogeneous(MARKDOWN_GTK_TABLE(table), homogeneous);
+
+  for (row_cnt=0; row_cnt < rows; row_cnt++)
+    gtk_grid_insert_row(MARKDOWN_GTK_TABLE(table), row_cnt);
+
+  for (col_cnt=0; col_cnt < columns; col_cnt++)
+    gtk_grid_insert_column(MARKDOWN_GTK_TABLE(table), col_cnt);
+#endif
+
+  return table;
+}
+
+void markdown_gtk_table_attach(MarkdownGtkTable *table, GtkWidget *child,
+  guint left_attach, guint right_attach, guint top_attach, guint bottom_attach,
+  GtkAttachOptions xoptions, GtkAttachOptions yoptions)
+{
+#if !GTK_CHECK_VERSION(3, 4, 0)
+  gtk_table_attach(table, child, left_attach, right_attach, top_attach,
+    bottom_attach, xoptions, yoptions, 0, 0);
+#else
+  gtk_grid_attach(table, child, left_attach, top_attach,
+    right_attach - left_attach, bottom_attach - top_attach);
+#endif
+}
+
+GtkWidget *markdown_gtk_color_button_new_with_color(MarkdownColor *color)
+{
+  GtkWidget *btn;
+
+  btn = gtk_color_button_new();
+
+#if !GTK_CHECK_VERSION(3, 0, 0)
+{
+  GdkColor clr;
+  clr.red = color->red * 256;
+  clr.green = color->green * 256;
+  clr.blue = color->blue * 256;
+  gtk_color_button_set_color(GTK_COLOR_BUTTON(btn), &clr);
+}
+#else
+{
+  GdkRGBA clr;
+  clr.red = color->red / 256.0;
+  clr.green = color->green / 256.0;
+  clr.blue = color->blue / 256.0;
+# if !GTK_CHECK_VERSION(3, 4, 0)
+  gtk_color_button_set_rgba(GTK_COLOR_BUTTON(btn), &clr);
+# else
+  gtk_color_chooser_set_rgba(GTK_COLOR_CHOOSER(btn), &clr);
+# endif
+}
+#endif
+
+  return btn;
+}
+
+gboolean markdown_color_parse(const gchar *spec, MarkdownColor *color)
+{
+  gboolean result;
+  g_return_val_if_fail(spec && color, FALSE);
+
+#if !GTK_CHECK_VERSION(3, 0, 0)
+{
+  GdkColor clr;
+  result = gdk_color_parse(spec, &clr);
+  if (result) {
+    color->red = clr.red / 256;
+    color->green = clr.green / 256;
+    color->blue = clr.blue / 256;
+  }
+}
+#else
+{
+  GdkRGBA clr;
+  result = gdk_rgba_parse(&clr, spec);
+  if (result) {
+    color->red = (guint8) (clr.red * 256.0);
+    color->green = (guint8) (clr.green * 256.0);
+    color->blue = (guint8) (clr.blue * 256.0);
+  }
+}
+#endif
+
+  return result;
+}
+
+void markdown_gtk_color_button_get_color(GtkColorButton *button, MarkdownColor *color)
+{
+  g_return_if_fail(button);
+  g_return_if_fail(color);
+
+#if !GTK_CHECK_VERSION(3, 0, 0)
+  GdkColor clr;
+  gtk_color_button_get_color(button, &clr);
+  color->red = clr.red / 256;
+  color->green = clr.green / 256;
+  color->blue = clr.blue / 256;
+#else
+  GdkRGBA clr;
+# if !GTK_CHECK_VERSION(3, 4, 0)
+  gtk_color_button_get_rgba(button, &clr);
+# else
+  gtk_color_chooser_get_rgba(GTK_COLOR_CHOOSER(button), &clr);
+# endif
+  color->red = (guint8) (clr.red * 256.0);
+  color->green = (guint8) (clr.green * 256.0);
+  color->blue = (guint8) (clr.blue * 256.0);
+#endif
+}

--- a/markdown/src/markdown-gtk-compat.h
+++ b/markdown/src/markdown-gtk-compat.h
@@ -1,0 +1,61 @@
+/*
+ * markdown-gtk-compat.h - Part of the Geany Markdown plugin
+ *
+ * Copyright 2012 Matthew Brush <mbrush@codebrainz.ca>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ *
+ *
+ */
+
+#ifndef MARKDOWN_GTK_COMPAT_H_
+#define MARKDOWN_GTK_COMPAT_H_
+
+#if !GTK_CHECK_VERSION(3, 4, 0)
+# define MarkdownGtkTable GtkTable
+# define MARKDOWN_GTK_TABLE GTK_TABLE
+# define markdown_gtk_table_set_row_spacing(table, spacing) \
+    gtk_table_set_row_spacings(table, spacing)
+# define markdown_gtk_table_set_col_spacing(table, spacing) \
+    gtk_table_set_col_spacings(table, spacing)
+#else
+# define MarkdownGtkTable GtkGrid
+# define MARKDOWN_GTK_TABLE GTK_GRID
+# define markdown_gtk_table_set_row_spacing(table, spacing) \
+    gtk_grid_set_row_spacing(table, spacing)
+# define markdown_gtk_table_set_col_spacing(table, spacing) \
+    gtk_grid_set_column_spacing(table, spacing)
+#endif
+
+typedef struct {
+  guint8 red;
+  guint8 green;
+  guint8 blue;
+} MarkdownColor;
+
+GtkWidget *markdown_gtk_table_new(guint rows, guint columns, gboolean homogeneous);
+
+void markdown_gtk_table_attach(MarkdownGtkTable *table, GtkWidget *child,
+  guint left_attach, guint right_attach, guint top_attach, guint bottom_attach,
+  GtkAttachOptions xoptions, GtkAttachOptions yoptions);
+
+GtkWidget *markdown_gtk_color_button_new_with_color(MarkdownColor *color);
+
+gboolean markdown_color_parse(const gchar *spec, MarkdownColor *color);
+
+void markdown_gtk_color_button_get_color(GtkColorButton *button, MarkdownColor *color);
+
+#endif /* MARKDOWN_GTK_COMPAT_H_ */


### PR DESCRIPTION
This PR adds support for GTK3 by adjusting build system as well as adding some GTK2-compatibility code.

TODO: Waf build system support for GTK+3 Markdown plugin.
