### PR TITLE
Addons: Add new feature "Copy File Path"

### DIFF
--- a/addons/README
+++ b/addons/README
@@ -91,6 +91,13 @@ then be linked to a keybinding (e.g. set [ and ] to be Enclose Pair 1 and the
 keybinding to ctrl+[ , highlight some text and press ctrl+[ to surround the
 selected text in brackets).
 
+*Copy File Path*
+^^^^^^^^^^^^^^^^
+Simple extension to easily copy the full path of the current file
+to the clipboard for further use.
+The action can be triggered by a keyboard shortcut as well as by
+a menu item in the Tools menu.
+
 Requirements
 ------------
 

--- a/addons/src/Makefile.am
+++ b/addons/src/Makefile.am
@@ -13,6 +13,7 @@ addons_la_SOURCES = \
 	ao_tasks.h \
 	ao_xmltagging.h \
 	ao_wrapwords.h \
+	ao_copyfilepath.h \
 	addons.c \
 	ao_blanklines.c \
 	ao_doclist.c \
@@ -22,7 +23,8 @@ addons_la_SOURCES = \
 	ao_markword.c \
 	ao_tasks.c \
 	ao_xmltagging.c \
-	ao_wrapwords.c
+	ao_wrapwords.c \
+	ao_copyfilepath.c
 
 addons_la_LIBADD = $(COMMONLIBS)
 

--- a/addons/src/addons.c
+++ b/addons/src/addons.c
@@ -38,6 +38,7 @@
 #include "ao_tasks.h"
 #include "ao_xmltagging.h"
 #include "ao_wrapwords.h"
+#include "ao_copyfilepath.h"
 
 
 GeanyPlugin		*geany_plugin;
@@ -62,6 +63,7 @@ enum
 	KB_FOCUS_TASKS,
 	KB_UPDATE_TASKS,
 	KB_XMLTAGGING,
+	KB_COPYFILEPATH,
 	KB_COUNT
 };
 
@@ -93,6 +95,7 @@ typedef struct
 	AoBookmarkList *bookmarklist;
 	AoMarkWord *markword;
 	AoTasks *tasks;
+	AoCopyFilePath *copyfilepath;
 } AddonsInfo;
 static AddonsInfo *ao_info = NULL;
 
@@ -153,6 +156,7 @@ static void kb_tasks_update(guint key_id)
 	ao_tasks_update(ao_info->tasks, NULL);
 }
 
+
 static void kb_ao_xmltagging(guint key_id)
 {
 	if (ao_info->enable_xmltagging == TRUE)
@@ -160,6 +164,13 @@ static void kb_ao_xmltagging(guint key_id)
 		ao_xmltagging();
 	}
 }
+
+
+static void kb_ao_copyfilepath(guint key_id)
+{
+	ao_copy_file_path_copy(ao_info->copyfilepath);
+}
+
 
 gboolean ao_editor_notify_cb(GObject *object, GeanyEditor *editor,
 							 SCNotification *nt, gpointer data)
@@ -243,6 +254,7 @@ GtkWidget *ao_image_menu_item_new(const gchar *stock_id, const gchar *label)
 void plugin_init(GeanyData *data)
 {
 	GKeyFile *config = g_key_file_new();
+	GtkWidget *ao_copy_file_path_menu_item;
 	GeanyKeyGroup *key_group;
 
 	ao_info = g_new0(AddonsInfo, 1);
@@ -287,6 +299,7 @@ void plugin_init(GeanyData *data)
 	ao_info->markword = ao_mark_word_new(ao_info->enable_markword);
 	ao_info->tasks = ao_tasks_new(ao_info->enable_tasks,
 						ao_info->tasks_token_list, ao_info->tasks_scan_all_documents);
+	ao_info->copyfilepath = ao_copy_file_path_new();
 
 	ao_blanklines_set_enable(ao_info->strip_trailing_blank_lines);
 
@@ -300,6 +313,9 @@ void plugin_init(GeanyData *data)
 		0, 0, "update_tasks", _("Update Tasks List"), NULL);
 	keybindings_set_item(key_group, KB_XMLTAGGING, kb_ao_xmltagging,
 		0, 0, "xml_tagging", _("Run XML tagging"), NULL);
