### PR TITLE
projectorganizer: Fix API version check

### DIFF
--- a/projectorganizer/src/prjorg-main.c
+++ b/projectorganizer/src/prjorg-main.c
@@ -34,7 +34,7 @@ GeanyPlugin *geany_plugin;
 GeanyData *geany_data;
 GeanyFunctions *geany_functions;
 
-PLUGIN_VERSION_CHECK(214)
+PLUGIN_VERSION_CHECK(221)
 PLUGIN_SET_TRANSLATABLE_INFO(
 	LOCALEDIR,
 	GETTEXT_PACKAGE,


### PR DESCRIPTION
The API version check was rolled back as part of c890cbc3 probably by
mistake, as the plugin really depends on 221 as it uses the new
TagManager API.

---

@techee is that OK?