### PR TITLE
Set G_LOG_DOMAIN for proper GLib error reporting/logging

### DIFF
--- a/geanypy/src/Makefile.am
+++ b/geanypy/src/Makefile.am
@@ -6,7 +6,8 @@ geanyplugindir				=	$(libdir)/geany
 geanypy_la_LDFLAGS			=	-module -avoid-version -Wl,--export-dynamic
 geanypy_la_CPPFLAGS			=	@GEANY_CFLAGS@ @PYGTK_CFLAGS@ @PYTHON_CPPFLAGS@ \
 								-DGEANYPY_PYTHON_DIR="\"$(libdir)/geany/geanypy\"" \
-								-DGEANYPY_PLUGIN_DIR="\"$(datadir)/geany/geanypy/plugins\""
+								-DGEANYPY_PLUGIN_DIR="\"$(datadir)/geany/geanypy/plugins\"" \
+								-DG_LOG_DOMAIN=\"GeanyPy\"
 geanypy_la_CFLAGS			=	@GEANYPY_CFLAGS@ @GMODULE_CFLAGS@
 geanypy_la_LIBADD			=	@GEANY_LIBS@ @PYGTK_LIBS@ \
 								$(PYTHON_LDFLAGS) $(PYTHON_LIBS) \


### PR DESCRIPTION
This turns messages like:
```
** INFO: User plugins: /home/enrico/tmp/geany_conf/plugins/geanypy/plugins
** INFO: System plugins: /home/enrico/apps/share/geany/geanypy/plugins
```
into
```
GeanyPy-INFO: User plugins: /home/enrico/tmp/geany_conf/plugins/geanypy/plugins
GeanyPy-INFO: System plugins: /home/enrico/apps/share/geany/geanypy/plugins
```