### PR TITLE
Multiterm: make strings translatable

### DIFF
--- a/multiterm/src/Makefile.am
+++ b/multiterm/src/Makefile.am
@@ -24,6 +24,7 @@ multiterm_la_SOURCES = \
 	terminal.vala
 
 multiterm_la_CFLAGS = \
+	-DGETTEXT_PACKAGE='"$(GETTEXT_PACKAGE)"' \
 	$(AM_CFLAGS) \
 	$(MULTITERM_CFLAGS)
 

--- a/multiterm/src/config.vala
+++ b/multiterm/src/config.vala
@@ -44,7 +44,7 @@ namespace MultiTerm
 			}
 			catch (FileError err)
 			{
-				warning("Unable to save config file %s: %s", _filename, err.message);
+				warning(_("Unable to save config file %s: %s"), _filename, err.message);
 				return true;
 			}
 		}
@@ -82,11 +82,11 @@ namespace MultiTerm
 			}
 			catch (KeyFileError err)
 			{
-				warning("Unable to load config file %s: %s", _filename, err.message);
+				warning(_("Unable to load config file %s: %s"), _filename, err.message);
 			}
 			catch (FileError err)
 			{
-				warning("Unable to load config file %s: %s", _filename, err.message);
+				warning(_("Unable to load config file %s: %s"), _filename, err.message);
 			}
 		}
 

--- a/multiterm/src/context-menu.vala
+++ b/multiterm/src/context-menu.vala
@@ -49,13 +49,13 @@ namespace MultiTerm
 		{
 			if (item.get_data<bool>("location_is_msgwin"))
 			{
-				item.set_label("Move to message window");
+				item.set_label(_("Move to message window"));
 				item.set_data<bool>("location_is_msgwin", false);
 				move_to_location_activate("sidebar");
 			}
 			else
 			{
-				item.set_label("Move to sidebar");
+				item.set_label(_("Move to sidebar"));
 				item.set_data<bool>("location_is_msgwin", true);
 				move_to_location_activate("msgwin");
 			}
@@ -78,7 +78,7 @@ namespace MultiTerm
 			menu = new Gtk.Menu();
 			menu.show();
 
-			item = new Gtk.MenuItem.with_label("Open Tab");
+			item = new Gtk.MenuItem.with_label(_("Open Tab"));
 			item.set_submenu(menu);
 			item.show();
 			this.append(item);
@@ -93,19 +93,19 @@ namespace MultiTerm
 				item.show();
 			}
 
-			item = new Gtk.MenuItem.with_label("Open Window");
+			item = new Gtk.MenuItem.with_label(_("Open Window"));
 			item.activate.connect(() => new_window_activate());
 			this.append(item);
 			item.show();
 
 			add_separator();
 
-			item = new Gtk.MenuItem.with_label("Next tab");
+			item = new Gtk.MenuItem.with_label(_("Next tab"));
 			item.activate.connect(() => on_next_previous_tab_activate(item, true));
 			//this.append(item);
 			//item.show();
 
-			item = new Gtk.MenuItem.with_label("Previous tab");
+			item = new Gtk.MenuItem.with_label(_("Previous tab"));
 			item.activate.connect(() => on_next_previous_tab_activate(item, false));
 			//this.append(item);
 			//item.show();
@@ -124,7 +124,7 @@ namespace MultiTerm
 
 			//add_separator();
 
-			check_item = new CheckMenuItem.with_label("Show Tabs");
+			check_item = new CheckMenuItem.with_label(_("Show Tabs"));
 			check_item.active = cfg.show_tabs;
 			check_item.activate.connect(() => on_show_tabs_activate(check_item));
 			this.append(check_item);
@@ -132,12 +132,12 @@ namespace MultiTerm
 
 			if (cfg.location == "msgwin")
 			{
-				item = new Gtk.MenuItem.with_label("Move to sidebar");
+				item = new Gtk.MenuItem.with_label(_("Move to sidebar"));
 				item.set_data<bool>("location_is_msgwin", true);
 			}
 			else
 			{
-				item = new Gtk.MenuItem.with_label("Move to message window");
+				item = new Gtk.MenuItem.with_label(_("Move to message window"));
 				item.set_data<bool>("location_is_msgwin", false);
 			}
 			item.activate.connect(() => on_move_to_location(item));

--- a/multiterm/src/notebook.vala
+++ b/multiterm/src/notebook.vala
@@ -88,7 +88,7 @@ namespace MultiTerm
 			}
 			catch (SpawnError err)
 			{
-				warning("Unable to launch external terminal: %s".printf(err.message));
+				warning(_("Unable to launch external terminal: %s").printf(err.message));
 			}
 		}
 
@@ -134,7 +134,7 @@ namespace MultiTerm
 					return;
 				}
 			}
-			warning("Unable to locate default shell in configuration file");
+			warning(_("Unable to locate default shell in configuration file"));
 		}
 
 		private bool on_terminal_right_click_event(EventButton event)
@@ -199,7 +199,7 @@ namespace MultiTerm
 			add_button.relief = ReliefStyle.NONE;
 			add_button.focus_on_click = false;
 			add_button.set_border_width(2);
