### PR TITLE
projectorganizer: Drop use of the most obvious deprecated Geany API

### DIFF
--- a/projectorganizer/src/prjorg-project.c
+++ b/projectorganizer/src/prjorg-project.c
@@ -577,7 +577,7 @@ gint prjorg_project_add_properties_tab(GtkWidget *notebook)
 	e->source_patterns = gtk_entry_new();
 	ui_table_add_row(GTK_TABLE(table), 0, label, e->source_patterns, NULL);
 	ui_entry_add_clear_icon(GTK_ENTRY(e->source_patterns));
-	ui_widget_set_tooltip_text(e->source_patterns,
+	gtk_widget_set_tooltip_text(e->source_patterns,
 		_("Space separated list of patterns that are used to identify source files. "
 		  "Used for header/source swapping."));
 	str = g_strjoinv(" ", prj_org->source_patterns);
@@ -589,7 +589,7 @@ gint prjorg_project_add_properties_tab(GtkWidget *notebook)
 	e->header_patterns = gtk_entry_new();
 	ui_entry_add_clear_icon(GTK_ENTRY(e->header_patterns));
 	ui_table_add_row(GTK_TABLE(table), 1, label, e->header_patterns, NULL);
-	ui_widget_set_tooltip_text(e->header_patterns,
+	gtk_widget_set_tooltip_text(e->header_patterns,
 		_("Space separated list of patterns that are used to identify headers. "
 		  "Used for header/source swapping."));
 	str = g_strjoinv(" ", prj_org->header_patterns);
@@ -601,7 +601,7 @@ gint prjorg_project_add_properties_tab(GtkWidget *notebook)
 	e->ignored_file_patterns = gtk_entry_new();
 	ui_entry_add_clear_icon(GTK_ENTRY(e->ignored_file_patterns));
 	ui_table_add_row(GTK_TABLE(table), 2, label, e->ignored_file_patterns, NULL);
-	ui_widget_set_tooltip_text(e->ignored_file_patterns,
+	gtk_widget_set_tooltip_text(e->ignored_file_patterns,
 		_("Space separated list of patterns that are used to identify files "
 		  "that are not displayed in the project tree."));
 	str = g_strjoinv(" ", prj_org->ignored_file_patterns);
@@ -613,7 +613,7 @@ gint prjorg_project_add_properties_tab(GtkWidget *notebook)
 	e->ignored_dirs_patterns = gtk_entry_new();
 	ui_entry_add_clear_icon(GTK_ENTRY(e->ignored_dirs_patterns));
 	ui_table_add_row(GTK_TABLE(table), 3, label, e->ignored_dirs_patterns, NULL);
-	ui_widget_set_tooltip_text(e->ignored_dirs_patterns,
+	gtk_widget_set_tooltip_text(e->ignored_dirs_patterns,
 		_("Space separated list of patterns that are used to identify directories "
 		  "that are not scanned for source files."));
 	str = g_strjoinv(" ", prj_org->ignored_dirs_patterns);
@@ -628,7 +628,7 @@ gint prjorg_project_add_properties_tab(GtkWidget *notebook)
 	gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(e->generate_tag_prefs), _("No"));
 	gtk_combo_box_set_active(GTK_COMBO_BOX(e->generate_tag_prefs), prj_org->generate_tag_prefs);
 	ui_table_add_row(GTK_TABLE(table), 4, label, e->generate_tag_prefs, NULL);
-	ui_widget_set_tooltip_text(e->generate_tag_prefs,
+	gtk_widget_set_tooltip_text(e->generate_tag_prefs,
 		_("Generate symbol list for all project files instead of only for the currently opened files. "
 		  "Might be slow for big projects."));
 

--- a/projectorganizer/src/prjorg-sidebar.c
+++ b/projectorganizer/src/prjorg-sidebar.c
@@ -1270,7 +1270,7 @@ void prjorg_sidebar_init(void)
 
 	item = GTK_WIDGET(gtk_tool_button_new(NULL, NULL));
 	gtk_tool_button_set_icon_name (GTK_TOOL_BUTTON(item), "prjorg-refresh");
-	ui_widget_set_tooltip_text(item, _("Reload all"));
+	gtk_widget_set_tooltip_text(item, _("Reload all"));
 	g_signal_connect(item, "clicked", G_CALLBACK(on_reload_project), NULL);
 	gtk_container_add(GTK_CONTAINER(s_toolbar), item);
 
@@ -1279,7 +1279,7 @@ void prjorg_sidebar_init(void)
 
 	item = GTK_WIDGET(gtk_tool_button_new(NULL, NULL));
 	gtk_tool_button_set_icon_name (GTK_TOOL_BUTTON(item), "prjorg-add-external");
-	ui_widget_set_tooltip_text(item, _("Add external directory"));
+	gtk_widget_set_tooltip_text(item, _("Add external directory"));
 	g_signal_connect(item, "clicked", G_CALLBACK(on_add_external), NULL);
 	gtk_container_add(GTK_CONTAINER(s_toolbar), item);
 	s_project_toolbar.add = item;
@@ -1289,14 +1289,14 @@ void prjorg_sidebar_init(void)
 
 	item = GTK_WIDGET(gtk_tool_button_new(NULL, NULL));
 	gtk_tool_button_set_icon_name (GTK_TOOL_BUTTON(item), "prjorg-expand");
-	ui_widget_set_tooltip_text(item, _("Expand all"));
+	gtk_widget_set_tooltip_text(item, _("Expand all"));
 	g_signal_connect(item, "clicked", G_CALLBACK(on_expand_all), NULL);
 	gtk_container_add(GTK_CONTAINER(s_toolbar), item);
 	s_project_toolbar.expand = item;
 
 	item = GTK_WIDGET(gtk_tool_button_new(NULL, NULL));
 	gtk_tool_button_set_icon_name (GTK_TOOL_BUTTON(item), "prjorg-collapse");
-	ui_widget_set_tooltip_text(item, _("Collapse to project root"));
+	gtk_widget_set_tooltip_text(item, _("Collapse to project root"));
 	g_signal_connect(item, "clicked", G_CALLBACK(on_collapse_all), NULL);
 	gtk_container_add(GTK_CONTAINER(s_toolbar), item);
 	s_project_toolbar.collapse = item;
@@ -1307,7 +1307,7 @@ void prjorg_sidebar_init(void)
 	item = GTK_WIDGET(gtk_toggle_tool_button_new());
 	gtk_toggle_tool_button_set_active(GTK_TOGGLE_TOOL_BUTTON(item), TRUE);
 	gtk_tool_button_set_icon_name (GTK_TOOL_BUTTON(item), "prjorg-follow");
-	ui_widget_set_tooltip_text(item, _("Follow active editor"));
+	gtk_widget_set_tooltip_text(item, _("Follow active editor"));
 	g_signal_connect(item, "clicked", G_CALLBACK(on_follow_active), NULL);
 	gtk_container_add(GTK_CONTAINER(s_toolbar), item);
 	s_project_toolbar.follow = item;


### PR DESCRIPTION
Not thoroughly tested but should be quite straightforward