### PR TITLE
overview: Fix Waf build

### DIFF
--- a/build/wafutils.py
+++ b/build/wafutils.py
@@ -179,6 +179,67 @@ def check_cfg_cached(conf, **kw):
     return result
 
 
+def check_c99(conf):
+    key = 'c99'
+    if key in cache:
+        v = cache[key]
+        if v:
+            raise v
+        return True
+
+    # FIXME: improve some checks?
+    # TODO: look at Autoconf's C99 checks?
+    fragment = '''
+    // single-line comments
+
+    #include <stdbool.h>
+
+    struct s { int a, b; };
+
+    // inlines
+    static inline void fun_inline(struct s param) {}
+
+    int main(void) {
+        _Bool b = false;
+
+        // variable declaration in for body
+        for (int i = 0; i < 2; i++);
+
+        // compound literals
+        fun_inline((struct s) { 1, 2 });
+
+        // mixed declarations and code
+        int mixed = 0;
+
+        // named initializers
+        struct s name_inited = {
+            .a = 42,
+            .b = 64
+        };
+
+        return (b || mixed || ! name_inited.a);
+    }
+    '''
+
+    exc = None
+    # list of flags is stolen from Autoconf 2.69
+    flags = ['', '-std=gnu99', '-std=c99', '-c99', '-AC99',
+             '-D_STDC_C99=', '-qlanglvl=extc99']
+    for flag in flags:
+        try:
+            desc = ['with flag %s' % flag, 'with no flags'][not flag]
+            conf.check_cc(fragment=fragment, uselib_store='C99', cflags=flag,
+                          msg="Checking for C99 support (%s)" % desc)
+            exc = None
+            break
+        except ConfigurationError as e:
+            exc = e
+    cache[key] = exc
+    if exc:
+        raise exc
+    return True
+
+
 def get_enabled_plugins(conf):
     plugins = get_plugins()
     enabled_plugins = []

--- a/overview/wscript_build
+++ b/overview/wscript_build
@@ -20,6 +20,7 @@
 #
 
 from build.wafutils import build_plugin
+from waflib.Utils import subst_vars
 
 name = 'Overview'
 sources = [
@@ -31,13 +32,11 @@ sources = [
   'overview/overviewui.c',
 ]
 includes = ['overview']
-packages = [ 'gtk+-2.0', 'glib-2.0', 'geany' ]
 libraries = [ 'GTK', 'GLIB', 'GEANY' ]
 defines = [ subst_vars('OVERVIEW_PREFS_UI_FILE="${PKGDATADIR}/overview/prefs.ui"', bld.env) ]
 
 build_plugin(bld, name,
              sources=sources,
              includes=includes,
-             packages=packages,
              libraries=libraries,
              defines=defines)

--- a/overview/wscript_build
+++ b/overview/wscript_build
@@ -32,7 +32,7 @@ sources = [
   'overview/overviewui.c',
 ]
 includes = ['overview']
-libraries = [ 'GTK', 'GLIB', 'GEANY' ]
+libraries = [ 'C99', 'GTK', 'GLIB', 'GEANY' ]
 defines = [ subst_vars('OVERVIEW_PREFS_UI_FILE="${PKGDATADIR}/overview/prefs.ui"', bld.env) ]
 
 build_plugin(bld, name,

--- a/overview/wscript_configure
+++ b/overview/wscript_configure
@@ -1,0 +1,3 @@
+from build.wafutils import check_c99
+
+check_c99(conf)


### PR DESCRIPTION
Fix build of the Overview plugin with Waf.  This fixes a few things in the overview's `wscript_build`, and adds a method to check for C99 compiler support.

Closes #220