### PR TITLE
Overview: install prefs.ui when using the Waf build system

### DIFF
--- a/overview/wscript_build
+++ b/overview/wscript_build
@@ -40,3 +40,8 @@ build_plugin(bld, name,
              includes=includes,
              libraries=libraries,
              defines=defines)
+
+# install UI file
+prefix = '${G_PREFIX}/' if target_is_win32(bld) else ''
+datadir = '${GEANYPLUGINS_DATADIR}/geany-plugins/%s' % (name.lower())
+bld.install_files('%s%s' % (prefix, datadir), 'data/prefs.ui')


### PR DESCRIPTION
This was missing so far causing the file data/prefs.ui not being installed when using the Waf build system.
I guess this part was just forgotten.