### PR TITLE
Limit the display of diff output to 16 KB to not freeze the UI while ren...

### DIFF
--- a/geanyvc/src/geanyvc.h
+++ b/geanyvc/src/geanyvc.h
@@ -52,6 +52,8 @@ enum
 	VC_COMMAND_STARTDIR_FILE
 };
 
+#define COMMIT_DIFF_MAXLENGTH  16384
+
 #define FLAG_RELOAD         (1<<0)
 #define FLAG_FORCE_ASK      (1<<1)
 #define FLAG_FILE           (1<<2)


### PR DESCRIPTION
...dering

This should workaround the long-standing bug that the commit dialog freezes Geany
when the diff output is very large. Now, if the output exceeds 16 KB, a short message
is displayed instead suggesting to open the diff for review in Geany directly.
