### PR TITLE
geanylua: Do not accept Lua5.2 as the plugin doesn't build with it

### DIFF
--- a/build/geanylua.m4
+++ b/build/geanylua.m4
@@ -14,8 +14,10 @@ AC_DEFUN([GP_CHECK_GEANYLUA],
         done])
 
     LUA_VERSION=5.1
+    LUA_VERSION_BOUNDARY=5.2
     GP_CHECK_PLUGIN_DEPS([GeanyLua], [LUA],
-                         [${LUA_PKG_NAME} >= ${LUA_VERSION}])
+                         [${LUA_PKG_NAME} >= ${LUA_VERSION}
+                          ${LUA_PKG_NAME} < ${LUA_VERSION_BOUNDARY}])
     GP_CHECK_PLUGIN_DEPS([GeanyLua], [GMODULE], [gmodule-2.0])
     GP_COMMIT_PLUGIN_STATUS([GeanyLua])
 

--- a/geanylua/wscript_configure
+++ b/geanylua/wscript_configure
@@ -30,10 +30,12 @@ def try_to_find_lua_package():
     for package_name in package_names:
         check_cfg_cached(conf,
                      package=package_name,
-                     atleast_version='5.1',
                      mandatory=False,
                      uselib_store='LUA',
-                     args='--cflags --libs')
+                     args='%s >= 5.1 %s < 5.2 --cflags --libs' %
+                          (package_name, package_name),
+                     msg="Checking for '%s' >= 5.1 and < 5.2" %
+                         package_name)
         if conf.env['HAVE_LUA'] == 1:
             return True
     return False


### PR DESCRIPTION
Make sure the found Lua package is version 5.1 and not newer, as 5.2
breaks compilation.

The issue with 5.2 was reported by an user on IRC.