### PR TITLE
git-changebar: Fix compilation against libgit2 >= 0.23

### DIFF
--- a/git-changebar/src/gcb-plugin.c
+++ b/git-changebar/src/gcb-plugin.c
@@ -655,8 +655,21 @@ diff_buf_to_doc (const git_buf   *old_buf,
   opts.context_lines = 0;
   opts.flags = GIT_DIFF_FORCE_TEXT;
   
-  ret = git_diff_buffers (old_buf->ptr, old_buf->size, NULL,
-                          buf, len, NULL, &opts, NULL, hunk_cb, NULL, payload);
+  ret = git_diff_buffers (
+    old_buf->ptr,   /* old_buffer */
+    old_buf->size,  /* old_len */
+    NULL,           /* old_as_path */
+    buf,            /* new_buffer */
+    len,            /* new_len */
+    NULL,           /* new_as_path */
+    &opts,          /* git_diff_options */
+    NULL,           /* file_cb */
+#if defined (LIBGIT2_SOVERSION) && LIBGIT2_SOVERSION > 22
+    NULL,           /* binary_cb */
+#endif
+    hunk_cb,        /* hunk_cb */
+    NULL,           /* line_cb */
+    payload);       /* payload */
   
   if (free_buf) {
     g_free (buf);


### PR DESCRIPTION
libgit2 changed its API and added a new argument to git_diff_buffers().

The new argument is a callback for binary files. This should not be relevant here because Geany probably won't be able to handle binary files in the near future.

I tested compilation with this patch against libgit2 0.22 *and* 0.23.

However, I could not test the plugin against 0.23 because of weird unresolved symbols in libgit2. I assume this is a temporary problem with my distro (ArchLinux).

@b4n not sure if you like the style, I broke the function arguments into one per line to make them more readable. Feel free to drop this PR and do it in another way.