### PR TITLE
Fix missing translations

### DIFF
--- a/addons/src/ao_wrapwords.c
+++ b/addons/src/ao_wrapwords.c
@@ -17,7 +17,11 @@
  *			MA 02110-1301, USA.
  */
 
-#include "geanyplugin.h"
+#ifdef HAVE_CONFIG_H
+	#include "config.h"
+#endif
+
+#include <geanyplugin.h>
 
 #include "addons.h"
 #include "ao_wrapwords.h"

--- a/addons/src/ao_wrapwords.c
+++ b/addons/src/ao_wrapwords.c
@@ -251,8 +251,8 @@ void ao_enclose_words_config (GtkButton *button, GtkWidget *config_window)
 	gint i;
 
 	dialog = gtk_dialog_new_with_buttons(_("Enclose Characters"), GTK_WINDOW(config_window),
-						GTK_DIALOG_DESTROY_WITH_PARENT, "Accept", GTK_RESPONSE_ACCEPT,
-						"Cancel", GTK_RESPONSE_CANCEL, "OK", GTK_RESPONSE_OK, NULL);
+						GTK_DIALOG_DESTROY_WITH_PARENT, _("Accept"), GTK_RESPONSE_ACCEPT,
+						_("Cancel"), GTK_RESPONSE_CANCEL, _("OK"), GTK_RESPONSE_OK, NULL);
 
 	vbox = ui_dialog_vbox_new (GTK_DIALOG (dialog));
 	chars_list = gtk_list_store_new (NUM_COLUMNS, G_TYPE_STRING, G_TYPE_STRING, G_TYPE_STRING);

--- a/projectorganizer/src/prjorg-sidebar.c
+++ b/projectorganizer/src/prjorg-sidebar.c
@@ -454,9 +454,9 @@ static void create_dialog_find_tag(void)
 	gtk_size_group_add_widget(size_group, label);
 
 	s_ft_dialog.combo_match = gtk_combo_box_text_new();
-	gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(s_ft_dialog.combo_match), "exact");
-	gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(s_ft_dialog.combo_match), "prefix");
-	gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(s_ft_dialog.combo_match), "pattern");
+	gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(s_ft_dialog.combo_match), _("exact"));
+	gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(s_ft_dialog.combo_match), _("prefix"));
+	gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(s_ft_dialog.combo_match), _("pattern"));
 	gtk_combo_box_set_active(GTK_COMBO_BOX(s_ft_dialog.combo_match), 1);
 	gtk_label_set_mnemonic_widget(GTK_LABEL(label), s_ft_dialog.combo_match);
 

--- a/tableconvert/src/tableconvert_ui.c
+++ b/tableconvert/src/tableconvert_ui.c
@@ -21,6 +21,10 @@
  *
  */
 
+#ifdef HAVE_CONFIG_H
+	#include "config.h" /* for the gettext domain */
+#endif
+
 #include "tableconvert_ui.h"
 
 GtkWidget *main_menu_item = NULL;


### PR DESCRIPTION
Fix actually translating some strings marked as translatable (in addons/wrapword and tableconvert).  Overview has a similar problem but I opened https://github.com/codebrainz/overview-plugin/pull/15 to please @codebrainz :)

Also, mark a few more visible strings as translatable.  This is harmless for the string freeze, as the strings weren't translatable at all anyway, so while they are technically new in the translations they aren't new in the code.  Maybe this could also warrant an update of the PO file as we are early in the freeze, so hopefully some translators will get the update version and the 6 additional strings.