### PR TITLE
Fix checks for openpty() on FreeBSD

### DIFF
--- a/build/debugger.m4
+++ b/build/debugger.m4
@@ -4,6 +4,7 @@ AC_DEFUN([GP_CHECK_DEBUGGER],
     GP_CHECK_PLUGIN_GTK2_ONLY([Debugger])
     GP_CHECK_PLUGIN_DEPS([debugger], [VTE],
                          [vte >= 0.24])
+    AC_CHECK_HEADERS([util.h pty.h libutil.h])
     GP_COMMIT_PLUGIN_STATUS([Debugger])
     AC_CONFIG_FILES([
         debugger/Makefile

--- a/build/scope.m4
+++ b/build/scope.m4
@@ -5,6 +5,7 @@ AC_DEFUN([GP_CHECK_SCOPE],
 
     GP_CHECK_PLUGIN_DEPS([scope], [VTE],
                          [vte >= 0.17])
+    AC_CHECK_HEADERS([util.h pty.h libutil.h])
 
     GP_COMMIT_PLUGIN_STATUS([Scope])
 

--- a/build/wafutils.py
+++ b/build/wafutils.py
@@ -141,6 +141,28 @@ def check_c_header_cached(conf, **kw):
     return result
 
 
+def check_c_func_in_headers_cached(conf, header_names, mandatory=True, **kw):
+    """
+    Check for @function_name in any of @header_names.
+    Use like a conf.check_cc() for a lib, but pass a list of headers in
+    @header_names.
+
+    This checks for the headers firs with check_c_header_cached(), then
+    if this succeeded calls conf.check_cc() on it.
+    """
+
+    exception = None
+    for header in header_names:
+        try:
+            check_c_header_cached(conf, header_name=header)
+            return conf.check_cc(**dict(kw, header_name=header, mandatory=True))
+        except Exception as e:
+            exception = e
+    if mandatory:
+        raise exception
+    return None
+
+
 def check_cfg_cached(conf, **kw):
     # Works as conf.check_cfg() but tries to cache already checked packages
     package = kw.get('package')

--- a/debugger/src/debug.c
+++ b/debugger/src/debug.c
@@ -29,6 +29,10 @@
  * 		Contains callbacks from debugger module to handle debug state changes.
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include <stdio.h>
 
 #include <stdlib.h>
@@ -37,9 +41,11 @@ int grantpt(int fd);
 
 #include <string.h>
 #include <unistd.h>
-#ifdef __APPLE__
+#if defined(HAVE_UTIL_H)
 #include <util.h>
-#else
+#elif defined(HAVE_LIBUTIL_H)
+#include <libutil.h>
+#elif defined(HAVE_PTY_H)
 #include <pty.h>
 #endif
 #include <gtk/gtk.h>

--- a/debugger/wscript_configure
+++ b/debugger/wscript_configure
@@ -21,6 +21,7 @@
 # $Id: wscript_configure 1735 2010-11-09 17:03:40Z eht16 $
 
 from build.wafutils import check_cfg_cached
+from build.wafutils import check_c_func_in_headers_cached
 
 
 check_cfg_cached(conf,
@@ -29,4 +30,7 @@ check_cfg_cached(conf,
                  args='--cflags --libs')
 
 conf.check_cc(function_name='poll', header_name='poll.h')
-conf.check_cc(function_name='openpty', header_name='pty.h', lib='util', uselib_store='UTIL')
+check_c_func_in_headers_cached(conf,
+                               function_name='openpty',
+                               header_names=['util.h', 'pty.h', 'libutil.h'],
+                               lib='util', uselib_store='UTIL')

--- a/scope/src/conterm.c
+++ b/scope/src/conterm.c
@@ -17,6 +17,10 @@
  *  along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include <errno.h>
 #include <stdlib.h>
 #include <string.h>
@@ -30,9 +34,11 @@
 #ifdef G_OS_UNIX
 #include <vte/vte.h>
 /* instead of detecting N kinds of *nix */
-#ifdef __APPLE__
+#if defined(HAVE_UTIL_H)
 #include <util.h>
-#else
+#elif defined(HAVE_LIBUTIL_H)
+#include <libutil.h>
+#elif defined(HAVE_PTY_H)
 #include <pty.h>
 #endif
 int grantpt(int fd);

--- a/scope/wscript_configure
+++ b/scope/wscript_configure
@@ -21,19 +21,14 @@
 # $Id: wscript_configure 1735 2010-11-09 17:03:40Z eht16 $
 
 from build.wafutils import check_cfg_cached, target_is_win32
+from build.wafutils import check_c_func_in_headers_cached
 
 if not target_is_win32(bld) :
 	check_cfg_cached(conf,
 			     package='vte',
 			     uselib_store='VTE',
 			     args='--cflags --libs')
-	try :
-		conf.check_cc(function_name='openpty',
-			      header_name='pty.h',
-			      lib='util',
-			      uselib_store='UTIL')
-	except :
-		conf.check_cc(function_name='openpty',
-			      header_name='util.h',
-			      lib='util',
-			      uselib_store='UTIL')
+	check_c_func_in_headers_cached(conf,
+	                               function_name='openpty',
+	                               header_names=['util.h', 'pty.h', 'libutil.h'],
+	                               lib='util', uselib_store='UTIL')


### PR DESCRIPTION
FreeBSD has openpty() in *libutil.h*.

I PR this because while the Waf changes work, they might be deemed ugly.  @eht16 if you have a better version for this it'd be welcome :)  Otherwise they are OK enough with me.