### PR TITLE
scope, debugger: use util.h instead of pty.h on OS X

### DIFF
--- a/debugger/src/debug.c
+++ b/debugger/src/debug.c
@@ -37,7 +37,11 @@ int grantpt(int fd);
 
 #include <string.h>
 #include <unistd.h>
+#ifdef __APPLE__
+#include <util.h>
+#else
 #include <pty.h>
+#endif
 #include <gtk/gtk.h>
 #include <gdk/gdkkeysyms.h>
 #include <vte/vte.h>

--- a/scope/src/conterm.c
+++ b/scope/src/conterm.c
@@ -30,7 +30,11 @@
 #ifdef G_OS_UNIX
 #include <vte/vte.h>
 /* instead of detecting N kinds of *nix */
+#ifdef __APPLE__
+#include <util.h>
+#else
 #include <pty.h>
+#endif
 int grantpt(int fd);
 int unlockpt(int fd);
 


### PR DESCRIPTION
pty.h doesn't exist on OS X, it's contents is present in util.h. This fixes plugins compilation problem on OS X (I tried just the basic ones with minimal dependencies).