### PR TITLE
Replace g_timeout_add with g_idle_add

### DIFF
--- a/automark/src/automark.c
+++ b/automark/src/automark.c
@@ -163,7 +163,7 @@ on_editor_notify(
 		/* if events are too intensive - remove old callback */
 		if (source_id)
 			g_source_remove(source_id);
-		source_id = g_timeout_add(150, automark, editor->document);
+		source_id = g_idle_add(automark, editor->document);
 	}
 	return FALSE;
 }


### PR DESCRIPTION
`g_idle_add` does not make a big performance impact but improves usability
by removing annoying delay