### PR TITLE
Fix build with -fno-common: use extern and NO_IMPORT_PYGOBJECT

### DIFF
--- a/geanypy/src/geanypy-editor.h
+++ b/geanypy/src/geanypy-editor.h
@@ -1,7 +1,7 @@
 #ifndef GEANYPY_EDITOR_H__
 #define GEANYPY_EDITOR_H__
 
-PyTypeObject IndentPrefsType;
+extern PyTypeObject IndentPrefsType;
 
 typedef struct
 {

--- a/geanypy/src/geanypy-encoding.h
+++ b/geanypy/src/geanypy-encoding.h
@@ -1,7 +1,7 @@
 #ifndef GEANYPY_ENCODING_H__
 #define GEANYPY_ENCODING_H__
 
-PyTypeObject EncodingType;
+extern PyTypeObject EncodingType;
 
 typedef struct
 {

--- a/geanypy/src/geanypy-plugin.c
+++ b/geanypy/src/geanypy-plugin.c
@@ -19,6 +19,8 @@
  * MA 02110-1301, USA.
  */
 
+#define INCLUDE_PYGOBJECT_ONCE_FULL
+
 #include "geanypy.h"
 
 G_MODULE_EXPORT GeanyPlugin		*geany_plugin;

--- a/geanypy/src/geanypy-project.h
+++ b/geanypy/src/geanypy-project.h
@@ -1,7 +1,7 @@
 #ifndef GEANYPY_PROJECT_H__
 #define GEANYPY_PROJECT_H__
 
-PyTypeObject ProjectType;
+extern PyTypeObject ProjectType;
 
 typedef struct
 {

--- a/geanypy/src/geanypy-scintilla.h
+++ b/geanypy/src/geanypy-scintilla.h
@@ -1,8 +1,8 @@
 #ifndef GEANYPY_SCINTILLA_H__
 #define GEANYPY_SCINTILLA_H__
 
-PyTypeObject NotificationType;
-PyTypeObject NotifyHeaderType;
+extern PyTypeObject NotificationType;
+extern PyTypeObject NotifyHeaderType;
 
 typedef struct
 {

--- a/geanypy/src/geanypy-uiutils.h
+++ b/geanypy/src/geanypy-uiutils.h
@@ -1,8 +1,8 @@
 #ifndef GEANYPY_UI_UTILS_H__
 #define GEANYPY_UI_UTILS_H__
 
-PyTypeObject InterfacePrefsType;
-PyTypeObject MainWidgetsType;
+extern PyTypeObject InterfacePrefsType;
+extern PyTypeObject MainWidgetsType;
 
 typedef struct
 {

--- a/geanypy/src/geanypy.h
+++ b/geanypy/src/geanypy.h
@@ -75,6 +75,15 @@ extern "C" {
 #include <string.h>
 
 #include <gtk/gtk.h>
+
+/* necessary for compilation with -fno-common,
+ * see https://bugzilla.gnome.org/show_bug.cgi?id=610657 for details,
+ * INCLUDE_PYGOBJECT_ONCE_FULL is set only once in geanypy-plugin.c */
+#ifndef INCLUDE_PYGOBJECT_ONCE_FULL
+#  define NO_IMPORT_PYGOBJECT
+#  define NO_IMPORT_PYGTK
+#endif
+
 #include <pygobject.h>
 
 #ifndef GEANYPY_WINDOWS


### PR DESCRIPTION
Define global variables as extern in the header files to fix build with the gcc
option -fno-common.
Also, define NO_IMPORT_PYGOBJECT and NO_IMPORT_PYGTK for PyGTK
as this also fails to build with linker errors if the headers are included multiple
times.

Without those changes, build fails with linker errors like:
- multiple definition of `_PyGtk_API
- multiple definition of `InterfacePrefsType'

when the gcc option -fno-common is used (which we do in the nightly builds against GTK 2.16).
-fno-common is certainly not strictly required but as the changes are not that much, I'd say it's worth.
