### PR TITLE
geanypy: Try to locate the real dereferenced Python DSO

### DIFF
--- a/geanypy/m4/ax_python_library.m4
+++ b/geanypy/m4/ax_python_library.m4
@@ -17,7 +17,10 @@ cvars = get_config_vars()
 # support multiarch-enabled distributions like Ubuntu
 if not 'MULTIARCH' in cvars.keys():
     cvars[['MULTIARCH']] = ''
-print(path_join(cvars[['LIBDIR']], cvars[['MULTIARCH']], cvars[['LDLIBRARY']]))
+# try to find the real installed lib, not the generic link
+if not 'INSTSONAME' in cvars.keys():
+    cvars[['INSTSONAME']] = cvars[['LDLIBRARY']]
+print(path_join(cvars[['LIBDIR']], cvars[['MULTIARCH']], cvars[['INSTSONAME']]))
 EOD`
 
 	AC_SUBST([PYTHON_LIBRARY], [$ax_python_library])


### PR DESCRIPTION
Try to pre-load the Python library with its real, fully dereferenced
path.

This is necessary because some installations don't have the symlink
from the generic (.so) to the versioned one (.so.X.Y) when the Python
development files aren't installed (i.e. libpython2.7-dev on Debian).

Fortunately for us (at least under Debian) Python has the name of the
final installed library in its `INSTSONAME` sysconfig's config var, so
use this instead of `LDLIBRARY` when it's available.

Closes https://github.com/codebrainz/geanypy/issues/20