### PR TITLE
Commander: few optimizations for better user experience

### DIFF
--- a/commander/src/commander-plugin.c
+++ b/commander/src/commander-plugin.c
@@ -152,7 +152,10 @@ key_score (const gchar *key_,
   gchar  *key   = g_utf8_casefold (key_, -1);
   gint    score;
   
-  score = get_score (key, text);
+  if(strncmp(text, key, strlen(key)) == 0)
+    score = strlen(key) * 2;
+  else
+    score = get_score (key, text);
   
   g_free (text);
   g_free (key);
@@ -391,7 +394,7 @@ fill_store (GtkListStore *store)
     
     gtk_list_store_insert_with_values (store, NULL, -1,
                                        COL_LABEL, label,
-                                       COL_PATH, DOC_FILENAME (documents[i]),
+                                       COL_PATH, basename,
                                        COL_TYPE, COL_TYPE_FILE,
                                        COL_DOCUMENT, documents[i],
                                        -1);


### PR DESCRIPTION
Here are two little changes to make commander search better:
1. Get more score for exact match. E.g. you have file named
"editor.c" and type "edi" - editor.c going to be first. With
current scoring system you may find "editor.c" document on 10th
line or deeper.
2. Remove path for documents. Usually you don't want to type full
path to file to find document in list. This makes fast document
searching possible with #1 optimization.
![img](http://i.imgur.com/djvJ42t.png)