-			add_button.set_tooltip_text("New terminal");
+			add_button.set_tooltip_text(_("New terminal"));
 			add_button.add(img);
 			add_button.clicked.connect(on_add_button_clicked);
 			add_button.show_all();

--- a/multiterm/src/plugin.vala
+++ b/multiterm/src/plugin.vala
@@ -39,8 +39,8 @@ public int plugin_version_check(int abi_version)
 /* Geany calls this to get some info about the plugin */
 public void plugin_set_info(Plugin.Info info)
 {
-	info.set("MultiTerm",
-			 "Multi-tabbed virtual terminal emulator.",
+	info.set(_("MultiTerm"),
+			 _("Multi-tabbed virtual terminal emulator."),
 			 "0.1", "Matthew Brush <matt@geany.org>");
 }
 
@@ -71,7 +71,7 @@ public void plugin_init(Geany.Data data)
 	}
 	catch (FileError err)
 	{
-		warning("Unable to write default config file: %s", err.message);
+		warning(_("Unable to write default config file: %s"), err.message);
 	}
 
 	/* Setup the widgets */
@@ -81,7 +81,7 @@ public void plugin_init(Geany.Data data)
 	align.show_all();
 	toplevel_widgets.append(align);
 
-	label = new Label("MultiTerm");
+	label = new Label(_("MultiTerm"));
 	notebook.set_data<Label>("label", label);
 	notebook.set_data<Gtk.Notebook>("msgwin_notebook", data.main_widgets.message_window_notebook);
 	notebook.set_data<Gtk.Notebook>("sidebar_notebook", data.main_widgets.sidebar_notebook);

--- a/multiterm/src/plugin.vala
+++ b/multiterm/src/plugin.vala
@@ -27,6 +27,9 @@ public Plugin		geany_plugin;
 public Data			geany_data;
 public Functions	geany_functions;
 
+extern const string LOCALEDIR;
+extern const string GETTEXT_PACKAGE;
+
 /* Widgets to clean up when the plugin is unloaded */
 private List<Widget> toplevel_widgets = null;
 
@@ -39,6 +42,7 @@ public int plugin_version_check(int abi_version)
 /* Geany calls this to get some info about the plugin */
 public void plugin_set_info(Plugin.Info info)
 {
+	Main.locale_init (LOCALEDIR, GETTEXT_PACKAGE);
 	info.set(_("MultiTerm"),
 			 _("Multi-tabbed virtual terminal emulator."),
 			 "0.1", "Matthew Brush <matt@geany.org>");

--- a/multiterm/src/shell-config.vala
+++ b/multiterm/src/shell-config.vala
@@ -27,7 +27,7 @@ namespace MultiTerm
 	{
 		public Config _cfg;
 		string _section;
-		const string warning_tmpl = "Unable to read value for '%s' key: %s";
+		const string warning_tmpl = _("Unable to read value for '%s' key: %s");
 
 		internal Config cfg { get { return _cfg; } }
 		internal KeyFile kf { get { return cfg.kf; } }

--- a/multiterm/src/tab-label.vala
+++ b/multiterm/src/tab-label.vala
@@ -59,7 +59,7 @@ namespace MultiTerm
 			btn.set_size_request(w+2, h+2);
 		}
 		
-		public TabLabel(string text="Terminal")
+		public TabLabel(string text=_("Terminal"))
 		{
 			Image img;
 			
@@ -81,7 +81,7 @@ namespace MultiTerm
 			btn = new Button();
 			btn.modify_style(style);
 			btn.add(img);
-			btn.set_tooltip_text("Close terminal");
+			btn.set_tooltip_text(_("Close terminal"));
 			btn.clicked.connect(on_button_clicked);
 			btn.relief = ReliefStyle.NONE;
 			btn.focus_on_click = false;

--- a/multiterm/src/terminal.vala
+++ b/multiterm/src/terminal.vala
@@ -85,7 +85,7 @@ namespace MultiTerm
 			}
 			catch (Error err)
 			{
-				warning("Unable to run command: %s", err.message);
+				warning(_("Unable to run command: %s"), err.message);
 			}
 		}
 

--- a/multiterm/src/vapi/geany.vapi
+++ b/multiterm/src/vapi/geany.vapi
@@ -341,7 +341,7 @@ namespace Geany {
 		public GLib.SList<Filetype>		filetypes_by_title;
 	}
 	/* reviewed */
