### PR TITLE
Use lowercase header names

### DIFF
--- a/geanyvc/src/externdiff.c
+++ b/geanyvc/src/externdiff.c
@@ -23,7 +23,7 @@
 #include "geanyvc.h"
 
 #ifdef G_OS_WIN32
-#include <Shlobj.h>
+#include <shlobj.h>
 #endif
 
 extern GeanyFunctions *geany_functions;


### PR DESCRIPTION
This fixes Windows cross-compilation on non-Windows systems with case-sensitive file systems.

Since most non-Windows systems use case-sensitive file systems and header files are usually named in lowercase, using lowercase header names in sources should be a good idea.
On Windows, it just doesn't matter.

Currently the Geany Windows nightly builds are broken because of 87e1f9fb8ae77cbd1ff3fe5c9769d15272ef1171.