### PR TITLE
update wscript to work with gtk3 geany builds

### DIFF
--- a/addons/wscript_configure
+++ b/addons/wscript_configure
@@ -1,0 +1,6 @@
+from build.wafutils import check_cfg_cached
+from waflib.Errors import ConfigurationError
+
+if 'gtk-2' not in conf.env['LIB_GEANY']: 
+    raise ConfigurationError
+


### PR DESCRIPTION
Small update to wscript to look-up which version of gtk geany was built with before configuring when using ./waf configure. 
Also number of plugins don't seem to keep their wscript_configure's up-to-date, I cheated a bit by adding a function to regex it out of their .m4 build scripts. That said I'm not sure what the original logic behind having two separate build systems was or if you are still keen on maintaining it. 
On a side note  `check_cfg_cached` for gtk probably doesn't really need to be in there either probably, since geany libs and cflags would cover it. 