### PR TITLE
Shiftcolumn: Geany deprecation fixes + a simple fix

### DIFF
--- a/shiftcolumn/src/shiftcolumn.c
+++ b/shiftcolumn/src/shiftcolumn.c
@@ -123,6 +123,7 @@ static void shift_left_cb(G_GNUC_UNUSED GtkMenuItem *menuitem,
 
          /* put the new text in */
          sci_set_selection_start(sci, startpos - 1);
+         sci_set_selection_end(sci, endpos);
          sci_replace_sel(sci, txt);
 
          /* select the right bit again */
@@ -261,6 +262,7 @@ static void shift_right_cb(G_GNUC_UNUSED GtkMenuItem *menuitem,
          sci_start_undo_action(sci);
 
          /* put the new text in */
+         sci_set_selection_start(sci, startpos);
          sci_set_selection_end(sci, endpos + 1);
          sci_replace_sel(sci, txt);
 

--- a/shiftcolumn/src/shiftcolumn.c
+++ b/shiftcolumn/src/shiftcolumn.c
@@ -60,7 +60,6 @@ enum{
    KB_SHIFT_RIGHT,
    KB_COUNT
    };
-PLUGIN_KEY_GROUP(shiftcolumn, KB_COUNT)
 
 
 static void shift_left_cb(G_GNUC_UNUSED GtkMenuItem *menuitem,
@@ -68,7 +67,6 @@ static void shift_left_cb(G_GNUC_UNUSED GtkMenuItem *menuitem,
    gchar *txt;
    gchar *txt_i;
    gchar char_before;
-   gint txt_len;
 
    gint startpos;
    gint endpos;
@@ -113,15 +111,12 @@ static void shift_left_cb(G_GNUC_UNUSED GtkMenuItem *menuitem,
       if(startline == endline){
 
          /* get the text in question */
-         txt_len = endpos - startpos;
-         txt_i = g_malloc(txt_len + 1);
-         txt = g_malloc(txt_len + 2);
-         sci_get_selected_text(sci, txt_i);
+         txt_i = sci_get_selection_contents(sci);
 
          char_before = sci_get_char_at(sci, startpos - 1);
 
          /* set up new text buf */
-         (void) g_sprintf(txt, "%s%c", txt_i, char_before);
+         txt = g_strdup_printf("%s%c", txt_i, char_before);
 
          /* start undo */
          sci_start_undo_action(sci);
@@ -182,15 +177,11 @@ static void shift_left_cb(G_GNUC_UNUSED GtkMenuItem *menuitem,
                sci_set_selection_start(sci, linepos + startcol);
                sci_set_selection_end(sci, linepos + endcol);
 
-               txt_len = sci_get_selected_text_length(sci);
-               txt_i = g_malloc(txt_len + 1);
-               txt = g_malloc(txt_len + 2);
-
-               sci_get_selected_text(sci, txt_i);
+               txt_i = sci_get_selection_contents(sci);
                char_before = sci_get_char_at(sci, linepos + startcol - 1);
 
                /* set up new text buf */
-               (void) g_sprintf(txt, "%s%c", txt_i, char_before);
+               txt = g_strdup_printf("%s%c", txt_i, char_before);
 
                /* put the new text in */
                sci_set_selection_start(sci, linepos + startcol - 1);
@@ -219,7 +210,6 @@ static void shift_right_cb(G_GNUC_UNUSED GtkMenuItem *menuitem,
    gchar *txt;
    gchar *txt_i;
    gchar char_after;
-   gint txt_len;
 
    gint startpos;
    gint endpos;
@@ -260,15 +250,12 @@ static void shift_right_cb(G_GNUC_UNUSED GtkMenuItem *menuitem,
       if(startline == endline){
 
          /* get the text in question */
-         txt_len = endpos - startpos;
-         txt_i = g_malloc(txt_len + 1);
-         txt = g_malloc(txt_len + 2);
-         sci_get_selected_text(sci, txt_i);
+         txt_i = sci_get_selection_contents(sci);
 
          char_after = sci_get_char_at(sci, endpos);
 
          /* set up new text buf */
-         (void) g_sprintf(txt, "%c%s", char_after, txt_i);
+         txt = g_strdup_printf("%c%s", char_after, txt_i);
 
          /* start undo */
          sci_start_undo_action(sci);
@@ -319,15 +306,11 @@ static void shift_right_cb(G_GNUC_UNUSED GtkMenuItem *menuitem,
                   sci_set_selection_start(sci, linepos + startcol);
                   sci_set_selection_end(sci, linepos + endcol);
 
-                  txt_len = sci_get_selected_text_length(sci);
-                  txt_i = g_malloc(txt_len + 1);
-                  txt = g_malloc(txt_len + 2);
-
-                  sci_get_selected_text(sci, txt_i);
+                  txt_i = sci_get_selection_contents(sci);
                   char_after = sci_get_char_at(sci, linepos + endcol);
 
                   /* set up new text buf */
-                  (void) g_sprintf(txt, "%c%s", char_after, txt_i);
+                  txt = g_strdup_printf("%c%s", char_after, txt_i);
 
                   /* put the new text in */
                   sci_set_selection_end(sci, linepos + endcol + 1);
@@ -373,6 +356,7 @@ static void kb_shift_right(G_GNUC_UNUSED guint key_id){
    }
 
 void plugin_init(G_GNUC_UNUSED GeanyData *data){
+   GeanyKeyGroup *key_group;
 
    /* init gettext and friends */
    main_locale_init(LOCALEDIR, GETTEXT_PACKAGE);
@@ -396,9 +380,10 @@ void plugin_init(G_GNUC_UNUSED GeanyData *data){
    ui_add_document_sensitive(menu_item_shift_left);
 
    /* setup keybindings */
-   keybindings_set_item(plugin_key_group, KB_SHIFT_LEFT, kb_shift_left,
+   key_group = plugin_set_key_group(geany_plugin, "shiftcolumn", KB_COUNT, NULL);
+   keybindings_set_item(key_group, KB_SHIFT_LEFT, kb_shift_left,
       0, GDK_CONTROL_MASK, "shift_left", _("Shift Left"), menu_item_shift_left);
-   keybindings_set_item(plugin_key_group, KB_SHIFT_RIGHT, kb_shift_right,
+   keybindings_set_item(key_group, KB_SHIFT_RIGHT, kb_shift_right,
       0, GDK_CONTROL_MASK, "shift_right", _("Shift Right"), menu_item_shift_right);
    }
 


### PR DESCRIPTION
Quickly tested.

Rectangular selection handling is still broken, but nothing different than before the patches.