### PR TITLE
Geanylatex: remove useless check

### DIFF
--- a/geanylatex/src/geanylatex.c
+++ b/geanylatex/src/geanylatex.c
@@ -1309,10 +1309,8 @@ on_insert_bibtex_dialog_activate(G_GNUC_UNUSED GtkMenuItem *menuitem,
 		}
 		else
 		{
-			if (ref_string != NULL)
-				g_free(ref_string);
-			if (template_string != NULL)
-				g_free(template_string);
+			g_free(ref_string);
+			g_free(template_string);
 		}
 	}
 


### PR DESCRIPTION
This was found by cppcheck. Freeing NULL is always safe.
