### PR TITLE
autoclose: Don't scroll the preferences UI horizontally

### DIFF
--- a/autoclose/src/autoclose.c
+++ b/autoclose/src/autoclose.c
@@ -1009,10 +1009,10 @@ plugin_configure(GtkDialog *dialog)
 	GtkWidget *widget, *vbox, *frame, *container, *scrollbox;
 	vbox = gtk_vbox_new(FALSE, 0);
 	scrollbox = gtk_scrolled_window_new(NULL, NULL);
-	gtk_widget_set_size_request(GTK_WIDGET(scrollbox), 350, 400);
+	gtk_widget_set_size_request(GTK_WIDGET(scrollbox), -1, 400);
 	gtk_scrolled_window_add_with_viewport(GTK_SCROLLED_WINDOW(scrollbox), vbox);
 	gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(scrollbox),
-		GTK_POLICY_AUTOMATIC, GTK_POLICY_AUTOMATIC);
+		GTK_POLICY_NEVER, GTK_POLICY_AUTOMATIC);
 
 #define WIDGET_FRAME(description) G_STMT_START {                               \
     container = gtk_vbox_new(FALSE, 0);                                        \


### PR DESCRIPTION
Translations tend to change the width of the text, and horizontal
scrolling in such a dialog is annoying.  So, let the size request do
its job for the width and don't allow horizontal scrolling.

@scriptum 