### PR TITLE
Properly test valac existence

### DIFF
--- a/build/multiterm.m4
+++ b/build/multiterm.m4
@@ -7,7 +7,7 @@ AC_DEFUN([GP_CHECK_MULTITERM],
         dnl FIXME: if the C sources are present (e.g. in a release tarball),
         dnl        we don't actually need valac
         AM_PROG_VALAC([0.7.0])
-        AS_IF([test "$VALAC" = ""],
+        AS_IF([test "$VALAC" = "valac"],
               [AS_IF([test "$enable_multiterm" = "auto"],
                      [enable_multiterm=no],
                      [AC_MSG_ERROR([valac not found])])])


### PR DESCRIPTION
According to the documentation

http://www.gnu.org/software/automake/manual/html_node/Vala-Support.html

$VALAC contains 'valac' when valac was not found. I kept the empty
string test just in case it is returned under some special circumstances.

This fixes autogen on OS X.