### PR TITLE
Geanyprj: fix memory leak, fix false positive

### DIFF
--- a/geanyprj/src/Makefile.am
+++ b/geanyprj/src/Makefile.am
@@ -13,4 +13,7 @@ geanyprj_la_SOURCES = geanyprj.c \
 geanyprj_la_CFLAGS = $(AM_CFLAGS)
 geanyprj_la_LIBADD = $(COMMONLIBS)
 
+AM_CPPCHECKFLAGS = --suppress='constStatement:*'
+AM_CPPCHECKFLAGS += --suppress='memleak:utils.c:72'
+
 include $(top_srcdir)/build/cppcheck.mk

--- a/geanyprj/src/project.c
+++ b/geanyprj/src/project.c
@@ -360,6 +360,7 @@ gboolean geany_project_add_file(struct GeanyPrj *prj, const gchar *path)
 		g_key_file_free(config);
 		return TRUE;
 	}
+	g_key_file_free(config);
 
 	filename = utils_get_locale_from_utf8(path);
 	tm_obj = tm_source_file_new(filename, FALSE, filetypes_detect_from_file(path)->name);


### PR DESCRIPTION
This leak was found by cppcheck. `config` was freed twice but didn't freed in function body:)

There is also false positive I think:

```
// memleak:utils.c:72
    v = g_strsplit_set(filename, "/\\", -1);
    if (!g_strv_length(v))
        return g_strdup("."); // possible leak
```

g_strv_length should be zero only if v is NULL, right? Otherwise this is a leak. Anyway only author can understand this pointer magic.