+	ao_copy_file_path_menu_item = ao_copy_file_path_get_menu_item(ao_info->copyfilepath);
+	keybindings_set_item(key_group, KB_COPYFILEPATH, kb_ao_copyfilepath,
+		0, 0, "copy_file_path", _("Copy File Path"), ao_copy_file_path_menu_item);
 
 	ao_enclose_words_init(ao_info->config_file, key_group, KB_COUNT);
 	ao_enclose_words_set_enabled (ao_info->enable_enclose_words, ao_info->enable_enclose_words_auto);
@@ -615,6 +631,7 @@ void plugin_cleanup(void)
 	g_object_unref(ao_info->bookmarklist);
 	g_object_unref(ao_info->markword);
 	g_object_unref(ao_info->tasks);
+	g_object_unref(ao_info->copyfilepath);
 	g_free(ao_info->tasks_token_list);
 
 	ao_blanklines_set_enable(FALSE);

--- a/addons/src/addons.c
+++ b/addons/src/addons.c
@@ -291,7 +291,7 @@ void plugin_init(GeanyData *data)
 	ao_blanklines_set_enable(ao_info->strip_trailing_blank_lines);
 
 	/* setup keybindings */
-	key_group = plugin_set_key_group(geany_plugin, "addons", KB_COUNT+8, NULL);
+	key_group = plugin_set_key_group(geany_plugin, "addons", KB_COUNT + AO_WORDWRAP_KB_COUNT, NULL);
 	keybindings_set_item(key_group, KB_FOCUS_BOOKMARK_LIST, kb_bmlist_activate,
 		0, 0, "focus_bookmark_list", _("Focus Bookmark List"), NULL);
 	keybindings_set_item(key_group, KB_FOCUS_TASKS, kb_tasks_activate,
@@ -301,7 +301,7 @@ void plugin_init(GeanyData *data)
 	keybindings_set_item(key_group, KB_XMLTAGGING, kb_ao_xmltagging,
 		0, 0, "xml_tagging", _("Run XML tagging"), NULL);
 
-	ao_enclose_words_init(ao_info->config_file, key_group);
+	ao_enclose_words_init(ao_info->config_file, key_group, KB_COUNT);
 	ao_enclose_words_set_enabled (ao_info->enable_enclose_words, ao_info->enable_enclose_words_auto);
 
 	g_key_file_free(config);

--- a/addons/src/ao_copyfilepath.c
+++ b/addons/src/ao_copyfilepath.c
@@ -1,0 +1,138 @@
+/*
+ *      ao_copyfilepath.c - this file is part of Addons, a Geany plugin
+ *
+ *      Copyright 2015 Enrico Tröger <enrico(dot)troeger(at)uvena(dot)de>
+ *
+ *      This program is free software; you can redistribute it and/or modify
+ *      it under the terms of the GNU General Public License as published by
+ *      the Free Software Foundation; either version 2 of the License, or
+ *      (at your option) any later version.
+ *
+ *      This program is distributed in the hope that it will be useful,
+ *      but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *      GNU General Public License for more details.
+ *
+ *      You should have received a copy of the GNU General Public License
+ *      along with this program; if not, write to the Free Software
+ *      Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#ifdef HAVE_CONFIG_H
+	#include "config.h"
+#endif
+#include <geanyplugin.h>
+
+#include "addons.h"
+#include "ao_copyfilepath.h"
+
+
+typedef struct _AoCopyFilePathPrivate			AoCopyFilePathPrivate;
+
+#define AO_COPY_FILE_PATH_GET_PRIVATE(obj)		(G_TYPE_INSTANCE_GET_PRIVATE((obj),\
+			AO_COPY_FILE_PATH_TYPE, AoCopyFilePathPrivate))
+
+struct _AoCopyFilePath
+{
+	GObject parent;
+};
+
+struct _AoCopyFilePathClass
+{
+	GObjectClass parent_class;
+};
+
+struct _AoCopyFilePathPrivate
+{
+	GtkWidget *tools_menu_item;
+};
+
+
+
+static void ao_copy_file_path_finalize(GObject *object);
+
+
+G_DEFINE_TYPE(AoCopyFilePath, ao_copy_file_path, G_TYPE_OBJECT)
+
+
+
+static void ao_copy_file_path_class_init(AoCopyFilePathClass *klass)
+{
+	GObjectClass *g_object_class;
+
+	g_object_class = G_OBJECT_CLASS(klass);
+
+	g_object_class->finalize = ao_copy_file_path_finalize;
+
+	g_type_class_add_private(klass, sizeof(AoCopyFilePathPrivate));
+}
+
+
+static void ao_copy_file_path_finalize(GObject *object)
+{
+	AoCopyFilePathPrivate *priv = AO_COPY_FILE_PATH_GET_PRIVATE(object);
+
+	gtk_widget_destroy(priv->tools_menu_item);
+
+	G_OBJECT_CLASS(ao_copy_file_path_parent_class)->finalize(object);
+}
+
+
+GtkWidget* ao_copy_file_path_get_menu_item(AoCopyFilePath *self)
+{
+	AoCopyFilePathPrivate *priv = AO_COPY_FILE_PATH_GET_PRIVATE(self);
+
+	return priv->tools_menu_item;
+}
+
+
+void ao_copy_file_path_copy(AoCopyFilePath *self)
+{
+	GeanyDocument *doc;
+	GtkClipboard *clipboard, *primary;
+
+	doc = document_get_current();
+	if (doc != NULL)
+	{
+		gchar *file_name = DOC_FILENAME(doc);
+		clipboard = gtk_clipboard_get(GDK_SELECTION_CLIPBOARD);
+		primary = gtk_clipboard_get(GDK_SELECTION_PRIMARY);
+		gtk_clipboard_set_text(clipboard, file_name, -1);
+		gtk_clipboard_set_text(primary, file_name, -1);
+
+		ui_set_statusbar(TRUE, _("File path \"%s\" copied to clipboard."), file_name);
+	}
+}
+
+
+static void copy_file_path_activated_cb(GtkMenuItem *item, AoCopyFilePath *self)
+{
+	ao_copy_file_path_copy(self);
+}
+
+
+static void ao_copy_file_path_init(AoCopyFilePath *self)
+{
+	AoCopyFilePathPrivate *priv = AO_COPY_FILE_PATH_GET_PRIVATE(self);
+
+	priv->tools_menu_item = ao_image_menu_item_new(GTK_STOCK_COPY, _("Copy File Path"));
+	gtk_widget_set_tooltip_text(
+		priv->tools_menu_item,
+		_("Copy the file path of the current document to the clipboard"));
+	gtk_widget_show(priv->tools_menu_item);
+	g_signal_connect(
+		priv->tools_menu_item,
+		"activate",
+		G_CALLBACK(copy_file_path_activated_cb),
+		self);
+	gtk_container_add(GTK_CONTAINER(geany->main_widgets->tools_menu), priv->tools_menu_item);
+
+	ui_add_document_sensitive(priv->tools_menu_item);
+}
+
+
+AoCopyFilePath *ao_copy_file_path_new(void)
+{
+	return g_object_new(AO_COPY_FILE_PATH_TYPE, NULL);
+}

--- a/addons/src/ao_copyfilepath.h
+++ b/addons/src/ao_copyfilepath.h
@@ -1,0 +1,49 @@
+/*
+ *      ao_copyfilepath.h - this file is part of Addons, a Geany plugin
+ *
+ *      Copyright 2015 Enrico Tröger <enrico(dot)troeger(at)uvena(dot)de>
+ *
+ *      This program is free software; you can redistribute it and/or modify
+ *      it under the terms of the GNU General Public License as published by
+ *      the Free Software Foundation; either version 2 of the License, or
+ *      (at your option) any later version.
+ *
+ *      This program is distributed in the hope that it will be useful,
+ *      but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *      GNU General Public License for more details.
+ *
+ *      You should have received a copy of the GNU General Public License
+ *      along with this program; if not, write to the Free Software
+ *      Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+
+#ifndef __AO_COPYFILEPATH_H__
+#define __AO_COPYFILEPATH_H__
+
+G_BEGIN_DECLS
+
+#define AO_COPY_FILE_PATH_TYPE				(ao_copy_file_path_get_type())
+#define AO_COPY_FILE_PATH(obj)				(G_TYPE_CHECK_INSTANCE_CAST((obj),\
+			AO_COPY_FILE_PATH_TYPE, AoCopyFilePath))
+#define AO_COPY_FILE_PATH_CLASS(klass)		(G_TYPE_CHECK_CLASS_CAST((klass),\
+			AO_COPY_FILE_PATH_TYPE, AoCopyFilePathClass))
+#define IS_AO_COPY_FILE_PATH(obj)			(G_TYPE_CHECK_INSTANCE_TYPE((obj),\
+			AO_COPY_FILE_PATH_TYPE))
+#define IS_AO_COPY_FILE_PATH_CLASS(klass)	(G_TYPE_CHECK_CLASS_TYPE((klass),\
+			AO_COPY_FILE_PATH_TYPE))
+
+typedef struct _AoCopyFilePath			AoCopyFilePath;
+typedef struct _AoCopyFilePathClass		AoCopyFilePathClass;
+
+
+GType			ao_copy_file_path_get_type		(void);
+AoCopyFilePath*	ao_copy_file_path_new			(void);
+void 			ao_copy_file_path_copy			(AoCopyFilePath *self);
+GtkWidget* 		ao_copy_file_path_get_menu_item	(AoCopyFilePath *self);
+
+G_END_DECLS
+
+#endif /* __AO_COPYFILEPATH_H__ */

--- a/addons/src/ao_wrapwords.c
+++ b/addons/src/ao_wrapwords.c
@@ -143,7 +143,7 @@ gboolean on_key_press (GtkWidget *widget, GdkEventKey *event, gpointer user_data
  * Loads the enclosing characters from the config file and sets keybindings.
  */
 
-void ao_enclose_words_init (gchar *config_file_name, GeanyKeyGroup *key_group)
+void ao_enclose_words_init (gchar *config_file_name, GeanyKeyGroup *key_group, gint ao_kb_count)
 {
 	GKeyFile *config = g_key_file_new();
 	gchar key_name[] = "Enclose_x";
@@ -152,14 +152,13 @@ void ao_enclose_words_init (gchar *config_file_name, GeanyKeyGroup *key_group)
 	config_file = g_strdup (config_file_name);
 	g_key_file_load_from_file (config, config_file, G_KEY_FILE_NONE, NULL);
 
-	for (i = 0; i < 8; i++)
+	for (i = 0; i < AO_WORDWRAP_KB_COUNT; i++)
 	{
 		key_name [8] = (gchar) (i + '0');
 		enclose_chars [i] = utils_get_setting_string (config, "addons", key_name, "  ");
 		key_name [8] = (gchar) ((i + 1) + '0');
-		keybindings_set_item (key_group, i+4, (GeanyKeyCallback) enclose_text_action, 0, 0, key_name,
-			key_name, NULL);
-
+		keybindings_set_item (key_group, i + ao_kb_count,
+			(GeanyKeyCallback) enclose_text_action, 0, 0, key_name, key_name, NULL);
 	}
 
 	g_key_file_free(config);

--- a/addons/src/ao_wrapwords.h
+++ b/addons/src/ao_wrapwords.h
@@ -20,8 +20,9 @@
 #ifndef __AO_WRAPWORDS_H__
 #define __AO_WRAPWORDS_H__
 
+#define AO_WORDWRAP_KB_COUNT 8
 
-void ao_enclose_words_init(gchar *, GeanyKeyGroup *);
+void ao_enclose_words_init(gchar *, GeanyKeyGroup *, gint);
 void ao_enclose_words_config(GtkButton *, GtkWidget *);
 void ao_enclose_words_set_enabled(gboolean, gboolean);
 

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -10,6 +10,7 @@ addons/src/ao_xmltagging.c
 addons/src/ao_openuri.c
 addons/src/ao_wrapwords.c
 addons/src/ao_doclist.c
+addons/src/ao_copyfilepath.c
 addons/src/addons.c
 
 # Autoclose


### PR DESCRIPTION
This little addon allows the user to easily copy the current document's
full file path to the clipboard in order to use it elsewhere, e.g.
to paste it into a terminal or similar.
The addon provides a menu item in the Tools menu and a
new keybinding.


This is a feature I personally often wished and also got reports
from users who wish this feature.
There is no configuration as this feature is that trivial and small.