### PR TITLE
geanypy: Drop use of the most obvious deprecated Geany API

### DIFF
--- a/geanypy/src/geanypy-document.c
+++ b/geanypy/src/geanypy-document.c
@@ -187,14 +187,14 @@ Document_close(Document *self)
 
 
 static PyObject*
-Document_reload_file(Document *self, PyObject *args, PyObject *kwargs)
+Document_reload_force(Document *self, PyObject *args, PyObject *kwargs)
 {
 	gchar *forced_enc = NULL;
 	static gchar *kwlist[] = { "forced_enc", NULL };
 
 	if (PyArg_ParseTupleAndKeywords(args, kwargs, "|z", kwlist, &forced_enc))
 	{
-		if (document_reload_file(self->doc, forced_enc))
+		if (document_reload_force(self->doc, forced_enc))
 			Py_RETURN_TRUE;
 		else
 			Py_RETURN_FALSE;
@@ -269,7 +269,11 @@ Document_save_file_as(Document *self, PyObject *args, PyObject *kwargs)
 static PyMethodDef Document_methods[] = {
 	{ "close",				(PyCFunction)Document_close, 		METH_NOARGS,
 		"Closes the document." },
-	{ "reload_file",		(PyCFunction)Document_reload_file,	METH_KEYWORDS,
+	/* Geany deprecated alias */
+	{ "reload_file",		(PyCFunction)Document_reload_force,	METH_KEYWORDS,
+		"Reloads the document with the specified file encoding or None "
+		"to auto-detect the file encoding." },
+	{ "reload_force",		(PyCFunction)Document_reload_force,	METH_KEYWORDS,
 		"Reloads the document with the specified file encoding or None "
 		"to auto-detect the file encoding." },
 	{ "rename_file",		(PyCFunction)Document_rename_file,	METH_KEYWORDS,

--- a/geanypy/src/geanypy-uiutils.c
+++ b/geanypy/src/geanypy-uiutils.c
@@ -359,7 +359,7 @@ UiUtils_widget_set_tooltip_text(PyObject *module, PyObject *args, PyObject *kwar
 		GOB_CHECK(py_widget, 1);
 		widget = pygobject_get(py_widget);
 		GOB_TYPE_CHECK(widget, GTK_TYPE_WIDGET, 1);
-		ui_widget_set_tooltip_text(GTK_WIDGET(widget), text);
+		gtk_widget_set_tooltip_text(GTK_WIDGET(widget), text);
 	}
 
 	Py_RETURN_NONE;


### PR DESCRIPTION
Also introduce the Document.reload_force() alias to Document.reload_file(), as per non-deprecated Geany API.

@codebrainz @elextr 