### PR TITLE
markword: A new "highlight all occurrences of selected text" mode.

### DIFF
--- a/addons/src/ao_markword.h
+++ b/addons/src/ao_markword.h
@@ -39,8 +39,14 @@ G_BEGIN_DECLS
 typedef struct _AoMarkWord				AoMarkWord;
 typedef struct _AoMarkWordClass			AoMarkWordClass;
 
+typedef enum
+{
+	MARKWORD_BY_DBLCLICK = 1,
+	MARKWORD_BY_SELECTION = 2
+} MarkWordMode;
+
 GType			ao_mark_word_get_type		(void);
-AoMarkWord*		ao_mark_word_new			(gboolean enable);
+AoMarkWord*		ao_mark_word_new			(gboolean enable, MarkWordMode markword_mode);
 void			ao_mark_word_check			(AoMarkWord *bm, GeanyEditor *editor,
 											 SCNotification *nt);
 


### PR DESCRIPTION
It's more comfortable for me than the kbd shortcut or double click.
It has a side effect, a "find with highlight" functionality when
using search-field on the toolbar, because current match will be
selected by the find.

KATE, Kwrite, NetBeans, etc also offers such functionality.

Disabled by default, enable it in addons plugin's preferences.
