### PR TITLE
Addons bookmark refresh fix

### DIFF
--- a/addons/src/ao_bookmarklist.c
+++ b/addons/src/ao_bookmarklist.c
@@ -69,7 +69,7 @@ struct _AoBookmarkListPrivate
 typedef struct
 {
 	AoBookmarkList *bm;
-	GeanyDocument *document;
+	guint document_id;
 } AoBookmarkListRefreshContainer;
 
 enum
@@ -416,11 +416,12 @@ static gboolean update_bookmark_list_delayed(gpointer data)
 	AoBookmarkListRefreshContainer *container = data;
 	AoBookmarkList *bm = container->bm;
 	AoBookmarkListPrivate *priv = AO_BOOKMARK_LIST_GET_PRIVATE(bm);
-	GeanyDocument *doc = container->document;
-	ScintillaObject *sci = doc->editor->sci;
+	GeanyDocument *doc = document_find_by_id(container->document_id);
 
-	if (priv->enable_bookmarklist && DOC_VALID(doc))
+	if (priv->enable_bookmarklist && doc != NULL)
 	{
+		ScintillaObject *sci = doc->editor->sci;
+
 		gtk_list_store_clear(priv->store);
 		while ((line_nr = scintilla_send_message(sci, SCI_MARKERNEXT, line_nr, mask)) != -1)
 		{
@@ -438,11 +439,13 @@ static gboolean update_bookmark_list_delayed(gpointer data)
 void ao_bookmark_list_update(AoBookmarkList *bm, GeanyDocument *doc)
 {
 	AoBookmarkListPrivate *priv = AO_BOOKMARK_LIST_GET_PRIVATE(bm);
+
 	if (priv->refresh_idle_source_id == 0)
 	{
 		AoBookmarkListRefreshContainer *container = g_new0(AoBookmarkListRefreshContainer, 1);
+
 		container->bm = bm;
-		container->document = doc;
+		container->document_id = doc->id;
 		priv->refresh_idle_source_id = plugin_idle_add(
 			geany_plugin,
 			update_bookmark_list_delayed,
@@ -455,16 +458,23 @@ void ao_bookmark_list_update_marker(AoBookmarkList *bm, GeanyEditor *editor, SCN
 {
 	AoBookmarkListPrivate *priv = AO_BOOKMARK_LIST_GET_PRIVATE(bm);
 
-	if (priv->enable_bookmarklist &&
-		nt->nmhdr.code == SCN_MODIFIED && nt->modificationType == SC_MOD_CHANGEMARKER)
+	if (priv->enable_bookmarklist && nt->nmhdr.code == SCN_MODIFIED)
 	{
-		if (sci_is_marker_set_at_line(editor->sci, nt->line, 1))
+		if (nt->modificationType == SC_MOD_CHANGEMARKER)
 		{
-			add_line(bm, editor->sci, nt->line);
+			if (sci_is_marker_set_at_line(editor->sci, nt->line, 1))
+			{
+				add_line(bm, editor->sci, nt->line);
+			}
+			else
+			{
+				delete_line(bm, nt->line);
+			}
 		}
-		else
+		else if (nt->linesAdded != 0)
 		{
-			delete_line(bm, nt->line);
+			/* if any lines changed, refresh the whole list as we refer line numbers */
+			ao_bookmark_list_update(bm, editor->document);
 		}
 	}
 }


### PR DESCRIPTION
Update bookmark list also on any line changes in the document

In addition to updating the bookmark list on document notebook tab change
and adding/removing line markers, also rebuild the bookmark list
when the text in the document changes with lines added or deleted.

Should fix SF bugs 129 and 39.

This implements some ideas mentioned in the above bug reports like updating the bookmark list
in an idle callback. Additionally, the list store is detach from the GtkTreeView to increase performance on big bookmark lists.

Maybe it is still worth to add a refresh button (or rather a context menu item to refresh) but I would try it without at first.

There is one issue left: if the `Transpose current line` feature is used, the bookmarks don't update. But this is not a problem in the plugin but rather in either Geany or Scintilla as the marker also stays at the "old" line. This should be managed separately.