### PR TITLE
updated treebrowser for GTK+ >= 3.10.0

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -127,10 +127,13 @@ W: http://plugins.geany.org/geanynumberedbookmarks.html
 S: Maintained
 
 geanypg
-P: Hans Alves <alves.h88@gmail.com>
-M: Hans Alves <alves.h88@gmail.com>
+P1: Hans Alves <alves.h88@gmail.com>
+P2: Paolo Stivanin <info@paolostivanin.com>
+M1: Hans Alves <alves.h88@gmail.com>
+M2: Paolo Stivanin <info@paolostivanin.com>
 W: http://plugins.geany.org/geanypg.html
-S: Odd Fixes
+S1: Odd Fixes
+S2: Maintained
 
 geanyprj
 P: Yura Siamashka <yurand2@gmail.com>
@@ -235,10 +238,10 @@ W: http://plugins.geany.org/tableconvert.html
 S: Maintained
 
 treebrowser
-P:
-M:
-W:
-S: Orphaned
+P: Paolo Stivanin
+M: Paolo Stivanin <info@paolostivanin.com>
+W: http://plugins.geany.org/treebrowser.html
+S: Maintained
 
 updatechecker
 P: Frank Lanitz <frank@frank.uvena.de>

--- a/treebrowser/AUTHORS
+++ b/treebrowser/AUTHORS
@@ -1,3 +1,4 @@
 Adrian Dimitrov <dimitrov.adrian@gmail.com>
+Paolo Stivanin <info@paolostivanin.com>
 
 And THANKS to all in #geany for support and help

--- a/treebrowser/ChangeLog
+++ b/treebrowser/ChangeLog
@@ -36,6 +36,10 @@
 | Development release ChangeLog |
 +-------------------------------+
 
+08-29-2015	Paolo Stivanin 		<info@paolostivanin.com>
+
+	* src/treebrowser.c
+		updated for GTK+ >= 3.10.0
 
 08-02-2011 	Adrian Dimitrov 		<dimitrov.adrian@gmail.com>
 

--- a/treebrowser/NEWS
+++ b/treebrowser/NEWS
@@ -1,3 +1,6 @@
+Most important changes in 0.30:
+	* plugin updated for GTK+ v3.10.0 and above
+
 Most important changes in 0.20:
 
 	* Added bookmarks support

--- a/treebrowser/README
+++ b/treebrowser/README
@@ -1,4 +1,4 @@
-.. |(version)| replace:: 0.20
+.. |(version)| replace:: 0.30
 
 TreeBrowser plugin
 ==================
@@ -33,7 +33,7 @@ Features
 
 Requirements
 ============
-* GTK >= 2.8.0
+* GTK >= 3.10.0
 * GIO >= 2.0 (optional)
 * Geany >= 0.17
 
@@ -49,7 +49,7 @@ FAQ
 ===
 
 * My base directory is not remember
-	Yes it isn`t saved, and I don`t think that it have to be saved while We have in Geany "Startup path", and "Load from the last session"
+	Yes it isn't saved, and I don't think that it have to be saved while we have in Geany "Startup path", and "Load from the last session"
 	These settings are useful and the plugin take care about them, use them and the problem with the last directory remembering will be solved.
 
 
@@ -64,7 +64,7 @@ TreeBrowser is part of the combined Geany Plugins release. For more information 
 Installation
 ============
 
