### PR TITLE
debugger: Fix crash with GDB 7.7

### DIFF
--- a/debugger/src/dbm_gdb.c
+++ b/debugger/src/dbm_gdb.c
@@ -369,7 +369,7 @@ static gboolean on_read_async_output(GIOChannel * src, GIOCondition cond, gpoint
 				update_files();
 
 				/* -exec-run */
-				exec_async_command("-exec-run &");
+				exec_async_command("-exec-run");
 			}
 		}
 		else
@@ -895,7 +895,7 @@ static gboolean run(const gchar* file, const gchar* commandline, GList* env, GLi
 static void restart(void)
 {
 	dbg_cbs->clear_messages();
-	exec_async_command("-exec-run &");
+	exec_async_command("-exec-run");
 }
 	
 /*


### PR DESCRIPTION
GDB 7.7 doesn't understand `&` as an argument to `-exec-run`.

Moreover, the code handling errors from GDB has an issue with this
error and leads to a crash.

Closes https://sourceforge.net/p/geany-plugins/bugs/112/

---
@cesspit Are you OK with this?  I think it's important to do something as it leads to a crash when using GDB 7.7 (version is according to your findings).  I also think that even if it prevents asynchronous debugging, it's still worth to fix until a proper asynchronous fix is released.
