### PR TITLE
Fix SourceForge tracker URL

### DIFF
--- a/commander/README
+++ b/commander/README
@@ -42,4 +42,4 @@ Bug reports and feature requests
 --------------------------------
 
 To report a bug or ask for a new feature, please use the Geany-Plugins tracker
-on SourceForge: http://sourceforge.net/tracker/?group_id=222729
+on SourceForge: https://sourceforge.net/projects/geany-plugins/

--- a/geanygendoc/README
+++ b/geanygendoc/README
@@ -67,4 +67,4 @@ Bug reports and feature requests
 --------------------------------
 
 To report a bug or ask for a new feature, please use the Geany-Plugins tracker
-on SourceForge: http://sourceforge.net/tracker/?group_id=222729
+on SourceForge: https://sourceforge.net/projects/geany-plugins/

--- a/geanylatex/doc/geanylatex.html
+++ b/geanylatex/doc/geanylatex.html
@@ -2724,8 +2724,8 @@ class="cmr-10">New features are always highly welcome. The TODO file inside sour
 class="cmr-10">wished features and which are being worked on. Also you can have a look onto the feature request tracker of</span>
 <span 
 class="cmr-10">geany-plugins project at </span><a 
-href="http://sourceforge.net/tracker/?group\_id=222729" class="url" ><span 
-class="cmtt-10">http://sourceforge.net/tracker/?group\_id=222729</span></a> <span 
+href="https://sourceforge.net/projects/geany-plugins/" class="url" ><span 
+class="cmtt-10">https://sourceforge.net/projects/geany-plugins/</span></a> <span 
 class="cmr-10">whether you find something</span>
 <span 
 class="cmr-10">interesting. Of course we are also open for not in the sources mentioned before listed items. Just contact one of the</span>
@@ -2920,8 +2920,8 @@ class="cmr-10">At time of the the documentation was created no issue were known.
 <span 
 class="cmr-10">recent information for all reported issues bug tracking system of SF at </span><br 
 class="newline" /><a 
-href="http://sourceforge.net/tracker/?group\_id=222729" class="url" ><span 
-class="cmtt-10">http://sourceforge.net/tracker/?group\_id=222729</span></a>
+href="https://sourceforge.net/projects/geany-plugins/" class="url" ><span 
+class="cmtt-10">https://sourceforge.net/projects/geany-plugins/</span></a>
 </p><!--l. 945--><p class="noindent" >
 </p>
 <h3 class="sectionHead"><span class="titlemark"><span 

--- a/geanylatex/doc/geanylatex.tex
+++ b/geanylatex/doc/geanylatex.tex
@@ -863,7 +863,7 @@ New features are always highly welcome. The TODO file inside source
 code archive gives a good idea of current wished features and which
 are being worked on. Also you can have a look onto the feature request
 tracker of geany-plugins project at
