### PR TITLE
Enable Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,61 @@
+language: c
+compiler:
+  - gcc
+env:
+  - GTK3=no
+  - GTK3=yes
+before_install:
+  - sudo apt-get update -qq
+install:
+  - sudo apt-get install -y libgtk2.0-dev libgtk-3-dev intltool libtool
+  - sudo apt-get install -y python-docutils
+  - sudo apt-get install -y cppcheck check
+  # debugger
+  - sudo apt-get install -y libvte-dev
+  # devhelp
+  - sudo apt-get install -y libwebkitgtk-dev libwnck-dev libgconf2-dev zlib1g-dev
+  # geanygendoc
+  - sudo apt-get install -y libctpl-dev
+  # geanylua
+  - sudo apt-get install -y liblua5.1-0-dev
+  # geanypg
+  - sudo apt-get install -y libgpgme11-dev
+  # geanypy
+  - sudo apt-get install -y libpython-dev
+  # geanyvc
+  - sudo apt-get install -y libgtkspell-dev
+  # geaniuspaste/updatechecker
+  - sudo apt-get install -y libsoup2.4-dev
+  # markdown
+  - sudo apt-get install -y libmarkdown2-dev
+  # markdown/webhelper
+  - sudo apt-get install -y libwebkitgtk-3.0-dev
+  # multiterm
+  - sudo apt-get install -y valac
+  # pretty-printer
+  - sudo apt-get install -y libxml2-dev
+  # spellcheck
+  - sudo apt-get install -y libenchant-dev
+before_script:
+  # build Geany
+  - TEMPDIR=$(mktemp -d)
+  - git clone git://github.com/geany/geany.git "$TEMPDIR/geany"
+  - export GEANY_PREFIX="$TEMPDIR/_install"
+  - ( cd "$TEMPDIR/geany"                                         &&
+      ./autogen.sh --prefix="$GEANY_PREFIX" --enable-gtk3=$GTK3   &&
+      make -j2                                                    &&
+      make install )
+  - export PKG_CONFIG_PATH="$GEANY_PREFIX/lib/pkgconfig:$PKG_CONFIG_PATH"
+  - export LD_LIBRARY_PATH="$GEANY_PREFIX/lib:$LD_LIBRARY_PATH"
+  # prepare for GP
+  - export CFLAGS="-g -O2 -Werror=pointer-arith -Werror=aggregate-return -Werror=implicit-function-declaration"
+script:
+  - >
+    NOCONFIGURE=1 ./autogen.sh  &&
+    mkdir _build                &&
+    cd _build                   &&
+    ../configure                &&
+    make -j2                    &&
+    make -j2 check
+after_script:
+  - test -z "$TEMPDIR" || rm -rf "$TEMPDIR"

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,8 @@ install:
   # geanypg
   - sudo apt-get install -y libgpgme11-dev
   # geanypy
-  - sudo apt-get install -y libpython-dev
+  # FIXME: Ubuntu 12.04 doesn't seem to have it??
+  #- sudo apt-get install -y libpython-dev
   # geanyvc
   - sudo apt-get install -y libgtkspell-dev
   # geaniuspaste/updatechecker

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,9 @@ before_install:
 install:
   - sudo apt-get install -y libgtk2.0-dev libgtk-3-dev intltool libtool
   - sudo apt-get install -y python-docutils
-  - sudo apt-get install -y cppcheck check
+  - sudo apt-get install -y check
+  # FIXME: there are weird error with spellcheck and Ubuntu 12.04's version of cppcheck (1.52)
+  #- sudo apt-get install -y cppcheck
   # debugger
   - sudo apt-get install -y libvte-dev
   # devhelp


### PR DESCRIPTION
***This has to be discussed a little before merging***

Here it is a bit more complex than [on Geany](/geany/geany/pull/360), but it's also probably more important.  Same concern applies than on Geany, so I won't repeat myself here and concentrate on technical questions.

1. We need a recent Geany (we can't simply install the Ubuntu 12.04 package).  Here I made the setup rules build it from latest Git, but it might not be so great:
  1. Any build issue in Geany git will break GP.
  2. It means we rebuild from source each time.  Maybe a better solution would be to [install](http://docs.travis-ci.com/user/installing-dependencies/#Installing-Packages-from-a-custom-APT-repository) from the [nightly builds .deb](http://nightly.geany.org/debian/)s but unfortunately the [Wheezy ones aren't compatible with Ubuntu 12.04](https://travis-ci.org/b4n/geany-plugins/jobs/38556973#L43).
2. As you can see with the additional commit, I couldn't build GeanyPy because [Ubuntu 12.04 don't seem to have libpython-dev](http://packages.ubuntu.com/search?keywords=libpython-dev&searchon=names&suite=precise&section=all), which is quite weird.
3. As you can also see, I had [a fairly weird](https://travis-ci.org/b4n/geany-plugins/jobs/38544571#L2945) problem with cppcheck that I can't reproduce on my machine (which has cppcheck 1.66).  If anyone can tell me what's going on here, please go ahead (especially as other cppcheck calls worked fine, see above in the log).

Finally, you might see that the [GTK2 build currently fails](https://travis-ci.org/b4n/geany-plugins/builds/38554414), but that's legitimate, see #171 (so that's a good point for Travis CI as I found the error when setting it up :).