### PR TITLE
Overview: Update README from upstream

### DIFF
--- a/overview/README
+++ b/overview/README
@@ -1,0 +1,6 @@
+This plugin is maintained upstream at:
+
+    https://github.com/codebrainz/overview-plugin/
+
+Please submit all bug reports and patches that project. The code in
+Geany-Plugins repository is kept in sync using a script.


### PR DESCRIPTION
I didn't make this clear, only mentioned in the description of the original PR to add the plugin.

If many plugins were to do this, it could become a maintenance burden trying to keep track of where all changes should go to, and which files can be touched. Maybe we should leave this PR open as reminder to further investigate a better way to handle allowing external plugins to be combined into Geany-Plugins (after next release of course).

I won't forget for too long because it bites me every time someone touches files in `overview` in the fork :)