-\url{http://sourceforge.net/tracker/?group\_id=222729} whether you find
+\url{https://sourceforge.net/projects/geany-plugins/} whether you find
 something interesting. Of course we are also open for not in the
 sources mentioned before listed items. Just contact one of the authors
 (see Chapter \ref{contact}).
@@ -940,7 +940,7 @@ the same conditions as Geany\LaTeX{} by the copyright owner.
 At time of the the documentation was created no issue were known.
 Since this is only a snapshot, you will find more recent information
 for all reported issues bug tracking system of SF at \\
-\url{http://sourceforge.net/tracker/?group\_id=222729}
+\url{https://sourceforge.net/projects/geany-plugins/}
 
 \section{Recommendations to improve work with \LaTeX{} and Geany}
 Geany is offering a number of nice features that can be used to make

--- a/geanylipsum/README
+++ b/geanylipsum/README
@@ -52,7 +52,7 @@ Known issues
 At the moment, there is no known issue.
 
 For more recent information all reported issues will be tracked at
-http://sourceforge.net/tracker/?group_id=222729
+https://sourceforge.net/projects/geany-plugins/
 
 
 License

--- a/geanypg/README
+++ b/geanypg/README
@@ -42,7 +42,7 @@ At the moment, the use of pinentry is only supported on unix-like
 systems. On Windows gpg-agent has to be used.
 
 For more recent information all reported issues will be tracked at
-http://sourceforge.net/tracker/?group_id=222729
+https://sourceforge.net/projects/geany-plugins/
 
 
 License

--- a/geanypg/doc/geanypg.html
+++ b/geanypg/doc/geanypg.html
@@ -77,8 +77,8 @@ At the moment, the use of pinentry is only supported on unix-like
 systems. On Windows gpg-agent has to be used.
 </p><p>
 For more recent information all reported issues will be tracked at
-<a href="http://sourceforge.net/tracker/?group_id=222729">
-http://sourceforge.net/tracker/?group_id=222729</a>
+<a href="https://sourceforge.net/projects/geany-plugins/">
+https://sourceforge.net/projects/geany-plugins/</a>
 </p><p>
 <h4>License</h4>
 GeanyPG and all its parts is distributed under the terms of the

--- a/geanysendmail/README
+++ b/geanysendmail/README
@@ -111,7 +111,7 @@ you should keep care of proper quoting since %s, %b and %r will be
 replaced without any quotes.
 
 For more recent information all reported issues will be tracked at
-http://sourceforge.net/tracker/?group_id=222729
+https://sourceforge.net/projects/geany-plugins/
 
 
 License

--- a/git-changebar/README
+++ b/git-changebar/README
@@ -52,4 +52,4 @@ Bug reports and feature requests
 --------------------------------
 
 To report a bug or ask for a new feature, please use the Geany-Plugins tracker
-on SourceForge: http://sourceforge.net/tracker/?group_id=222729
+on SourceForge: https://sourceforge.net/projects/geany-plugins/

--- a/multiterm/README
+++ b/multiterm/README
@@ -75,4 +75,4 @@ Bug reports and feature requests
 --------------------------------
 
 To report a bug or ask for a new feature, please use the Geany-Plugins tracker
-on SourceForge: http://sourceforge.net/tracker/?group_id=222729
+on SourceForge: https://sourceforge.net/projects/geany-plugins/

--- a/pohelper/README
+++ b/pohelper/README
@@ -70,4 +70,4 @@ Bug reports and feature requests
 --------------------------------
 
 To report a bug or ask for a new feature, please use the Geany-Plugins tracker
-on SourceForge: http://sourceforge.net/tracker/?group_id=222729
+on SourceForge: https://sourceforge.net/projects/geany-plugins/

--- a/tableconvert/README
+++ b/tableconvert/README
@@ -112,7 +112,7 @@ moment. However, at least the second point is planned for some later
 release.
 
 For more recent information all reported issues will be tracked at
-http://sourceforge.net/tracker/?group_id=222729
+https://sourceforge.net/projects/geany-plugins/
 
 
 License

--- a/treebrowser/README
+++ b/treebrowser/README
@@ -76,7 +76,7 @@ TreeBrowser plugin is distrubuted under the same license as and geany.
 Ideas, questions, patches and bug reports
 =========================================
 
-Report them at http://sourceforge.net/tracker/?group_id=222729.
+Report them at https://sourceforge.net/projects/geany-plugins/.
 
 --
 2010 Adrian Dimitrov

--- a/updatechecker/README
+++ b/updatechecker/README
@@ -65,7 +65,7 @@ Known issues
 At the moment, there is no known issue.
 
 For more recent information all reported issues will be tracked at
-http://sourceforge.net/tracker/?group_id=222729
+https://sourceforge.net/projects/geany-plugins/
 
 
 License

--- a/webhelper/README
+++ b/webhelper/README
@@ -79,4 +79,4 @@ Bug reports and feature requests
 --------------------------------
 
 To report a bug or ask for a new feature, please use the Geany-Plugins tracker
-on SourceForge: http://sourceforge.net/tracker/?group_id=222729
+on SourceForge: https://sourceforge.net/projects/geany-plugins/


### PR DESCRIPTION
Apparently the old tracker URL doesn't work anymore, so use the new one.