-	[CCode (cprefix = "dialogs_")]
+	[CCode (cprefix = "dialogs_", lower_case_cprefix = "dialogs_")]
 	namespace Dialogs {
 		public string?	show_input (string title, Gtk.Window parent,
 									string? label_text = null, string? default_text = null);
@@ -1243,7 +1243,7 @@ namespace Geany {
 		 * so we need to have it here. */
 	}
 	/* reviewed */
-	[CCode (cprefix = "highlighting_")]
+	[CCode (cprefix = "highlighting_", lower_case_cprefix = "highlighting_")]
 	namespace Highlighting {
 		public unowned LexerStyle	get_style (int ft_id, int style_id);
 		public bool					is_code_style (int lexer, int style);
@@ -1264,7 +1264,7 @@ namespace Geany {
 		public string 			name;
 	}
 	/* reviewed */
-	[CCode (cprefix = "keybindings_")]
+	[CCode (cprefix = "keybindings_", lower_case_cprefix = "keybindings_")]
 	namespace Keybindings {
 		public unowned KeyBinding	get_item (KeyGroup group, size_t key_id);
 		public void					send_command (KeyGroupID group_id, KeyBindingID key_id);
@@ -1444,7 +1444,7 @@ namespace Geany {
 		public bool	italic;
 	}
 	/* reviewed */
-	[CCode (cprefix = "main_")]
+	[CCode (cprefix = "main_", lower_case_cprefix = "main_")]
 	namespace Main {
 		public void		reload_configuration ();
 		public void		locale_init (string locale_dir, string package);
@@ -1562,7 +1562,7 @@ namespace Geany {
 		public void		switch_tab (MessageWindow.TabID tabnum, bool show);
 	}
 	/* reviewed */
-	[CCode (cprefix = "navqueue_")]
+	[CCode (cprefix = "navqueue_", lower_case_cprefix = "navqueue_")]
 	namespace NavQueue {
 		public bool		goto_line (Document? old_doc, Document new_doc, int line);
 	}
@@ -1759,7 +1759,7 @@ namespace Geany {
 		}
 	}
 	/* reviewed */
-	[CCode (cprefix = "search_")]
+	[CCode (cprefix = "search_", lower_case_cprefix = "search_")]
 	namespace Search {
 		public void		show_find_in_files_dialog (string? dir = null);
 	}
@@ -1797,12 +1797,12 @@ namespace Geany {
 		public void		update (Gtk.Widget? owner);
 	}
 	/* reviewed */
-	[CCode (cprefix = "symbols_")]
+	[CCode (cprefix = "symbols_", lower_case_cprefix = "symbols_")]
 	namespace Symbols {
 		public unowned string	get_context_separator (FiletypeID ft_id);
 	}
 	/* reviewed */
-	[CCode (cprefix = "templates_")]
+	[CCode (cprefix = "templates_", lower_case_cprefix = "templates_")]
 	namespace Templates {
 		public string	get_template_fileheader (int filetype_idx, string fname);
 	}
@@ -1958,7 +1958,7 @@ namespace Geany {
 			[CCode (cname = "tm_tag_attr_max_t")]
 			MAX
 		}
-		[CCode (cprefix = "TAG_ACCESS_")]
+		[CCode (cprefix = "TAG_ACCESS_", lower_case_cprefix = "TAG_ACCESS_")]
 		namespace TagAccess {
 			char PUBLIC; /*!< Public member */
 			char PROTECTED; /*!< Protected member */
@@ -1967,7 +1967,7 @@ namespace Geany {
 			char DEFAULT; /*!< Default access (Java) */
 			char UNKNOWN; /*!< Unknown access type */
 		}
-		[CCode (cprefix = "TAG_IMPL_")]
+		[CCode (cprefix = "TAG_IMPL_", lower_case_cprefix = "TAG_IMPL_")]
 		namespace TagImplementation {
 			char VIRTUAL; /*!< Virtual implementation */
 			char UNKNOWN; /*!< Unknown implementation */

--- a/multiterm/wscript_build
+++ b/multiterm/wscript_build
@@ -47,6 +47,8 @@ def build_vala_plugin(ctx, name, sources, vapi_dirs=None, packages=None,
                      vapi_dirs = vapi_dirs,
                      use = libraries,
                      vala_defines = [ 'G_LOG_DOMAIN="%s"' % log_domain ],
+                     defines = [ 'GETTEXT_PACKAGE="%s"' % ctx.env['GETTEXT_PACKAGE'],
+                                 'LOCALEDIR="%s"' % ctx.env['LOCALEDIR'] ],
                      install_path = install_path)
 
     install_docs(ctx, plugin_name,

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -224,6 +224,15 @@ git-changebar/src/gcb-plugin.c
 markdown/src/conf.c
 markdown/src/plugin.c
 
+# Multiterm
+multiterm/src/config.vala
+multiterm/src/context-menu.vala
+multiterm/src/notebook.vala
+multiterm/src/plugin.vala
+multiterm/src/shell-config.vala
+multiterm/src/tab-label.vala
+multiterm/src/terminal.vala
+
 # Overview
 overview/overview/overviewcolor.c
 overview/overview/overviewplugin.c


### PR DESCRIPTION
Closes #247.

---

I'm not quite sure whether https://github.com/geany/geany-plugins/blob/master/multiterm/src/shell-config.vala#L48 should be translated or not, but I left it alone.

Also, being able to translate the [default profile name](https://github.com/geany/geany-plugins/blob/master/multiterm/src/defconf.vala#L97) would be nice.  This would be quite easy if this was a real file that would get installed instead of a string template.  Or the template could be built with a translation in the middle.