### PR TITLE
tableconvert: Fix a typo in the build system (oops)

### DIFF
--- a/tableconvert/src/Makefile.am
+++ b/tableconvert/src/Makefile.am
@@ -2,7 +2,7 @@ include $(top_srcdir)/build/vars.build.mk
 
 geanyplugins_LTLIBRARIES = tableconvert.la
 
-tableconvert_la_SOURCES =
+tableconvert_la_SOURCES = \
 	tableconvert.c \
 	tableconvert.h \
 	tableconvert_ui.c \


### PR DESCRIPTION
Fix from 2c88da358f25b6535333f107aa8ab75409855228 had a typo leading to nothing to be built (sure it built better…)
