### PR TITLE
geanyinsertnum: Drop use of the most obvious deprecated Geany API

### DIFF
--- a/geanyinsertnum/src/insertnum.c
+++ b/geanyinsertnum/src/insertnum.c
@@ -309,7 +309,7 @@ static void set_entry(GtkWidget *entry, gint maxlen, GtkWidget *label, const gch
 	gtk_entry_set_max_length(GTK_ENTRY(entry), maxlen);
 	gtk_entry_set_activates_default(GTK_ENTRY(entry), TRUE);
 	gtk_label_set_mnemonic_widget(GTK_LABEL(label), entry);
-	ui_widget_set_tooltip_text(entry, tooltip);
+	gtk_widget_set_tooltip_text(entry, tooltip);
 }
 
 #if !GTK_CHECK_VERSION(3, 0, 0)
@@ -376,20 +376,20 @@ static void on_insert_numbers_activate(G_GNUC_UNUSED GtkMenuItem *menuitem, G_GN
 	gtk_table_attach(grid, GTK_WIDGET(combo), 1, 3, 1, 2, GTK_EXPAND | GTK_FILL, 0, 0, 0);
 #endif
 	label = gtk_label_new(_("Letters:"));
-	ui_widget_set_tooltip_text(label, case_tip);
+	gtk_widget_set_tooltip_text(label, case_tip);
 	gtk_grid_attach(grid, label, 3, 1, 1, 1);
 	upper = gtk_radio_button_new_with_mnemonic(NULL, _("_Upper"));
-	ui_widget_set_tooltip_text(upper, case_tip);
+	gtk_widget_set_tooltip_text(upper, case_tip);
 	gtk_grid_attach(grid, upper, 4, 1, 1, 1);
 	d.lower = gtk_radio_button_new_from_widget(GTK_RADIO_BUTTON(upper));
-	ui_widget_set_tooltip_text(label, case_tip);
+	gtk_widget_set_tooltip_text(label, case_tip);
 	label = gtk_label_new_with_mnemonic(_("_Lower"));
-	ui_widget_set_tooltip_text(label, case_tip);
+	gtk_widget_set_tooltip_text(label, case_tip);
 	gtk_container_add(GTK_CONTAINER(d.lower), label);
 	gtk_grid_attach(grid, d.lower, 5, 1, 1, 1);
 
 	d.prefix = gtk_check_button_new_with_mnemonic(_("Base _prefix"));
-	ui_widget_set_tooltip_text(d.prefix,
+	gtk_widget_set_tooltip_text(d.prefix,
 		_("0 for octal, 0x for hex, + for positive decimal"));
 	gtk_grid_attach(grid, d.prefix, 1, 2, 2, 1);
 	label = gtk_label_new(_("Padding:"));


### PR DESCRIPTION
Not really tested, but should not be a big deal as it's only `s/ui_widget_set_tooltip_text/gtk_widget_set_tooltip_text/`, which are synonyms nowadays.