### PR TITLE
new maintainer for treebrowser plugin

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -193,10 +193,10 @@ W: http://plugins.geany.org/tableconvert.html
 S: Maintained
 
 treebrowser
-P:
-M:
-W:
-S: Orphan
+P: Adam Dingle <adam@yorba.org>
+M: Adam Dingle <adam@yorba.org>
+W: http://plugins.geany.org/treebrowser.html
+S: Maintained
 
 updatechecker
 P: Frank Lanitz <frank@frank.uvena.de>


### PR DESCRIPTION
I see that the treebrowser plugin is orphaned.  I'd like to take over as an active maintainer.  Here's a change to add me to the MAINTAINERS file.
