### PR TITLE
addons: support for URI's containing ~ and +

### DIFF
--- a/addons/src/ao_openuri.c
+++ b/addons/src/ao_openuri.c
@@ -250,7 +250,7 @@ void ao_open_uri_update_menu(AoOpenUri *openuri, GeanyDocument *doc, gint pos)
 		sci_get_selected_text(doc->editor->sci, text);
 	}
 	else
-		text = editor_get_word_at_pos(doc->editor, pos, GEANY_WORDCHARS"@.://-?&%#=");
+		text = editor_get_word_at_pos(doc->editor, pos, GEANY_WORDCHARS"@.://-?&%#=~+");
 
 	/* TODO be more restrictive when handling selections as there are too many hits by now */
 	if (text != NULL && (ao_uri_has_scheme(text) || ao_uri_is_link(text)))


### PR DESCRIPTION
Better current word selection for URI's containing ~ and/or +. By adding ~ and + to GEANY_WORDCHARS URI's from launchpad.net (and others) get selected (and opened) correctly. Otherwise these get cut at the tilde character.

Example: https://launchpad.net/~geany-dev/+archive/ubuntu/ppa gets selected as https://launchpad.net/