### PR TITLE
Ported treebrowser plugin to GTK+ >= 3.10.0

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -127,10 +127,13 @@ W: http://plugins.geany.org/geanynumberedbookmarks.html
 S: Maintained
 
 geanypg
-P: Hans Alves <alves.h88@gmail.com>
-M: Hans Alves <alves.h88@gmail.com>
+P1: Hans Alves <alves.h88@gmail.com>
+P2: Paolo Stivanin <info@paolostivanin.com>
+M1: Hans Alves <alves.h88@gmail.com>
+M2: Paolo Stivanin <info@paolostivanin.com>
 W: http://plugins.geany.org/geanypg.html
-S: Odd Fixes
+S1: Odd Fixes
+S2: Maintained
 
 geanyprj
 P: Yura Siamashka <yurand2@gmail.com>

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -235,10 +235,10 @@ W: http://plugins.geany.org/tableconvert.html
 S: Maintained
 
 treebrowser
-P:
-M:
-W:
-S: Orphaned
+P: Paolo Stivanin
+M: Paolo Stivanin <info@paolostivanin.com>
+W: http://plugins.geany.org/treebrowser.html
+S: Maintained
 
 updatechecker
 P: Frank Lanitz <frank@frank.uvena.de>

--- a/addons/src/addons.c
+++ b/addons/src/addons.c
@@ -233,7 +233,8 @@ GtkWidget *ao_image_menu_item_new(const gchar *icon_name, const gchar *label)
 {
 	GtkWidget *item = gtk_menu_item_new_with_label(label);
 	GtkWidget *image = gtk_image_new_from_icon_name(icon_name, GTK_ICON_SIZE_MENU);
-
+    gtk_container_add(GTK_CONTAINER(item), image);
+    
 	gtk_widget_show(image);
 	return item;
 }

--- a/addons/src/addons.c
+++ b/addons/src/addons.c
@@ -229,12 +229,11 @@ static void ao_document_reload_cb(GObject *obj, GeanyDocument *doc, gpointer dat
 }
 
 
-GtkWidget *ao_image_menu_item_new(const gchar *stock_id, const gchar *label)
+GtkWidget *ao_image_menu_item_new(const gchar *icon_name, const gchar *label)
 {
-	GtkWidget *item = gtk_image_menu_item_new_with_label(label);
-	GtkWidget *image = gtk_image_new_from_icon_name(stock_id, GTK_ICON_SIZE_MENU);
+	GtkWidget *item = gtk_menu_item_new_with_label(label);
+	GtkWidget *image = gtk_image_new_from_icon_name(icon_name, GTK_ICON_SIZE_MENU);
 
-	gtk_image_menu_item_set_image(GTK_IMAGE_MENU_ITEM(item), image);
 	gtk_widget_show(image);
 	return item;
 }

--- a/addons/src/ao_bookmarklist.c
+++ b/addons/src/ao_bookmarklist.c
@@ -298,13 +298,25 @@ static void popup_item_click_cb(GtkWidget *button, gpointer data)
 }
 
 
