### PR TITLE
autotools: Add a flag to enable or disable all plugins

### DIFF
--- a/README
+++ b/README
@@ -82,6 +82,15 @@ Example:
 This will force force both geanylua and spellcheck plugins to be enabled even
 if some dependencies are missing.
 
+You can also use the special option ``all-plugins`` to change the default for all
+plugins.  For example, using ``--enable-all-plugins`` will forcefully enable all
+plugins as if you passed each plugin-specific ``--enable-<option>``.  This can be
+combined with specific plugin's ``--enable-<option>`` to only select a specific
+subset of the plugins without listing them all.  For example, you can use this
+to easily enable one single plugin, using e.g. ``--disable-all-plugins
+--enable-<option>``, or to forcefully enable all plugins but a few specific
+ones, using e.g. ``--enable-all-plugins --enable-<option>=auto``.
+
 
 Other tweaks
 ============

--- a/build/common.m4
+++ b/build/common.m4
@@ -1,16 +1,33 @@
+dnl _GP_ARG_DISABLE_ALL
+dnl Adds the --disable-all-plugins option
+dnl Sets gp_enable_all=[$enableval|auto]
+AC_DEFUN([_GP_ARG_DISABLE_ALL],
+[
+    AC_ARG_ENABLE([all-plugins],
+                  [AS_HELP_STRING([--disable-all-plugins],
+                                  [Disable all plugins])],
+                  [gp_enable_all=$enableval],
+                  [gp_enable_all=auto])
+])
+
 dnl GP_ARG_DISABLE(PluginName, default)
 dnl - default can either be yes(enabled) or no(disabled), or auto(to be used
 dnl   with GP_CHECK_PLUGIN_DEPS)
 dnl Generates --enable/disable options with help strings
 AC_DEFUN([GP_ARG_DISABLE],
 [
+    AC_REQUIRE([_GP_ARG_DISABLE_ALL])
+
     AC_ARG_ENABLE(m4_tolower(AS_TR_SH($1)),
         AS_HELP_STRING(m4_join(-,
                                --m4_if($2, no, enable, disable),
                                m4_tolower(AS_TR_SH($1))),
                        [Do not build the $1 plugin]),
         m4_tolower(AS_TR_SH(enable_$1))=$enableval,
-        m4_tolower(AS_TR_SH(enable_$1))=$2)
+        [AS_CASE([$gp_enable_all],
+                 [no],  [m4_tolower(AS_TR_SH(enable_$1))=no],
+                 [yes], [m4_tolower(AS_TR_SH(enable_$1))=yes],
+                        [m4_tolower(AS_TR_SH(enable_$1))=$2])])
 ])
 
 dnl GP_CHECK_PLUGIN_DEPS(PluginName, VARIABLE-PREFIX,  modules...)


### PR DESCRIPTION
This allows to change the default for whether every plugins are enabled or disabled, effectively allowing to easily select either all, or only a specific set of plugins.

To force enable all plugins:
	`configure --enable-all-plugins`

To force enable all plugins, but disable Addons:
	`configure --enable-all-plugins --disable-addons`

To force enable all plugins, but Addons which is checked automatically:
	`configure --enable-all-plugins --enable-addons=auto`

To disable all plugins, but force enable Addons:
	`configure --disable-all-plugins --enable-addons`