### PR TITLE
pairtaghighlighter: Fix clearing previous indicators

### DIFF
--- a/pairtaghighlighter/src/pair_tag_highlighter.c
+++ b/pairtaghighlighter/src/pair_tag_highlighter.c
@@ -150,7 +150,7 @@ static void highlight_matching_pair(ScintillaObject *sci)
 static void clear_previous_highlighting(ScintillaObject *sci, gint rangeStart, gint rangeEnd)
 {
     scintilla_send_message(sci, SCI_SETINDICATORCURRENT, INDICATOR_TAGMATCH, 0);
-    scintilla_send_message(sci, SCI_INDICATORCLEARRANGE, rangeStart, rangeEnd+1);
+    scintilla_send_message(sci, SCI_INDICATORCLEARRANGE, rangeStart, rangeEnd-rangeStart+1);
 }
 
 


### PR DESCRIPTION
The second argument for SCI_INDICATORCLEARRANGE is the length to clear,
not the end position.

This used to work on earlier versions of Scintilla for some reason,
probably because it didn't check length, but current versions do nothing
with an invalid length.