### PR TITLE
scope: Don't use an untrusted string as a printf format

### DIFF
--- a/scope/src/debug.c
+++ b/scope/src/debug.c
@@ -253,7 +253,7 @@ static void debug_parse(char *string, const char *error)
 		}
 
 		if (error)
-			dc_error(error);
+			dc_error("%s", error);
 		else if (!end)
 			dc_error("\" expected");
 		else if (g_str_has_prefix(string, "~^(Scope)#07"))


### PR DESCRIPTION
Reported by GCC's `-Wformat-security`.