### PR TITLE
Adding html table conversion support for markdown files

### DIFF
--- a/tableconvert/src/tableconvert.c
+++ b/tableconvert/src/tableconvert.c
@@ -202,7 +202,7 @@ static void convert_to_table(gboolean header)
 					return;
 				}
 				case GEANY_FILETYPES_HTML:
-                case GEANY_FILETYPES_MARKDOWN:
+				case GEANY_FILETYPES_MARKDOWN:
 				{
 					replacement = convert_to_table_worker(rows,
 						header,


### PR DESCRIPTION
Hi,
    When editing a markdown file, I realized it would be really useful to have the convert to table plugin work for it. Actually I assumed it would work as markdown files support embedding html too.  As this did not work, I made a small change to tableconvert.c to support html tables in markdown files.  I compiled the latest of geany (Geany 1.24 git >= ef33175) and geany-plugins with the change and it worked very well.  I hope you will find the change useful.
