### PR TITLE
Use GLib error reporting/logging instead of fprintf()

### DIFF
--- a/geanypg/src/Makefile.am
+++ b/geanypg/src/Makefile.am
@@ -21,5 +21,7 @@ geanypg_la_LIBADD = \
 geanypg_la_CFLAGS = \
 	$(AM_CFLAGS) \
 	$(GPGME_CFLAGS)
+geanypg_la_CPPFLAGS = $(AM_CPPFLAGS) \
+                      -DG_LOG_DOMAIN=\"GeanyPG\"
 
 include $(top_srcdir)/build/cppcheck.mk

--- a/geanypg/src/decrypt_cb.c
+++ b/geanypg/src/decrypt_cb.c
@@ -30,7 +30,7 @@ static void geanypg_decrypt_verify(encrypt_data * ed)
     tempfile = tmpfile();
     if (!(tempfile))
     {
-        fprintf(stderr, "GeanyPG: %s: %s.\n", _("couldn't create tempfile"), strerror(errno));
+        g_warning("%s: %s.", _("couldn't create tempfile"), strerror(errno));
         return ;
     }
     gpgme_data_new_from_stream(&plain, tempfile);

--- a/geanypg/src/encrypt_cb.c
+++ b/geanypg/src/encrypt_cb.c
@@ -29,7 +29,7 @@ static void geanypg_encrypt(encrypt_data * ed, gpgme_key_t * recp, int sign, int
     tempfile = tmpfile();
     if (!(tempfile))
     {
-        fprintf(stderr, "GeanyPG: %s: %s.\n", _("couldn't create tempfile"), strerror(errno));
+        g_warning("%s: %s.", _("couldn't create tempfile"), strerror(errno));
         return ;
     }
     gpgme_data_new_from_stream(&cipher, tempfile);

--- a/geanypg/src/geanypg.c
+++ b/geanypg/src/geanypg.c
@@ -44,8 +44,7 @@ static gpgme_error_t geanypg_init_gpgme(void)
 {
     /* Initialize the locale environment. */
     setlocale(LC_ALL, "");
-    fprintf(stderr, "GeanyPG: %s %s\n", _("Using libgpgme version:"),
-            gpgme_check_version("1.1.0"));
+    g_message("%s %s", _("Using libgpgme version:"), gpgme_check_version("1.1.0"));
     gpgme_set_locale(NULL, LC_CTYPE, setlocale(LC_CTYPE, NULL));
 #ifdef LC_MESSAGES /* only necessary for portability to W32 systems */
     gpgme_set_locale(NULL, LC_MESSAGES, setlocale(LC_MESSAGES, NULL));
@@ -58,7 +57,7 @@ gpgme_error_t geanypg_show_err_msg(gpgme_error_t err)
     gchar const * msg = (gchar const *)gpgme_strerror(err);
     gchar const * src = (gchar const *)gpgme_strsource(err);
     dialogs_show_msgbox(GTK_MESSAGE_ERROR, "%s %s: %s\n", _("Error from"), src, msg);
-    fprintf(stderr, "GeanyPG: %s %s: %s\n", _("Error from"), msg, src);
+    g_warning("%s %s: %s", _("Error from"), msg, src);
     return err;
 }
 

--- a/geanypg/src/pinentry.c
+++ b/geanypg/src/pinentry.c
@@ -83,12 +83,12 @@ gpgme_error_t geanypg_passphrase_cb(void * hook,
 
     if (pipe(outpipe))
     {
-        fprintf(stderr, "GeanyPG: %s\n", strerror(errno));
+        g_warning("%s", strerror(errno));
         return gpgme_error_from_errno(errno);
     }
     if (pipe(inpipe))
     {
-        fprintf(stderr, "GeanyPG: %s\n", strerror(errno));
+        g_warning("%s", strerror(errno));
         return gpgme_error_from_errno(errno);
     }
 
@@ -108,7 +108,7 @@ gpgme_error_t geanypg_passphrase_cb(void * hook,
 
         execvp(*argv, argv);
         /* shouldn't get here */
-        fprintf(stderr, "GeanyPG: %s\n%s\n", _("Could not use pinentry."), strerror(errno));
+        g_warning("%s: %s", _("Could not use pinentry."), strerror(errno));
         exit(1); /* kill the child */
     }
     /* GeanpyPG */
@@ -120,7 +120,7 @@ gpgme_error_t geanypg_passphrase_cb(void * hook,
     geanypg_read(outpipe[READ], ' ', 2049, readbuffer);
     if (strncmp(readbuffer, "OK", 3))
     {
-        fprintf(stderr, "GeanyPG: %s\n", _("Unexpected output from pinentry."));
+        g_warning(_("Unexpected output from pinentry."));
         fclose(childin);
         waitpid(childpid, &status, 0);
         close(outpipe[READ]);
@@ -168,10 +168,10 @@ gpgme_error_t geanypg_passphrase_cb(void * hook,
             geanypg_read(outpipe[READ], ' ', 2049, readbuffer);
             sscanf(readbuffer, "%lu", &errval);
             geanypg_read(outpipe[READ], '\n', 2049, readbuffer);
-            fprintf(stderr, "GeanyPG: %s %lu %s\n", _("pinentry gave error"), errval, readbuffer);
+            g_warning("%s %lu %s", _("pinentry gave error"), errval, readbuffer);
         }
         else
-            fprintf(stderr, "GeanyPG: %s\n", _("Unexpected error from pinentry."));
+            g_warning(_("Unexpected error from pinentry."));
         fclose(childin);
         waitpid(childpid, &status, 0);
         close(outpipe[READ]);

--- a/geanypg/src/sign_cb.c
+++ b/geanypg/src/sign_cb.c
@@ -30,7 +30,7 @@ static void geanypg_sign(encrypt_data * ed)
     tempfile = tmpfile();
     if (!(tempfile))
     {
-        fprintf(stderr, "GeanyPG: %s: %s\n", _("couldn't create tempfile"), strerror(errno));
+        g_warning("%s: %s", _("couldn't create tempfile"), strerror(errno));
         return ;
     }
     gpgme_data_new_from_stream(&cipher, tempfile);

--- a/geanypg/src/verify_aux.c
+++ b/geanypg/src/verify_aux.c
@@ -176,7 +176,7 @@ void geanypg_handle_signatures(encrypt_data * ed, int need_error)
     }
     if (!verified && need_error)
     {
-        fprintf(stderr, "GeanyPG: %s\n", _("Could not find verification results"));
+        g_warning(_("Could not find verification results"));
         dialogs_show_msgbox(GTK_MESSAGE_ERROR, _("Error, could not find verification results"));
     }
 }


### PR DESCRIPTION
This makes logging and error reporting in the plugin more consistent
with other plugins and Geany.
Also set the G_LOG_DOMAIN for the plugin in order to have proper
log messages.