### PR TITLE
Updatechecker improvements - more notifications and setting a timeout

### DIFF
--- a/updatechecker/src/updatechecker.c
+++ b/updatechecker/src/updatechecker.c
@@ -84,8 +84,10 @@ static void update_check(gint type)
                                      GEANY_VERSION, NULL);
 
     g_message("Checking for updates (querying URL \"%s\")", UPDATE_CHECK_URL);
-    soup = soup_session_async_new_with_options(SOUP_SESSION_USER_AGENT,
-            user_agent, NULL);
+    soup = soup_session_async_new_with_options(
+            SOUP_SESSION_USER_AGENT, user_agent,
+            SOUP_SESSION_TIMEOUT, 10,
+            NULL);
 
     g_free(user_agent);
 


### PR DESCRIPTION
Make update check results and notifications more visibile to the user and set a short default timeout for the HTTP request.

Before, the update checker plugin mostly said "yes, updates" or "no updates". Now. it tells also the available version if any and push yes/no messages also to the status messages in case the update check was performed at program start.
