### PR TITLE
[1.26] projectorganizer: Add ellipsis to menu items requiring user input

### DIFF
--- a/projectorganizer/src/prjorg-menu.c
+++ b/projectorganizer/src/prjorg-menu.c
@@ -369,7 +369,7 @@ void prjorg_menu_init(void)
 
 	image = gtk_image_new_from_stock(GTK_STOCK_FIND, GTK_ICON_SIZE_MENU);
 	gtk_widget_show(image);
-	s_fif_item = gtk_image_menu_item_new_with_mnemonic(_("Find in Project Files"));
+	s_fif_item = gtk_image_menu_item_new_with_mnemonic(_("Find in Project Files..."));
 	gtk_image_menu_item_set_image(GTK_IMAGE_MENU_ITEM(s_fif_item), image);
 	gtk_widget_show(s_fif_item);
 	gtk_container_add(GTK_CONTAINER(geany->main_widgets->project_menu), s_fif_item);
@@ -379,7 +379,7 @@ void prjorg_menu_init(void)
 
 	image = gtk_image_new_from_stock(GTK_STOCK_FIND, GTK_ICON_SIZE_MENU);
 	gtk_widget_show(image);
-	s_ff_item = gtk_image_menu_item_new_with_mnemonic(_("Find Project File"));
+	s_ff_item = gtk_image_menu_item_new_with_mnemonic(_("Find Project File..."));
 	gtk_image_menu_item_set_image(GTK_IMAGE_MENU_ITEM(s_ff_item), image);
 	gtk_widget_show(s_ff_item);
 	gtk_container_add(GTK_CONTAINER(geany->main_widgets->project_menu), s_ff_item);
@@ -389,7 +389,7 @@ void prjorg_menu_init(void)
 
 	image = gtk_image_new_from_stock(GTK_STOCK_FIND, GTK_ICON_SIZE_MENU);
 	gtk_widget_show(image);
-	s_ft_item = gtk_image_menu_item_new_with_mnemonic(_("Find Project Tag"));
+	s_ft_item = gtk_image_menu_item_new_with_mnemonic(_("Find Project Tag..."));
 	gtk_image_menu_item_set_image(GTK_IMAGE_MENU_ITEM(s_ft_item), image);
 	gtk_widget_show(s_ft_item);
 	gtk_container_add(GTK_CONTAINER(geany->main_widgets->project_menu), s_ft_item);

--- a/projectorganizer/src/prjorg-sidebar.c
+++ b/projectorganizer/src/prjorg-sidebar.c
@@ -1344,7 +1344,7 @@ void prjorg_sidebar_init(void)
 
 	image = gtk_image_new_from_stock(GTK_STOCK_FIND, GTK_ICON_SIZE_MENU);
 	gtk_widget_show(image);
-	item = gtk_image_menu_item_new_with_mnemonic(_("Find in Files"));
+	item = gtk_image_menu_item_new_with_mnemonic(_("Find in Files..."));
 	gtk_image_menu_item_set_image(GTK_IMAGE_MENU_ITEM(item), image);
 	gtk_widget_show(item);
 	gtk_container_add(GTK_CONTAINER(s_popup_menu.widget), item);
@@ -1353,7 +1353,7 @@ void prjorg_sidebar_init(void)
 
 	image = gtk_image_new_from_stock(GTK_STOCK_FIND, GTK_ICON_SIZE_MENU);
 	gtk_widget_show(image);
-	item = gtk_image_menu_item_new_with_mnemonic(_("Find File"));
+	item = gtk_image_menu_item_new_with_mnemonic(_("Find File..."));
 	gtk_image_menu_item_set_image(GTK_IMAGE_MENU_ITEM(item), image);
 	gtk_widget_show(item);
 	gtk_container_add(GTK_CONTAINER(s_popup_menu.widget), item);
@@ -1362,7 +1362,7 @@ void prjorg_sidebar_init(void)
 
 	image = gtk_image_new_from_stock(GTK_STOCK_FIND, GTK_ICON_SIZE_MENU);
 	gtk_widget_show(image);
-	item = gtk_image_menu_item_new_with_mnemonic(_("Find Tag"));
+	item = gtk_image_menu_item_new_with_mnemonic(_("Find Tag..."));
 	gtk_image_menu_item_set_image(GTK_IMAGE_MENU_ITEM(item), image);
 	gtk_widget_show(item);
 	gtk_container_add(GTK_CONTAINER(s_popup_menu.widget), item);


### PR DESCRIPTION
This is consistent with Geany and follows various common HIG.

https://developer.gnome.org/hig-book/stable/menus-design.html.en#menu-item-type-command

----

**WARNING**: do *not* merge before 1.25 is out, as we froze strings and this modifies some.