### PR TITLE
Treebrowser: exclude false-positives, fix memory leaks

### DIFF
--- a/treebrowser/src/Makefile.am
+++ b/treebrowser/src/Makefile.am
@@ -6,4 +6,7 @@ treebrowser_la_SOURCES = treebrowser.c
 treebrowser_la_CFLAGS = $(AM_CFLAGS) $(GIO_CFLAGS)
 treebrowser_la_LIBADD = $(COMMONLIBS) $(GIO_LIBS)
 
+AM_CPPCHECKFLAGS = --suppress='deallocDealloc:$(srcdir)/treebrowser.c'
+AM_CPPCHECKFLAGS += --suppress='doubleFree:$(srcdir)/treebrowser.c'
+
 include $(top_srcdir)/build/cppcheck.mk

--- a/treebrowser/src/treebrowser.c
+++ b/treebrowser/src/treebrowser.c
@@ -685,6 +685,7 @@ treebrowser_load_bookmarks(void)
 			gtk_tree_path_free(tree_path);
 		}
 	}
+	g_free(bookmarks);
 }
 
 static gboolean
@@ -726,7 +727,6 @@ treebrowser_search(gchar *uri, gpointer parent)
 static void
 fs_remove(gchar *root, gboolean delete_root)
 {
-	GDir *dir;
 	gchar *path;
 	const gchar *name;
 
@@ -735,6 +735,7 @@ fs_remove(gchar *root, gboolean delete_root)
 
 	if (g_file_test(root, G_FILE_TEST_IS_DIR))
 	{
+		GDir *dir;
 		dir = g_dir_open (root, 0, NULL);
 
 		if (!dir)
@@ -756,6 +757,7 @@ fs_remove(gchar *root, gboolean delete_root)
 			g_free(path);
 			name = g_dir_read_name(dir);
 		}
+		g_dir_close(dir);
 	}
 	else
 		delete_root = TRUE;


### PR DESCRIPTION
This leak was found by cppcheck. Also reduced scope of dir variable.

Note: this partially covers #125.