+static GtkWidget *
+gtk3_ui_image_menu_item_new(const gchar *icon_name, const gchar *label)
+{
+	GtkWidget *item = gtk_menu_item_new_with_mnemonic(label);
+	GtkWidget *image = gtk_image_new_from_icon_name(icon_name, GTK_ICON_SIZE_MENU);
+
+	gtk_container_add(GTK_CONTAINER(item), image);
+	gtk_widget_show(image);
+	return item;
+}
+
+
 static GtkWidget *create_popup_menu(AoBookmarkList *bm)
 {
 	GtkWidget *item, *menu;
 
 	menu = gtk_menu_new();
 
-	item = ui_image_menu_item_new(GTK_STOCK_DELETE, _("_Remove Bookmark"));
+	item = gtk3_ui_image_menu_item_new("edit-delete", _("_Remove Bookmark"));
 	gtk_widget_show(item);
 	gtk_container_add(GTK_CONTAINER(menu), item);
 	g_signal_connect(item, "activate", G_CALLBACK(popup_item_click_cb), bm);

--- a/addons/src/ao_doclist.c
+++ b/addons/src/ao_doclist.c
@@ -177,6 +177,18 @@ static void ao_doclist_menu_item_activate_cb(GtkMenuItem *menuitem, gpointer dat
 }
 
 
+static GtkWidget *
+gtk3_ui_image_menu_item_new(const gchar *icon_name, const gchar *label)
+{
+	GtkWidget *item = gtk_menu_item_new_with_mnemonic(label);
+	GtkWidget *image = gtk_image_new_from_icon_name(icon_name, GTK_ICON_SIZE_MENU);
+
+	gtk_container_add(GTK_CONTAINER(item), image);
+	gtk_widget_show(image);
+	return item;
+}
+
+
 static void ao_toolbar_item_doclist_clicked_cb(GtkWidget *button, gpointer data)
 {
 	static GtkWidget *menu = NULL;
@@ -211,12 +223,12 @@ static void ao_toolbar_item_doclist_clicked_cb(GtkWidget *button, gpointer data)
 	gtk_widget_show(menu_item);
 	gtk_container_add(GTK_CONTAINER(menu), menu_item);
 
-	menu_item = ui_image_menu_item_new(GTK_STOCK_CLOSE, _("Close Ot_her Documents"));
+	menu_item = gtk3_ui_image_menu_item_new("window-close", _("Close Ot_her Documents"));
 	gtk_widget_show(menu_item);
 	gtk_container_add(GTK_CONTAINER(menu), menu_item);
 	g_signal_connect(menu_item, "activate", G_CALLBACK(ao_doclist_menu_item_activate_cb),
 		GINT_TO_POINTER(ACTION_CLOSE_OTHER));
-	menu_item = ui_image_menu_item_new(GTK_STOCK_CLOSE, _("C_lose All"));
+	menu_item = gtk3_ui_image_menu_item_new("window-close", _("C_lose All"));
 	gtk_widget_show(menu_item);
 	gtk_container_add(GTK_CONTAINER(menu), menu_item);
 	g_signal_connect(menu_item, "activate", G_CALLBACK(ao_doclist_menu_item_activate_cb),
@@ -243,7 +255,7 @@ static void ao_toolbar_update(AoDocList *self)
 	{
 		if (priv->toolbar_doclist_button == NULL)
 		{
-			priv->toolbar_doclist_button = gtk_tool_button_new_from_stock(GTK_STOCK_INDEX);
+			priv->toolbar_doclist_button = gtk_tool_button_new(NULL, "_Index");
 #if GTK_CHECK_VERSION(2, 12, 0)
 			gtk_tool_item_set_tooltip_text(GTK_TOOL_ITEM(priv->toolbar_doclist_button),
 				_("Show Document List"));

--- a/addons/src/ao_doclist.c
+++ b/addons/src/ao_doclist.c
@@ -255,7 +255,9 @@ static void ao_toolbar_update(AoDocList *self)
 	{
 		if (priv->toolbar_doclist_button == NULL)
 		{
-			priv->toolbar_doclist_button = gtk_tool_button_new(NULL, "_Index");
+            GtkWidget *image = gtk_image_new_from_icon_name("system-file-mangager", GTK_ICON_SIZE_MENU);
+            gtk_widget_show(image);
+			priv->toolbar_doclist_button = gtk_tool_button_new(image, "_Index");
 #if GTK_CHECK_VERSION(2, 12, 0)
 			gtk_tool_item_set_tooltip_text(GTK_TOOL_ITEM(priv->toolbar_doclist_button),
 				_("Show Document List"));

--- a/addons/src/ao_openuri.c
+++ b/addons/src/ao_openuri.c
@@ -162,13 +162,13 @@ static void ao_open_uri_init(AoOpenUri *self)
 	priv->uri = NULL;
 
 	priv->menu_item_open = ao_image_menu_item_new(
-		ao_find_icon_name("text-html", GTK_STOCK_NEW), _("Open URI"));
+		ao_find_icon_name("text-html", "document-new"), _("Open URI"));
 	gtk_container_add(GTK_CONTAINER(geany->main_widgets->editor_menu), priv->menu_item_open);
 	gtk_menu_reorder_child(GTK_MENU(geany->main_widgets->editor_menu), priv->menu_item_open, 0);
 	gtk_widget_hide(priv->menu_item_open);
 	g_signal_connect(priv->menu_item_open, "activate", G_CALLBACK(ao_menu_open_activate_cb), self);
 
-	priv->menu_item_copy = ao_image_menu_item_new(GTK_STOCK_COPY, _("Copy URI"));
+	priv->menu_item_copy = ao_image_menu_item_new("edit-copy", _("Copy URI"));
 	gtk_container_add(GTK_CONTAINER(geany->main_widgets->editor_menu), priv->menu_item_copy);
 	gtk_menu_reorder_child(GTK_MENU(geany->main_widgets->editor_menu), priv->menu_item_copy, 1);
 	gtk_widget_hide(priv->menu_item_copy);

--- a/addons/src/ao_systray.c
+++ b/addons/src/ao_systray.c
@@ -205,7 +205,7 @@ static void ao_systray_init(AoSystray *self)
 	priv->popup_menu = gtk_menu_new();
 	g_object_ref_sink(priv->popup_menu);
 
-	item = gtk_menu_item_new_with_mnemonic("_Open");
+	item = gtk_menu_item_new_with_mnemonic(_("_Open"));
 	gtk_widget_show(item);
 	gtk_container_add(GTK_CONTAINER(priv->popup_menu), item);
 	g_signal_connect(item, "activate",

--- a/addons/src/ao_systray.c
+++ b/addons/src/ao_systray.c
@@ -205,13 +205,13 @@ static void ao_systray_init(AoSystray *self)
 	priv->popup_menu = gtk_menu_new();
 	g_object_ref_sink(priv->popup_menu);
 
-	item = gtk_image_menu_item_new_from_stock(GTK_STOCK_OPEN, NULL);
+	item = gtk_menu_item_new_with_mnemonic("_Open");
 	gtk_widget_show(item);
 	gtk_container_add(GTK_CONTAINER(priv->popup_menu), item);
 	g_signal_connect(item, "activate",
 		G_CALLBACK(icon_popup_menu_cmd_clicked_cb), GINT_TO_POINTER(WIDGET_OPEN));
 
-	item = gtk_image_menu_item_new_from_stock(GEANY_STOCK_SAVE_ALL, NULL);
+	item = gtk_menu_item_new_with_mnemonic(GEANY_STOCK_SAVE_ALL);
 	gtk_widget_show(item);
 	gtk_container_add(GTK_CONTAINER(priv->popup_menu), item);
 	g_signal_connect(item, "activate",
@@ -221,7 +221,7 @@ static void ao_systray_init(AoSystray *self)
 	gtk_widget_show(item);
 	gtk_container_add(GTK_CONTAINER(priv->popup_menu), item);
 
-	item = gtk_image_menu_item_new_from_stock(GTK_STOCK_PREFERENCES, NULL);
+	item = gtk_menu_item_new_with_mnemonic("_Preferences");
 	gtk_widget_show(item);
 	gtk_container_add(GTK_CONTAINER(priv->popup_menu), item);
 	g_signal_connect(item, "activate",
@@ -231,7 +231,7 @@ static void ao_systray_init(AoSystray *self)
 	gtk_widget_show(item);
 	gtk_container_add(GTK_CONTAINER(priv->popup_menu), item);
 
-	item = gtk_image_menu_item_new_from_stock(GTK_STOCK_QUIT, NULL);
+	item = gtk_menu_item_new_with_mnemonic("_Quit");
 	gtk_widget_show(item);
 	gtk_container_add(GTK_CONTAINER(priv->popup_menu), item);
 	g_signal_connect(item, "activate", G_CALLBACK(icon_popup_quit_clicked_cb), NULL);

--- a/addons/src/ao_tasks.c
+++ b/addons/src/ao_tasks.c
@@ -353,6 +353,18 @@ static void popup_hide_item_click_cb(GtkWidget *button, AoTasks *t)
 }
 
 
+static GtkWidget *
+gtk3_ui_image_menu_item_new(const gchar *icon_name, const gchar *label)
+{
+	GtkWidget *item = gtk_menu_item_new_with_mnemonic(label);
+	GtkWidget *image = gtk_image_new_from_icon_name(icon_name, GTK_ICON_SIZE_MENU);
+
+	gtk_container_add(GTK_CONTAINER(item), image);
+	gtk_widget_show(image);
+	return item;
+}
+
+
 static GtkWidget *create_popup_menu(AoTasks *t)
 {
 	GtkWidget *item, *menu;
@@ -360,7 +372,7 @@ static GtkWidget *create_popup_menu(AoTasks *t)
 
 	menu = gtk_menu_new();
 
-	item = gtk_image_menu_item_new_from_stock(GTK_STOCK_DELETE, NULL);
+	item = gtk_menu_item_new_with_mnemonic("_Delete");
 	priv->popup_menu_delete_button = item;
 	gtk_widget_show(item);
 	gtk_container_add(GTK_CONTAINER(menu), item);
@@ -370,7 +382,7 @@ static GtkWidget *create_popup_menu(AoTasks *t)
 	gtk_widget_show(item);
 	gtk_container_add(GTK_CONTAINER(menu), item);
 
-	item = ui_image_menu_item_new(GTK_STOCK_REFRESH, _("_Update"));
+	item = gtk3_ui_image_menu_item_new("view-refresh", _("_Update"));
 	gtk_widget_show(item);
 	gtk_container_add(GTK_CONTAINER(menu), item);
 	g_signal_connect(item, "activate", G_CALLBACK(popup_update_item_click_cb), t);

--- a/addons/src/ao_xmltagging.c
+++ b/addons/src/ao_xmltagging.c
@@ -53,8 +53,8 @@ void ao_xmltagging(void)
 
 		dialog = gtk_dialog_new_with_buttons(_("XML tagging"),
 							 GTK_WINDOW(geany->main_widgets->window),
-							 GTK_DIALOG_DESTROY_WITH_PARENT, GTK_STOCK_CANCEL,
-							 GTK_RESPONSE_CANCEL, GTK_STOCK_OK, GTK_RESPONSE_ACCEPT,
+							 GTK_DIALOG_DESTROY_WITH_PARENT, "_Cancel",
+							 GTK_RESPONSE_CANCEL, "_OK", GTK_RESPONSE_ACCEPT,
 							 NULL);
 		vbox = ui_dialog_vbox_new(GTK_DIALOG(dialog));
 		gtk_widget_set_name(dialog, "GeanyDialog");
@@ -70,7 +70,8 @@ void ao_xmltagging(void)
 
 		gtk_container_add(GTK_CONTAINER(hbox), label);
 		gtk_container_add(GTK_CONTAINER(hbox), textbox);
-		gtk_misc_set_alignment(GTK_MISC(label), 0, 0.5);
+		g_object_set(label, "xalign",  0.0, NULL);
+        g_object_set(label, "yalign",  0.5, NULL);
 
 		gtk_container_add(GTK_CONTAINER(vbox), hbox);
 		gtk_container_add(GTK_CONTAINER(vbox), textline);

--- a/geanypg/AUTHORS
+++ b/geanypg/AUTHORS
@@ -1,1 +1,3 @@
 Hans Alves <alves(dot)h88(at)gmail(dot)com>
+
+Paolo Stivanin <info(at)paolostivanin(dot)com>

--- a/geanypg/ChangeLog
+++ b/geanypg/ChangeLog
@@ -1,3 +1,7 @@
+2015-08-26 Paolo Stivanin <info(at)paolostivanin(dot)com>
+
+	* Plugin ported to GTK+ v3.10.0 and above
+
 2012-08-24 Hans Alves  <alves(dot)h88(at)gmail(dot)com>
 
 * Fixed bug 3557458 which caused a 0 byte to be added to the text

--- a/geanypg/README
+++ b/geanypg/README
@@ -60,5 +60,4 @@ able to get a copy by contacting the Free Software Foundation, Inc.,
 Bugs, questions
 ---------------
 
-If you found any bugs or want to provide a patch, please contact Hans
-Alves (alves(dot)h88(at)gmail(dot)com).
+If you found any bugs or want to provide a patch, please contact Paolo Stivanin <info(at)paolostivanin(dot)com>

--- a/geanypg/configure.ac
+++ b/geanypg/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([geanypg], [0.1], [alves.h88@gmail.com])
+AC_INIT([geanypg], [0.2], [alves.h88@gmail.com])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign])
 AC_PROG_CC
 AC_DISABLE_STATIC
@@ -8,7 +8,7 @@ AC_PROG_LIBTOOL
 AM_PATH_GPGME()
 
 # checking for Geany
-PKG_CHECK_MODULES(GEANY, [geany >= 0.20])
+PKG_CHECK_MODULES(GEANY, [geany >= 1.24])
 AC_SUBST(GEANY_CFLAGS)
 AC_SUBST(GEANY_LIBS)
 

--- a/geanypg/src/key_selection_dialog.c
+++ b/geanypg/src/key_selection_dialog.c
@@ -155,8 +155,8 @@ int geanypg_encrypt_selection_dialog(encrypt_data * ed, gpgme_key_t ** selected,
 
 
     /* add ok and cancel buttons */
-    gtk_dialog_add_button(GTK_DIALOG(dialog), "_OK", GTK_RESPONSE_OK);
-    gtk_dialog_add_button(GTK_DIALOG(dialog), "_Cancel", GTK_RESPONSE_CANCEL);
+    gtk_dialog_add_button(GTK_DIALOG(dialog), _("_OK"), GTK_RESPONSE_OK);
+    gtk_dialog_add_button(GTK_DIALOG(dialog), _("_Cancel"), GTK_RESPONSE_CANCEL);
 
     gtk_window_set_title(GTK_WINDOW(dialog), _("Select recipients"));
     gtk_widget_show_all(dialog);

--- a/geanypg/src/key_selection_dialog.c
+++ b/geanypg/src/key_selection_dialog.c
@@ -142,8 +142,7 @@ int geanypg_encrypt_selection_dialog(encrypt_data * ed, gpgme_key_t ** selected,
     list = geanypg_makelist(ed->key_array, ed->nkeys, 0);
     listview = geanypg_listview(list, &data);
     scrollwin = gtk_scrolled_window_new(NULL, NULL);
-    gtk_scrolled_window_add_with_viewport(GTK_SCROLLED_WINDOW(scrollwin),
-                        listview);
+    gtk_container_add(GTK_CONTAINER(scrollwin), listview);
     gtk_widget_set_size_request(scrollwin, 500, 160);
     combobox = geanypg_combobox(geanypg_makelist(ed->skey_array, ed->nskeys, 1));
 
@@ -156,8 +155,8 @@ int geanypg_encrypt_selection_dialog(encrypt_data * ed, gpgme_key_t ** selected,
 
 
     /* add ok and cancel buttons */
-    gtk_dialog_add_button(GTK_DIALOG(dialog), GTK_STOCK_OK, GTK_RESPONSE_OK);
-    gtk_dialog_add_button(GTK_DIALOG(dialog), GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL);
+    gtk_dialog_add_button(GTK_DIALOG(dialog), "_OK", GTK_RESPONSE_OK);
+    gtk_dialog_add_button(GTK_DIALOG(dialog), "_Cancel", GTK_RESPONSE_CANCEL);
 
     gtk_window_set_title(GTK_WINDOW(dialog), _("Select recipients"));
     gtk_widget_show_all(dialog);
@@ -225,8 +224,8 @@ int geanypg_sign_selection_dialog(encrypt_data * ed)
     gtk_box_pack_start(GTK_BOX(contentarea), combobox, TRUE, TRUE, 0);
 
     /* add ok and cancel buttons */
-    gtk_dialog_add_button(GTK_DIALOG(dialog), GTK_STOCK_OK, GTK_RESPONSE_OK);
-    gtk_dialog_add_button(GTK_DIALOG(dialog), GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL);
+    gtk_dialog_add_button(GTK_DIALOG(dialog), "_OK", GTK_RESPONSE_OK);
+    gtk_dialog_add_button(GTK_DIALOG(dialog), "_Cancel", GTK_RESPONSE_CANCEL);
 
     gtk_widget_show_all(dialog);
     gtk_window_set_title(GTK_WINDOW(dialog), _("Select signer"));

--- a/geanypg/src/verify_cb.c
+++ b/geanypg/src/verify_cb.c
@@ -27,8 +27,8 @@ static char * geanypg_choose_sig(void)
     GtkWidget * dialog = gtk_file_chooser_dialog_new(_("Open a signature file"),
                                                      GTK_WINDOW(geany->main_widgets->window),
                                                      GTK_FILE_CHOOSER_ACTION_OPEN,
-                                                     GTK_STOCK_OPEN, GTK_RESPONSE_OK,
-                                                     GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL,
+                                                     "_Open", GTK_RESPONSE_OK,
+                                                     "_Cancel", GTK_RESPONSE_CANCEL,
                                                      NULL);
     gtk_widget_show_all(dialog);
     response = gtk_dialog_run(GTK_DIALOG(dialog));

--- a/treebrowser/AUTHORS
+++ b/treebrowser/AUTHORS
@@ -1,3 +1,4 @@
 Adrian Dimitrov <dimitrov.adrian@gmail.com>
+Paolo Stivanin <info@paolostivanin.com>
 
 And THANKS to all in #geany for support and help

--- a/treebrowser/ChangeLog
+++ b/treebrowser/ChangeLog
@@ -36,6 +36,10 @@
 | Development release ChangeLog |
 +-------------------------------+
 
+08-02-2011 	Adrian Dimitrov 		<info@paolostivanin.com>
+
+	* src/treebrowser.c
+		ported to GTK+ > 3.14.0
 
 08-02-2011 	Adrian Dimitrov 		<dimitrov.adrian@gmail.com>
 

--- a/treebrowser/ChangeLog
+++ b/treebrowser/ChangeLog
@@ -39,7 +39,7 @@
 08-02-2011 	Adrian Dimitrov 		<info@paolostivanin.com>
 
 	* src/treebrowser.c
-		ported to GTK+ > 3.14.0
+		ported to GTK+ > 3.10.0
 
 08-02-2011 	Adrian Dimitrov 		<dimitrov.adrian@gmail.com>
 

--- a/treebrowser/NEWS
+++ b/treebrowser/NEWS
@@ -1,5 +1,5 @@
 Most important changes in 0.30:
-	* required version of GTK+ is now 3.14.0
+	* required version of GTK+ is now 3.10.0
 
 Most important changes in 0.20:
 

--- a/treebrowser/NEWS
+++ b/treebrowser/NEWS
@@ -1,3 +1,6 @@
+Most important changes in 0.30:
+	* required version of GTK+ is now 3.14.0
+
 Most important changes in 0.20:
 
 	* Added bookmarks support

--- a/treebrowser/README
+++ b/treebrowser/README
@@ -1,4 +1,4 @@
-.. |(version)| replace:: 0.20
+.. |(version)| replace:: 0.30
 
 TreeBrowser plugin
 ==================
@@ -33,7 +33,7 @@ Features
 
 Requirements
 ============
-* GTK >= 2.8.0
+* GTK >= 3.10.0
 * GIO >= 2.0 (optional)
 * Geany >= 0.17
 
@@ -49,7 +49,7 @@ FAQ
 ===
 
 * My base directory is not remember
-	Yes it isn`t saved, and I don`t think that it have to be saved while We have in Geany "Startup path", and "Load from the last session"
+	Yes it isn't saved, and I don't think that it have to be saved while we have in Geany "Startup path", and "Load from the last session"
 	These settings are useful and the plugin take care about them, use them and the problem with the last directory remembering will be solved.
 
 
@@ -64,7 +64,7 @@ TreeBrowser is part of the combined Geany Plugins release. For more information 
 Installation
 ============
 
- The plugin is part from the geany-plugins projects, you can see the plugin`s install page at http://plugins.geany.org/install.html
+ The plugin is part from the geany-plugins projects, you can see the plugin's install page at http://plugins.geany.org/install.html
 
 
 License
@@ -79,5 +79,8 @@ Ideas, questions, patches and bug reports
 Report them at https://github.com/geany/geany-plugins/issues
 
 --
+2015 Paolo Stivanin
+info(at)paolostivanin(dot)com
+
 2010 Adrian Dimitrov
 dimitrov(dot)adrian(at)gmail(dot)com

--- a/treebrowser/src/treebrowser.c
+++ b/treebrowser/src/treebrowser.c
@@ -192,7 +192,7 @@ tree_view_row_expanded_iter(GtkTreeView *tree_view, GtkTreeIter *iter)
 }
 
 static GdkPixbuf *
-utils_pixbuf_from_stock(const gchar *icon_name)
+utils_pixbuf_from_name(const gchar *icon_name)
 {
     GError *error = NULL;
     GtkIconTheme *icon_theme;
@@ -201,10 +201,10 @@ utils_pixbuf_from_stock(const gchar *icon_name)
     icon_theme = gtk_icon_theme_get_default ();
     pixbuf = gtk_icon_theme_load_icon(icon_theme, icon_name, 16, 0, &error);
 
-	if (!pixbuf)
+	if(!pixbuf)
     {
-        g_warning ("Couldn’t load icon: %s", error->message);
-        g_error_free (error);
+        g_warning("Couldn't load icon: %s", error->message);
+        g_error_free(error);
         return NULL;
     }
     else
@@ -237,7 +237,7 @@ utils_pixbuf_from_path(gchar *path)
 	}
 	return ret;
 #else
-	return utils_pixbuf_from_stock(g_file_test(path, G_FILE_TEST_IS_DIR)
+	return utils_pixbuf_from_name(g_file_test(path, G_FILE_TEST_IS_DIR)
 									? "folder"
 									: "text-x-generic");
 #endif
@@ -530,7 +530,7 @@ treebrowser_browse(gchar *directory, gpointer parent)
 						gtk_tree_iter_free(last_dir_iter);
 					}
 					last_dir_iter = gtk_tree_iter_copy(&iter);
-					icon = CONFIG_SHOW_ICONS ? utils_pixbuf_from_stock("folder") : NULL;
+					icon = CONFIG_SHOW_ICONS ? utils_pixbuf_from_name("folder") : NULL;
 					gtk_tree_store_set(treestore, &iter,
 										TREEBROWSER_COLUMN_ICON, 	icon,
 										TREEBROWSER_COLUMN_NAME, 	fname,
@@ -550,7 +550,7 @@ treebrowser_browse(gchar *directory, gpointer parent)
 						icon = CONFIG_SHOW_ICONS == 2
 									? utils_pixbuf_from_path(uri)
 									: CONFIG_SHOW_ICONS
-										? utils_pixbuf_from_stock("text-x-generic")
+										? utils_pixbuf_from_name("text-x-generic")
 										: NULL;
 						gtk_tree_store_append(treestore, &iter, parent);
 						gtk_tree_store_set(treestore, &iter,
@@ -624,7 +624,7 @@ treebrowser_load_bookmarks(void)
 		else
 		{
 			gtk_tree_store_prepend(treestore, &bookmarks_iter, NULL);
-			icon = CONFIG_SHOW_ICONS ? utils_pixbuf_from_stock("go-home") : NULL;
+			icon = CONFIG_SHOW_ICONS ? utils_pixbuf_from_name("go-home") : NULL;
 			gtk_tree_store_set(treestore, &bookmarks_iter,
 											TREEBROWSER_COLUMN_ICON, 	icon,
 											TREEBROWSER_COLUMN_NAME, 	_("Bookmarks"),
@@ -660,7 +660,7 @@ treebrowser_load_bookmarks(void)
 					gchar *file_name = g_path_get_basename(path_full);
 
 					gtk_tree_store_append(treestore, &iter, &bookmarks_iter);
-					icon = CONFIG_SHOW_ICONS ? utils_pixbuf_from_stock("folder") : NULL;
+					icon = CONFIG_SHOW_ICONS ? utils_pixbuf_from_name("folder") : NULL;
 					gtk_tree_store_set(treestore, &iter,
 												TREEBROWSER_COLUMN_ICON, 	icon,
 												TREEBROWSER_COLUMN_NAME, 	file_name,
@@ -1202,12 +1202,6 @@ on_menu_show_bars(GtkMenuItem *menuitem, gpointer *user_data)
 	showbars(gtk_check_menu_item_get_active(GTK_CHECK_MENU_ITEM(menuitem)));
 }
 
-static GtkWidget *
-get_image_menu_item_new(const gchar *label)
-{
-	GtkWidget *item = gtk_menu_item_new_with_mnemonic(label);
-	return item;
-}
 
 static GtkWidget*
 create_popup_menu(const gchar *name, const gchar *uri)
@@ -1218,33 +1212,33 @@ create_popup_menu(const gchar *name, const gchar *uri)
 	gboolean is_dir 		= is_exists ? g_file_test(uri, G_FILE_TEST_IS_DIR) : FALSE;
 	gboolean is_document 	= document_find_by_filename(uri) != NULL ? TRUE : FALSE;
 
-	item = get_image_menu_item_new(_("Go up"));
+	GtkWidget *item = gtk_menu_item_new_with_mnemonic(_("Go up"));
 	gtk_container_add(GTK_CONTAINER(menu), item);
 	g_signal_connect(item, "activate", G_CALLBACK(on_menu_go_up), NULL);
 
-	item = get_image_menu_item_new(_("Set path from document"));
+	GtkWidget *item = gtk_menu_item_new_with_mnemonic(_("Set path from document"));
 	gtk_container_add(GTK_CONTAINER(menu), item);
 	g_signal_connect(item, "activate", G_CALLBACK(on_menu_current_path), NULL);
 
-	item = get_image_menu_item_new(_("_Open"));
+	GtkWidget *item = gtk_menu_item_new_with_mnemonic(_("_Open"));
 	gtk_container_add(GTK_CONTAINER(menu), item);
 	g_signal_connect_data(item, "activate", G_CALLBACK(on_menu_open_externally), g_strdup(uri), (GClosureNotify)g_free, 0);
 	gtk_widget_set_sensitive(item, is_exists);
 
-	item = get_image_menu_item_new(_("Open Terminal"));
+	GtkWidget *item = gtk_menu_item_new_with_mnemonic(_("Open Terminal"));
 	gtk_container_add(GTK_CONTAINER(menu), item);
 	g_signal_connect_data(item, "activate", G_CALLBACK(on_menu_open_terminal), g_strdup(uri), (GClosureNotify)g_free, 0);
 
-	item = get_image_menu_item_new(_("Set as root"));
+	GtkWidget *item = gtk_menu_item_new_with_mnemonic(_("Set as root"));
 	gtk_container_add(GTK_CONTAINER(menu), item);
 	g_signal_connect_data(item, "activate", G_CALLBACK(on_menu_set_as_root), g_strdup(uri), (GClosureNotify)g_free, 0);
 	gtk_widget_set_sensitive(item, is_dir);
 
-	item = get_image_menu_item_new(_("Refresh"));
+	GtkWidget *item = gtk_menu_item_new_with_mnemonic(_("Refresh"));
 	gtk_container_add(GTK_CONTAINER(menu), item);
 	g_signal_connect(item, "activate", G_CALLBACK(on_menu_refresh), NULL);
 
-	item = get_image_menu_item_new(_("_Find in Files"));
+	GtkWidget *item = gtk_menu_item_new_with_mnemonic(_("_Find in Files"));
 	gtk_container_add(GTK_CONTAINER(menu), item);
 	g_signal_connect_data(item, "activate", G_CALLBACK(on_menu_find_in_files), g_strdup(uri), (GClosureNotify)g_free, 0);
 	gtk_widget_set_sensitive(item, is_dir);
@@ -1252,20 +1246,20 @@ create_popup_menu(const gchar *name, const gchar *uri)
 	item = gtk_separator_menu_item_new();
 	gtk_container_add(GTK_CONTAINER(menu), item);
 
-	item = get_image_menu_item_new(_("Create new directory"));
+	GtkWidget *item = gtk_menu_item_new_with_mnemonic(_("Create new directory"));
 	gtk_container_add(GTK_CONTAINER(menu), item);
 	g_signal_connect(item, "activate", G_CALLBACK(on_menu_create_new_object), (gpointer)"directory");
 
-	item = get_image_menu_item_new(_("Create new file"));
+	GtkWidget *item = gtk_menu_item_new_with_mnemonic(_("Create new file"));
 	gtk_container_add(GTK_CONTAINER(menu), item);
 	g_signal_connect(item, "activate", G_CALLBACK(on_menu_create_new_object), (gpointer)"file");
 
-	item = get_image_menu_item_new(_("Rename"));
+	GtkWidget *item = gtk_menu_item_new_with_mnemonic(_("Rename"));
 	gtk_container_add(GTK_CONTAINER(menu), item);
 	g_signal_connect(item, "activate", G_CALLBACK(on_menu_rename), NULL);
 	gtk_widget_set_sensitive(item, is_exists);
 
-	item = get_image_menu_item_new(_("Delete"));
+	GtkWidget *item = gtk_menu_item_new_with_mnemonic(_("Delete"));
 	gtk_container_add(GTK_CONTAINER(menu), item);
 	g_signal_connect(item, "activate", G_CALLBACK(on_menu_delete), NULL);
 	gtk_widget_set_sensitive(item, is_exists);
@@ -1273,17 +1267,17 @@ create_popup_menu(const gchar *name, const gchar *uri)
 	item = gtk_separator_menu_item_new();
 	gtk_container_add(GTK_CONTAINER(menu), item);
 
-	item = get_image_menu_item_new(g_strdup_printf(_("Close: %s"), name));
+	GtkWidget *item = gtk_menu_item_new_with_mnemonic(g_strdup_printf(_("Close: %s"), name));
 	gtk_container_add(GTK_CONTAINER(menu), item);
 	g_signal_connect_data(item, "activate", G_CALLBACK(on_menu_close), g_strdup(uri), (GClosureNotify)g_free, 0);
 	gtk_widget_set_sensitive(item, is_document);
 
-	item = get_image_menu_item_new(g_strdup_printf(_("Close Child Documents ")));
+	GtkWidget *item = gtk_menu_item_new_with_mnemonic(g_strdup_printf(_("Close Child Documents ")));
 	gtk_container_add(GTK_CONTAINER(menu), item);
 	g_signal_connect_data(item, "activate", G_CALLBACK(on_menu_close_children), g_strdup(uri), (GClosureNotify)g_free, 0);
 	gtk_widget_set_sensitive(item, is_dir);
 
-	item = get_image_menu_item_new(_("_Copy full path to clipboard"));
+	GtkWidget *item = gtk_menu_item_new_with_mnemonic(_("_Copy full path to clipboard"));
 	gtk_container_add(GTK_CONTAINER(menu), item);
 	g_signal_connect_data(item, "activate", G_CALLBACK(on_menu_copy_uri), g_strdup(uri), (GClosureNotify)g_free, 0);
 	gtk_widget_set_sensitive(item, is_exists);
@@ -1292,11 +1286,11 @@ create_popup_menu(const gchar *name, const gchar *uri)
 	gtk_container_add(GTK_CONTAINER(menu), item);
 	gtk_widget_show(item);
 
-	item = get_image_menu_item_new(_("Expand all"));
+	GtkWidget *item = gtk_menu_item_new_with_mnemonic(_("Expand all"));
 	gtk_container_add(GTK_CONTAINER(menu), item);
 	g_signal_connect(item, "activate", G_CALLBACK(on_menu_expand_all), NULL);
 
-	item = get_image_menu_item_new(_("Collapse all"));
+	GtkWidget *item = gtk_menu_item_new_with_mnemonic(_("Collapse all"));
 	gtk_container_add(GTK_CONTAINER(menu), item);
 	g_signal_connect(item, "activate", G_CALLBACK(on_menu_collapse_all), NULL);
 
@@ -1581,7 +1575,7 @@ on_treeview_row_expanded(GtkWidget *widget, GtkTreeIter *iter, GtkTreePath *path
 	}
 	if (CONFIG_SHOW_ICONS)
 	{
-		GdkPixbuf *icon = utils_pixbuf_from_stock("document-open");
+		GdkPixbuf *icon = utils_pixbuf_from_name("document-open");
 
 		gtk_tree_store_set(treestore, iter, TREEBROWSER_COLUMN_ICON, icon, -1);
 		g_object_unref(icon);
@@ -1599,7 +1593,7 @@ on_treeview_row_collapsed(GtkWidget *widget, GtkTreeIter *iter, GtkTreePath *pat
 		return;
 	if (CONFIG_SHOW_ICONS)
 	{
-		GdkPixbuf *icon = utils_pixbuf_from_stock("folder");
+		GdkPixbuf *icon = utils_pixbuf_from_name("folder");
 
 		gtk_tree_store_set(treestore, iter, TREEBROWSER_COLUMN_ICON, icon, -1);
 		g_object_unref(icon);


### PR DESCRIPTION
now the treebrowser plugin uses GTK+ API compatible with version 3.10.0 and above. No more warnings during compilation :)

Tested on Arch x64, Ubuntu 14.04 x86, Ubuntu 15.04 amd64.