### PR TITLE
webhelper: replace depricated glib (>=2.32) functions

### DIFF
--- a/webhelper/src/gwh-plugin.c
+++ b/webhelper/src/gwh-plugin.c
@@ -419,11 +419,14 @@ plugin_init (GeanyData *data)
    * (g_quark_from_static_string() for example) so it's not safe to remove it */
   plugin_module_make_resident (geany_plugin);
   
-  /* webkit uses threads but don't initialize the thread system */
+  /* Deprecated function g_thread_init() is not needed. after glib 
+   * versions >= 2.32 
+  
   if (! g_thread_supported ()) {
     g_thread_init (NULL);
   }
   
+   */
   load_config ();
   gwh_keybindings_init ();
   

--- a/webhelper/src/gwh-settings.c
+++ b/webhelper/src/gwh-settings.c
@@ -196,7 +196,6 @@ gwh_settings_install_property (GwhSettings *self,
         break;
     
     HANDLE_BASIC_TYPE (BOOLEAN, Boolean, boolean)
-    HANDLE_BASIC_TYPE (CHAR,    Char,    char)
     HANDLE_BASIC_TYPE (UCHAR,   UChar,   uchar)
     HANDLE_BASIC_TYPE (INT,     Int,     int)
     HANDLE_BASIC_TYPE (UINT,    UInt,    uint)
@@ -211,7 +210,12 @@ gwh_settings_install_property (GwhSettings *self,
     HANDLE_BASIC_TYPE (STRING,  String,  string)
     
     #undef HANDLE_BASIC_TYPE
-    
+
+    /* remove depricated function g_value_set_char and replace w/ this. */
+    case G_TYPE_CHAR:
+    	g_value_set_schar(value, (gint8)((GParamSpecChar*)pspec)->default_value);
+        break;
+
     case G_TYPE_PARAM:
     case G_TYPE_BOXED:
     case G_TYPE_POINTER:


### PR DESCRIPTION
The glib functions `g_value_set_char` and `g_thread_init`
are depricated, throwing a GCC warning on their compilation.
This commit fixes the GCC warnings by removing the old
function (`g_thread_init`), and changes a block in gwh-plugin.c 
to use the newer (`g_value_set_schar`).