- The plugin is part from the geany-plugins projects, you can see the plugin`s install page at http://plugins.geany.org/install.html
+ The plugin is part from the geany-plugins projects, you can see the plugin's install page at http://plugins.geany.org/install.html
 
 
 License
@@ -79,5 +79,8 @@ Ideas, questions, patches and bug reports
 Report them at https://github.com/geany/geany-plugins/issues
 
 --
+2015 Paolo Stivanin
+info(at)paolostivanin(dot)com
+
 2010 Adrian Dimitrov
 dimitrov(dot)adrian(at)gmail(dot)com

--- a/treebrowser/src/treebrowser.c
+++ b/treebrowser/src/treebrowser.c
@@ -1,7 +1,7 @@
 /*
- *      treebrowser.c - v0.20
- *
- *      Copyright 2010 Adrian Dimitrov <dimitrov.adrian@gmail.com>
+ *      treebrowser.c - v0.30
+ *      
+ *      Copyright 2015 Paolo Stivanin <info@paolostivanin.com>
  */
 
 #ifdef HAVE_CONFIG_H
@@ -126,8 +126,8 @@ PLUGIN_SET_TRANSLATABLE_INFO(
 	GETTEXT_PACKAGE,
 	_("TreeBrowser"),
 	_("This plugin adds a tree browser to Geany, allowing the user to browse files using a tree view of the directory being browsed."),
-	"0.20" ,
-	"Adrian Dimitrov (dimitrov.adrian@gmail.com)")
+	"0.30" ,
+	"Adrian Dimitrov, Paolo Stivanin")
 
 
 /* ------------------
@@ -192,17 +192,23 @@ tree_view_row_expanded_iter(GtkTreeView *tree_view, GtkTreeIter *iter)
 }
 
 static GdkPixbuf *
-utils_pixbuf_from_stock(const gchar *stock_id)
+utils_pixbuf_from_name(const gchar *icon_name)
 {
-	GtkIconSet *icon_set;
+    GError *error = NULL;
+    GtkIconTheme *icon_theme;
+    GdkPixbuf *pixbuf;
+    
+    icon_theme = gtk_icon_theme_get_default ();
+    pixbuf = gtk_icon_theme_load_icon(icon_theme, icon_name, 16, 0, &error);
 
-	icon_set = gtk_icon_factory_lookup_default(stock_id);
-
-	if (icon_set)
-		return gtk_icon_set_render_icon(icon_set, gtk_widget_get_default_style(),
-										gtk_widget_get_default_direction(),
-										GTK_STATE_NORMAL, GTK_ICON_SIZE_MENU, NULL, NULL);
-	return NULL;
+	if(!pixbuf)
+    {
+        g_warning("Couldn't load icon: %s", error->message);
+        g_error_free(error);
+        return NULL;
+    }
+    else
+        return pixbuf;
 }
 
 static GdkPixbuf *
@@ -227,13 +233,13 @@ utils_pixbuf_from_path(gchar *path)
 		if (!info)
 			return NULL;
 		ret = gtk_icon_info_load_icon (info, NULL);
-		gtk_icon_info_free(info);
+		g_object_unref(info);
 	}
 	return ret;
 #else
-	return utils_pixbuf_from_stock(g_file_test(path, G_FILE_TEST_IS_DIR)
-									? GTK_STOCK_DIRECTORY
-									: GTK_STOCK_FILE);
+	return utils_pixbuf_from_name(g_file_test(path, G_FILE_TEST_IS_DIR)
+									? "folder"
+									: "text-x-generic");
 #endif
 }
 
@@ -414,16 +420,35 @@ static gboolean
 treebrowser_checkdir(gchar *directory)
 {
 	gboolean is_dir;
-	static const GdkColor red 	= {0, 0xffff, 0x6666, 0x6666};
-	static const GdkColor white = {0, 0xffff, 0xffff, 0xffff};
 	static gboolean old_value = TRUE;
+    GtkCssProvider *provider;
+    GdkDisplay *display;
+    GdkScreen *screen;
 
 	is_dir = g_file_test(directory, G_FILE_TEST_IS_DIR);
-
+    
 	if (old_value != is_dir)
 	{
-		gtk_widget_modify_base(GTK_WIDGET(addressbar), GTK_STATE_NORMAL, is_dir ? NULL : &red);
-		gtk_widget_modify_text(GTK_WIDGET(addressbar), GTK_STATE_NORMAL, is_dir ? NULL : &white);
+        provider = gtk_css_provider_new ();
+        display = gdk_display_get_default ();
+        screen = gdk_display_get_default_screen (display);
+        gtk_style_context_add_provider_for_screen (screen, GTK_STYLE_PROVIDER (provider),
+                                                   GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
+        if(!is_dir)
+        {
+            gtk_css_provider_load_from_data (GTK_CSS_PROVIDER(provider),
+                                             " #addrbar {\n"
+                                             "   background: red;\n"
+                                             "}\n", -1, NULL);
+        }
+        else
+        {
+            gtk_css_provider_load_from_data (GTK_CSS_PROVIDER(provider),
+                                             " #addrbar {\n"
+                                             "   background: white;\n"
+                                             "}\n", -1, NULL);
+        }
+        g_object_unref (provider);
 		old_value = is_dir;
 	}
 
@@ -524,7 +549,7 @@ treebrowser_browse(gchar *directory, gpointer parent)
 						gtk_tree_iter_free(last_dir_iter);
 					}
 					last_dir_iter = gtk_tree_iter_copy(&iter);
-					icon = CONFIG_SHOW_ICONS ? utils_pixbuf_from_stock(GTK_STOCK_DIRECTORY) : NULL;
+					icon = CONFIG_SHOW_ICONS ? utils_pixbuf_from_name("folder") : NULL;
 					gtk_tree_store_set(treestore, &iter,
 										TREEBROWSER_COLUMN_ICON, 	icon,
 										TREEBROWSER_COLUMN_NAME, 	fname,
@@ -544,7 +569,7 @@ treebrowser_browse(gchar *directory, gpointer parent)
 						icon = CONFIG_SHOW_ICONS == 2
 									? utils_pixbuf_from_path(uri)
 									: CONFIG_SHOW_ICONS
-										? utils_pixbuf_from_stock(GTK_STOCK_FILE)
+										? utils_pixbuf_from_name("text-x-generic")
 										: NULL;
 						gtk_tree_store_append(treestore, &iter, parent);
 						gtk_tree_store_set(treestore, &iter,
@@ -618,7 +643,7 @@ treebrowser_load_bookmarks(void)
 		else
 		{
 			gtk_tree_store_prepend(treestore, &bookmarks_iter, NULL);
-			icon = CONFIG_SHOW_ICONS ? utils_pixbuf_from_stock(GTK_STOCK_HOME) : NULL;
+			icon = CONFIG_SHOW_ICONS ? utils_pixbuf_from_name("go-home") : NULL;
 			gtk_tree_store_set(treestore, &bookmarks_iter,
 											TREEBROWSER_COLUMN_ICON, 	icon,
 											TREEBROWSER_COLUMN_NAME, 	_("Bookmarks"),
@@ -654,7 +679,7 @@ treebrowser_load_bookmarks(void)
 					gchar *file_name = g_path_get_basename(path_full);
 
 					gtk_tree_store_append(treestore, &iter, &bookmarks_iter);
-					icon = CONFIG_SHOW_ICONS ? utils_pixbuf_from_stock(GTK_STOCK_DIRECTORY) : NULL;
+					icon = CONFIG_SHOW_ICONS ? utils_pixbuf_from_name("folder") : NULL;
 					gtk_tree_store_set(treestore, &iter,
 												TREEBROWSER_COLUMN_ICON, 	icon,
 												TREEBROWSER_COLUMN_NAME, 	file_name,
@@ -1196,6 +1221,7 @@ on_menu_show_bars(GtkMenuItem *menuitem, gpointer *user_data)
 	showbars(gtk_check_menu_item_get_active(GTK_CHECK_MENU_ITEM(menuitem)));
 }
 
+
 static GtkWidget*
 create_popup_menu(const gchar *name, const gchar *uri)
 {
@@ -1205,33 +1231,33 @@ create_popup_menu(const gchar *name, const gchar *uri)
 	gboolean is_dir 		= is_exists ? g_file_test(uri, G_FILE_TEST_IS_DIR) : FALSE;
 	gboolean is_document 	= document_find_by_filename(uri) != NULL ? TRUE : FALSE;
 
-	item = ui_image_menu_item_new(GTK_STOCK_GO_UP, _("Go up"));
+	item = gtk_menu_item_new_with_mnemonic(_("Go up"));
 	gtk_container_add(GTK_CONTAINER(menu), item);
 	g_signal_connect(item, "activate", G_CALLBACK(on_menu_go_up), NULL);
 
-	item = ui_image_menu_item_new(GTK_STOCK_GO_UP, _("Set path from document"));
+	item = gtk_menu_item_new_with_mnemonic(_("Set path from document"));
 	gtk_container_add(GTK_CONTAINER(menu), item);
 	g_signal_connect(item, "activate", G_CALLBACK(on_menu_current_path), NULL);
 
-	item = ui_image_menu_item_new(GTK_STOCK_OPEN, _("_Open externally"));
+	item = gtk_menu_item_new_with_mnemonic(_("_Open"));
 	gtk_container_add(GTK_CONTAINER(menu), item);
 	g_signal_connect_data(item, "activate", G_CALLBACK(on_menu_open_externally), g_strdup(uri), (GClosureNotify)g_free, 0);
 	gtk_widget_set_sensitive(item, is_exists);
 
-	item = ui_image_menu_item_new("utilities-terminal", _("Open Terminal"));
+	item = gtk_menu_item_new_with_mnemonic(_("Open Terminal"));
 	gtk_container_add(GTK_CONTAINER(menu), item);
 	g_signal_connect_data(item, "activate", G_CALLBACK(on_menu_open_terminal), g_strdup(uri), (GClosureNotify)g_free, 0);
 
-	item = ui_image_menu_item_new(GTK_STOCK_GOTO_TOP, _("Set as root"));
+	item = gtk_menu_item_new_with_mnemonic(_("Set as root"));
 	gtk_container_add(GTK_CONTAINER(menu), item);
 	g_signal_connect_data(item, "activate", G_CALLBACK(on_menu_set_as_root), g_strdup(uri), (GClosureNotify)g_free, 0);
 	gtk_widget_set_sensitive(item, is_dir);
 
-	item = ui_image_menu_item_new(GTK_STOCK_REFRESH, _("Refresh"));
+	item = gtk_menu_item_new_with_mnemonic(_("Refresh"));
 	gtk_container_add(GTK_CONTAINER(menu), item);
 	g_signal_connect(item, "activate", G_CALLBACK(on_menu_refresh), NULL);
 
-	item = ui_image_menu_item_new(GTK_STOCK_FIND, _("_Find in Files"));
+	item = gtk_menu_item_new_with_mnemonic(_("_Find in Files"));
 	gtk_container_add(GTK_CONTAINER(menu), item);
 	g_signal_connect_data(item, "activate", G_CALLBACK(on_menu_find_in_files), g_strdup(uri), (GClosureNotify)g_free, 0);
 	gtk_widget_set_sensitive(item, is_dir);
@@ -1239,20 +1265,20 @@ create_popup_menu(const gchar *name, const gchar *uri)
 	item = gtk_separator_menu_item_new();
 	gtk_container_add(GTK_CONTAINER(menu), item);
 
-	item = ui_image_menu_item_new(GTK_STOCK_ADD, _("Create new directory"));
+	item = gtk_menu_item_new_with_mnemonic(_("Create new directory"));
 	gtk_container_add(GTK_CONTAINER(menu), item);
 	g_signal_connect(item, "activate", G_CALLBACK(on_menu_create_new_object), (gpointer)"directory");
 
-	item = ui_image_menu_item_new(GTK_STOCK_NEW, _("Create new file"));
+	item = gtk_menu_item_new_with_mnemonic(_("Create new file"));
 	gtk_container_add(GTK_CONTAINER(menu), item);
 	g_signal_connect(item, "activate", G_CALLBACK(on_menu_create_new_object), (gpointer)"file");
 
-	item = ui_image_menu_item_new(GTK_STOCK_SAVE_AS, _("Rename"));
+	item = gtk_menu_item_new_with_mnemonic(_("Rename"));
 	gtk_container_add(GTK_CONTAINER(menu), item);
 	g_signal_connect(item, "activate", G_CALLBACK(on_menu_rename), NULL);
 	gtk_widget_set_sensitive(item, is_exists);
 
-	item = ui_image_menu_item_new(GTK_STOCK_DELETE, _("Delete"));
+	item = gtk_menu_item_new_with_mnemonic(_("Delete"));
 	gtk_container_add(GTK_CONTAINER(menu), item);
 	g_signal_connect(item, "activate", G_CALLBACK(on_menu_delete), NULL);
 	gtk_widget_set_sensitive(item, is_exists);
@@ -1260,17 +1286,17 @@ create_popup_menu(const gchar *name, const gchar *uri)
 	item = gtk_separator_menu_item_new();
 	gtk_container_add(GTK_CONTAINER(menu), item);
 
-	item = ui_image_menu_item_new(GTK_STOCK_CLOSE, g_strdup_printf(_("Close: %s"), name));
+	item = gtk_menu_item_new_with_mnemonic(g_strdup_printf(_("Close: %s"), name));
 	gtk_container_add(GTK_CONTAINER(menu), item);
 	g_signal_connect_data(item, "activate", G_CALLBACK(on_menu_close), g_strdup(uri), (GClosureNotify)g_free, 0);
 	gtk_widget_set_sensitive(item, is_document);
 
-	item = ui_image_menu_item_new(GTK_STOCK_CLOSE, g_strdup_printf(_("Close Child Documents ")));
+	item = gtk_menu_item_new_with_mnemonic(g_strdup_printf(_("Close Child Documents ")));
 	gtk_container_add(GTK_CONTAINER(menu), item);
 	g_signal_connect_data(item, "activate", G_CALLBACK(on_menu_close_children), g_strdup(uri), (GClosureNotify)g_free, 0);
 	gtk_widget_set_sensitive(item, is_dir);
 
-	item = ui_image_menu_item_new(GTK_STOCK_COPY, _("_Copy full path to clipboard"));
+	item = gtk_menu_item_new_with_mnemonic(_("_Copy full path to clipboard"));
 	gtk_container_add(GTK_CONTAINER(menu), item);
 	g_signal_connect_data(item, "activate", G_CALLBACK(on_menu_copy_uri), g_strdup(uri), (GClosureNotify)g_free, 0);
 	gtk_widget_set_sensitive(item, is_exists);
@@ -1279,11 +1305,11 @@ create_popup_menu(const gchar *name, const gchar *uri)
 	gtk_container_add(GTK_CONTAINER(menu), item);
 	gtk_widget_show(item);
 
-	item = ui_image_menu_item_new(GTK_STOCK_GO_FORWARD, _("Expand all"));
+	item = gtk_menu_item_new_with_mnemonic(_("Expand all"));
 	gtk_container_add(GTK_CONTAINER(menu), item);
 	g_signal_connect(item, "activate", G_CALLBACK(on_menu_expand_all), NULL);
 
-	item = ui_image_menu_item_new(GTK_STOCK_GO_BACK, _("Collapse all"));
+	item = gtk_menu_item_new_with_mnemonic(_("Collapse all"));
 	gtk_container_add(GTK_CONTAINER(menu), item);
 	g_signal_connect(item, "activate", G_CALLBACK(on_menu_collapse_all), NULL);
 
@@ -1568,7 +1594,7 @@ on_treeview_row_expanded(GtkWidget *widget, GtkTreeIter *iter, GtkTreePath *path
 	}
 	if (CONFIG_SHOW_ICONS)
 	{
-		GdkPixbuf *icon = utils_pixbuf_from_stock(GTK_STOCK_OPEN);
+		GdkPixbuf *icon = utils_pixbuf_from_name("document-open");
 
 		gtk_tree_store_set(treestore, iter, TREEBROWSER_COLUMN_ICON, icon, -1);
 		g_object_unref(icon);
@@ -1586,7 +1612,7 @@ on_treeview_row_collapsed(GtkWidget *widget, GtkTreeIter *iter, GtkTreePath *pat
 		return;
 	if (CONFIG_SHOW_ICONS)
 	{
-		GdkPixbuf *icon = utils_pixbuf_from_stock(GTK_STOCK_DIRECTORY);
+		GdkPixbuf *icon = utils_pixbuf_from_name("folder");
 
 		gtk_tree_store_set(treestore, iter, TREEBROWSER_COLUMN_ICON, icon, -1);
 		g_object_unref(icon);
@@ -1718,7 +1744,7 @@ create_sidebar(void)
 {
 	GtkWidget 			*scrollwin;
 	GtkWidget 			*toolbar;
-	GtkWidget 			*wid;
+	GtkToolItem			*wid;
 	GtkTreeSelection 	*selection;
 
 	treeview 				= create_view_and_model();
@@ -1729,41 +1755,48 @@ create_sidebar(void)
 	filter 					= gtk_entry_new();
 	scrollwin 				= gtk_scrolled_window_new(NULL, NULL);
 
+    gtk_widget_set_name (GTK_WIDGET(addressbar), "addrbar");
 	gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(scrollwin), GTK_POLICY_AUTOMATIC, GTK_POLICY_AUTOMATIC);
 
 	toolbar = gtk_toolbar_new();
 	gtk_toolbar_set_icon_size(GTK_TOOLBAR(toolbar), GTK_ICON_SIZE_MENU);
 	gtk_toolbar_set_style(GTK_TOOLBAR(toolbar), GTK_TOOLBAR_ICONS);
 
-	wid = GTK_WIDGET(gtk_tool_button_new_from_stock(GTK_STOCK_GO_UP));
-	ui_widget_set_tooltip_text(wid, _("Go up"));
+    wid = gtk_tool_button_new(NULL, NULL);
+    gtk_tool_button_set_icon_name(GTK_TOOL_BUTTON(wid), "go-up");
+	ui_widget_set_tooltip_text(GTK_WIDGET(wid), _("Go up"));
 	g_signal_connect(wid, "clicked", G_CALLBACK(on_button_go_up), NULL);
-	gtk_container_add(GTK_CONTAINER(toolbar), wid);
+	gtk_container_add(GTK_CONTAINER(toolbar), GTK_WIDGET(wid));
 
-	wid = GTK_WIDGET(gtk_tool_button_new_from_stock(GTK_STOCK_REFRESH));
-	ui_widget_set_tooltip_text(wid, _("Refresh"));
+	wid = gtk_tool_button_new(NULL, NULL);
+    gtk_tool_button_set_icon_name(GTK_TOOL_BUTTON(wid), "view-refresh");
+	ui_widget_set_tooltip_text(GTK_WIDGET(wid), _("Refresh"));
 	g_signal_connect(wid, "clicked", G_CALLBACK(on_button_refresh), NULL);
-	gtk_container_add(GTK_CONTAINER(toolbar), wid);
+	gtk_container_add(GTK_CONTAINER(toolbar), GTK_WIDGET(wid));
 
-	wid = GTK_WIDGET(gtk_tool_button_new_from_stock(GTK_STOCK_HOME));
-	ui_widget_set_tooltip_text(wid, _("Home"));
+	wid = gtk_tool_button_new(NULL, NULL);
+    gtk_tool_button_set_icon_name(GTK_TOOL_BUTTON(wid), "go-home");
+	ui_widget_set_tooltip_text(GTK_WIDGET(wid), _("Home"));
 	g_signal_connect(wid, "clicked", G_CALLBACK(on_button_go_home), NULL);
-	gtk_container_add(GTK_CONTAINER(toolbar), wid);
+	gtk_container_add(GTK_CONTAINER(toolbar), GTK_WIDGET(wid));
 
-	wid = GTK_WIDGET(gtk_tool_button_new_from_stock(GTK_STOCK_JUMP_TO));
-	ui_widget_set_tooltip_text(wid, _("Set path from document"));
+	wid = gtk_tool_button_new(NULL, NULL);
+    gtk_tool_button_set_icon_name(GTK_TOOL_BUTTON(wid), "go-jump");
+	ui_widget_set_tooltip_text(GTK_WIDGET(wid), _("Set path from document"));
 	g_signal_connect(wid, "clicked", G_CALLBACK(on_button_current_path), NULL);
-	gtk_container_add(GTK_CONTAINER(toolbar), wid);
+	gtk_container_add(GTK_CONTAINER(toolbar), GTK_WIDGET(wid));
 
-	wid = GTK_WIDGET(gtk_tool_button_new_from_stock(GTK_STOCK_DIRECTORY));
-	ui_widget_set_tooltip_text(wid, _("Track path"));
+	wid = gtk_tool_button_new(NULL, NULL);
+    gtk_tool_button_set_icon_name(GTK_TOOL_BUTTON(wid), "folder");
+	ui_widget_set_tooltip_text(GTK_WIDGET(wid), _("Track path"));
 	g_signal_connect(wid, "clicked", G_CALLBACK(treebrowser_track_current), NULL);
-	gtk_container_add(GTK_CONTAINER(toolbar), wid);
+	gtk_container_add(GTK_CONTAINER(toolbar), GTK_WIDGET(wid));
 
-	wid = GTK_WIDGET(gtk_tool_button_new_from_stock(GTK_STOCK_CLOSE));
-	ui_widget_set_tooltip_text(wid, _("Hide bars"));
+	wid = gtk_tool_button_new(NULL, NULL);
+    gtk_tool_button_set_icon_name(GTK_TOOL_BUTTON(wid), "window-close");
+	ui_widget_set_tooltip_text(GTK_WIDGET(wid), _("Hide bars"));
 	g_signal_connect(wid, "clicked", G_CALLBACK(on_button_hide_bars), NULL);
-	gtk_container_add(GTK_CONTAINER(toolbar), wid);
+	gtk_container_add(GTK_CONTAINER(toolbar), GTK_WIDGET(wid));
 
 	gtk_container_add(GTK_CONTAINER(scrollwin), 			treeview);
 	gtk_box_pack_start(GTK_BOX(sidebar_vbox_bars), 			filter, 			FALSE, TRUE,  1);
@@ -1950,7 +1983,12 @@ plugin_configure(GtkDialog *dialog)
 	label 	= gtk_label_new(_("External open command"));
 	configure_widgets.OPEN_EXTERNAL_CMD = gtk_entry_new();
 	gtk_entry_set_text(GTK_ENTRY(configure_widgets.OPEN_EXTERNAL_CMD), CONFIG_OPEN_EXTERNAL_CMD);
+#if GTK_CHECK_VERSION(3, 16, 0)
+	gtk_label_set_xalign (GTK_LABEL (label), 0.0);
+	gtk_label_set_yalign (GTK_LABEL (label), 0.5);
+#else
 	gtk_misc_set_alignment(GTK_MISC(label), 0, 0.5);
+#endif
 	ui_widget_set_tooltip_text(configure_widgets.OPEN_EXTERNAL_CMD,
 		_("The command to execute when using \"Open with\". You can use %f and %d wildcards.\n"
 		  "%f will be replaced with the filename including full path\n"
@@ -1963,7 +2001,12 @@ plugin_configure(GtkDialog *dialog)
 	label = gtk_label_new(_("Terminal"));
 	configure_widgets.OPEN_TERMINAL = gtk_entry_new();
 	gtk_entry_set_text(GTK_ENTRY(configure_widgets.OPEN_TERMINAL), CONFIG_OPEN_TERMINAL);
+#if GTK_CHECK_VERSION(3, 16, 0)
+	gtk_label_set_xalign (GTK_LABEL (label), 0.0);
+	gtk_label_set_yalign (GTK_LABEL (label), 0.5);
+#else
 	gtk_misc_set_alignment(GTK_MISC(label), 0, 0.5);
+#endif
 	ui_widget_set_tooltip_text(configure_widgets.OPEN_TERMINAL,
 		_("The terminal to use with the command \"Open Terminal\""));
 	gtk_box_pack_start(GTK_BOX(hbox), label, FALSE, FALSE, 6);


### PR DESCRIPTION
- removed deprecation warnings
- uses GTK+ 3.10 and above
