### PR TITLE
[GeanyVC] use compatible gtkspell on building for gtk3

### DIFF
--- a/build/geanyvc.m4
+++ b/build/geanyvc.m4
@@ -6,12 +6,13 @@ AC_DEFUN([GP_CHECK_GEANYVC],
         AC_HELP_STRING([--enable-gtkspell=ARG],
             [Enable GtkSpell support in GeanyVC. [[default=auto]]]),,
         enable_gtkspell=auto)
-
+    GP_CHECK_GTK3([gtkspell_package=gtkspell3-3.0],
+                  [gtkspell_package=gtkspell-2.0])
     if [[ x"$enable_gtkspell" = "xauto" ]]; then
-        PKG_CHECK_MODULES(GTKSPELL, gtkspell-2.0,
+        PKG_CHECK_MODULES(GTKSPELL, $gtkspell_package,
             enable_gtkspell=yes, enable_gtkspell=no)
     elif [[ x"$enable_gtkspell" = "xyes" ]]; then
-        PKG_CHECK_MODULES(GTKSPELL, [gtkspell-2.0])
+        PKG_CHECK_MODULES(GTKSPELL, [$gtkspell_package])
     fi
     if [[ x"$enable_gtkspell" = "xyes" ]]; then
         AC_DEFINE(USE_GTKSPELL, 1, [GtkSpell support])

--- a/geanyvc/src/geanyvc.c
+++ b/geanyvc/src/geanyvc.c
@@ -1598,14 +1598,16 @@ vccommit_activated(G_GNUC_UNUSED GtkMenuItem * menuitem, G_GNUC_UNUSED gpointer 
     #endif
 	if (speller == NULL)
 	{
-		ui_set_statusbar(FALSE, _("Error initializing spell checking: %s"),
+        if (spellcheck_error != NULL)
+		{
+            ui_set_statusbar(FALSE, _("Error initializing spell checking: %s"),
 				 spellcheck_error->message);
-		g_error_free(spellcheck_error);
-		spellcheck_error = NULL;
+            g_error_free(spellcheck_error);
+            spellcheck_error = NULL;
+        }
 	}
 	else if (!EMPTY(lang))
 	{
-
 		gtkspell_set_language(speller, lang, &spellcheck_error);
 		if (spellcheck_error != NULL)
 		{

--- a/geanyvc/src/geanyvc.c
+++ b/geanyvc/src/geanyvc.c
@@ -1528,6 +1528,10 @@ vccommit_activated(G_GNUC_UNUSED GtkMenuItem * menuitem, G_GNUC_UNUSED gpointer 
 	gint height;
 
 #ifdef USE_GTKSPELL
+#if GTK_CHECK_VERSION (3, 0, 0)
+    #define GtkSpell GtkSpellChecker
+    #define gtkspell_set_language gtk_spell_checker_set_language
+#endif
 	GtkSpell *speller = NULL;
 	GError *spellcheck_error = NULL;
 #endif
@@ -1586,7 +1590,12 @@ vccommit_activated(G_GNUC_UNUSED GtkMenuItem * menuitem, G_GNUC_UNUSED gpointer 
 	gtk_paned_set_position(GTK_PANED(vpaned2), height * 50 / 100);
 
 #ifdef USE_GTKSPELL
-	speller = gtkspell_new_attach(GTK_TEXT_VIEW(messageView), NULL, &spellcheck_error);
+    #if GTK_CHECK_VERSION (3, 0, 0)
+        speller = gtk_spell_checker_new ();
+        gtk_spell_checker_attach (speller, GTK_TEXT_VIEW (messageView));
+    #else
+        speller = gtkspell_new_attach(GTK_TEXT_VIEW(messageView), NULL, &spellcheck_error);
+    #endif
 	if (speller == NULL)
 	{
 		ui_set_statusbar(FALSE, _("Error initializing spell checking: %s"),
@@ -1596,6 +1605,7 @@ vccommit_activated(G_GNUC_UNUSED GtkMenuItem * menuitem, G_GNUC_UNUSED gpointer 
 	}
 	else if (!EMPTY(lang))
 	{
+
 		gtkspell_set_language(speller, lang, &spellcheck_error);
 		if (spellcheck_error != NULL)
 		{

--- a/geanyvc/src/geanyvc.c
+++ b/geanyvc/src/geanyvc.c
@@ -39,6 +39,25 @@
 
 #ifdef USE_GTKSPELL
 #include <gtkspell/gtkspell.h>
+/* forward compatibility with GtkSpell3 */
+#if GTK_CHECK_VERSION(3, 0, 0)
+#define GtkSpell GtkSpellChecker
+#define gtkspell_set_language gtk_spell_checker_set_language
+static GtkSpell *gtkspell_new_attach(GtkTextView *view, const gchar *lang, GError **error)
+{
+       GtkSpellChecker *speller = gtk_spell_checker_new();
+
+       if (! lang || gtk_spell_checker_set_language(speller, lang, error))
+               gtk_spell_checker_attach(speller, view);
+       else
+       {
+               g_object_unref(g_object_ref_sink(speller));
+               speller = NULL;
+       }
+
+       return speller;
+}
+#endif
 #endif
 
 GeanyData *geany_data;
@@ -1528,12 +1547,7 @@ vccommit_activated(G_GNUC_UNUSED GtkMenuItem * menuitem, G_GNUC_UNUSED gpointer 
 	gint height;
 
 #ifdef USE_GTKSPELL
-#if !GTK_CHECK_VERSION (3, 0, 0)
-//Since gtk3 will be default in future may be going this way would be better.
-    #define GtkSpellSpellChecker GtkSpell
-    #define gtk_spell_checker_set_language gtkspell_set_language
-#endif
-	GtkSpellChecker *speller = NULL;
+	GtkSpell *speller = NULL;
 	GError *spellcheck_error = NULL;
 #endif
 
@@ -1591,34 +1605,13 @@ vccommit_activated(G_GNUC_UNUSED GtkMenuItem * menuitem, G_GNUC_UNUSED gpointer 
 	gtk_paned_set_position(GTK_PANED(vpaned2), height * 50 / 100);
 
 #ifdef USE_GTKSPELL
-    #if GTK_CHECK_VERSION (3, 0, 0)
-        speller = gtk_spell_checker_new ();
-        gtk_spell_checker_attach (speller, GTK_TEXT_VIEW (messageView));
-    #else
-        speller = gtkspell_new_attach(GTK_TEXT_VIEW(messageView), NULL, &spellcheck_error);
-    #endif
-	if (speller == NULL)
+    speller = gtkspell_new_attach(GTK_TEXT_VIEW(messageView), lang, &spellcheck_error);
+	if (speller == NULL && spellcheck_error != NULL)
 	{
-        if (spellcheck_error != NULL)
-		{
-            ui_set_statusbar(FALSE, _("Error initializing spell checking: %s"),
-				 spellcheck_error->message);
+        ui_set_statusbar(TRUE, _("Error initializing spell checking: %s"),
+                spellcheck_error->message);
             g_error_free(spellcheck_error);
             spellcheck_error = NULL;
-        }
-	}
-	else if (!EMPTY(lang))
-	{
-		gtk_spell_checker_set_language(speller, lang, &spellcheck_error);
-		if (spellcheck_error != NULL)
-		{
-			ui_set_statusbar(TRUE,
-					 _
-					 ("Error while setting up language for spellchecking. Please check configuration. Error message was: %s"),
-					 spellcheck_error->message);
-			g_error_free(spellcheck_error);
-			spellcheck_error = NULL;
-		}
 	}
 #endif
 

--- a/geanyvc/src/geanyvc.c
+++ b/geanyvc/src/geanyvc.c
@@ -1528,11 +1528,12 @@ vccommit_activated(G_GNUC_UNUSED GtkMenuItem * menuitem, G_GNUC_UNUSED gpointer 
 	gint height;
 
 #ifdef USE_GTKSPELL
-#if GTK_CHECK_VERSION (3, 0, 0)
-    #define GtkSpell GtkSpellChecker
-    #define gtkspell_set_language gtk_spell_checker_set_language
+#if !GTK_CHECK_VERSION (3, 0, 0)
+//Since gtk3 will be default in future may be going this way would be better.
+    #define GtkSpellSpellChecker GtkSpell
+    #define gtk_spell_checker_set_language gtkspell_set_language
 #endif
-	GtkSpell *speller = NULL;
+	GtkSpellChecker *speller = NULL;
 	GError *spellcheck_error = NULL;
 #endif
 
@@ -1608,7 +1609,7 @@ vccommit_activated(G_GNUC_UNUSED GtkMenuItem * menuitem, G_GNUC_UNUSED gpointer 
 	}
 	else if (!EMPTY(lang))
 	{
-		gtkspell_set_language(speller, lang, &spellcheck_error);
+		gtk_spell_checker_set_language(speller, lang, &spellcheck_error);
 		if (spellcheck_error != NULL)
 		{
 			ui_set_statusbar(TRUE,


### PR DESCRIPTION
When building against gtk3 the gtkspell support was missing for geanyvc plugin commit dialog box.