### PR TITLE
GeanyPy: Unload Python plugins when GeanyPy is deactivated

### DIFF
--- a/geanypy/geany/manager.py
+++ b/geanypy/geany/manager.py
@@ -93,6 +93,9 @@ class PluginManager(gtk.Dialog):
 	def deactivate_plugin(self, filename):
 		self.loader.unload_plugin(filename)
 
+	def deactivate_all_plugins(self):
+		self.response(gtk.RESPONSE_CLOSE)
+		self.loader.unload_all_plugins()
 
 	def load_plugins_list(self):
 		liststore = gtk.ListStore(gobject.TYPE_BOOLEAN, str, str)

--- a/geanypy/src/geanypy-plugin.c
+++ b/geanypy/src/geanypy-plugin.c
@@ -278,6 +278,17 @@ plugin_init(GeanyData *data)
 
 G_MODULE_EXPORT void plugin_cleanup(void)
 {
+    PyObject* deactivate_all_plugins = PyObject_GetAttrString(manager,
+            "deactivate_all_plugins");
+    if (deactivate_all_plugins != NULL)
+    {
+        PyObject* r = PyObject_CallObject(deactivate_all_plugins, NULL);
+        if (r)
+            Py_DECREF(r);
+        Py_DECREF(deactivate_all_plugins);
+
+    }
+
     signal_manager_free(signal_manager);
     Py_XDECREF(manager);
 	GeanyPy_stop_interpreter();


### PR DESCRIPTION
This prevents crashes and/or lockups when the GeanyPy C plugin
is reloaded.

FIXME: Because it calls the normal unloading path, it updates
the list of loaded plugins to remove each plugin. The net effect
is that when the C GeanyPy plugin is unloaded, it forgets all
of the Python plugins that were loaded at the time.
