### PR TITLE
Define G_LOG_DOMAIN for all plugins where it is missing

### DIFF
--- a/autoclose/src/Makefile.am
+++ b/autoclose/src/Makefile.am
@@ -3,6 +3,7 @@ include $(top_srcdir)/build/vars.build.mk
 geanyplugins_LTLIBRARIES = autoclose.la
 
 autoclose_la_SOURCES = autoclose.c
+autoclose_la_CPPFLAGS = $(AM_CPPFLAGS) -DG_LOG_DOMAIN=\"AutoClose\"
 autoclose_la_LIBADD = $(COMMONLIBS)
 
 include $(top_srcdir)/build/cppcheck.mk

--- a/automark/src/Makefile.am
+++ b/automark/src/Makefile.am
@@ -3,6 +3,7 @@ include $(top_srcdir)/build/vars.build.mk
 geanyplugins_LTLIBRARIES = automark.la
 
 automark_la_SOURCES = automark.c
+automark_la_CPPFLAGS = $(AM_CPPFLAGS) -DG_LOG_DOMAIN=\"AutoMark\"
 automark_la_LIBADD = $(COMMONLIBS)
 
 include $(top_srcdir)/build/cppcheck.mk

--- a/codenav/src/Makefile.am
+++ b/codenav/src/Makefile.am
@@ -12,6 +12,7 @@ codenav_la_SOURCES = \
 	utils.c \
 	utils.h
 
+codenav_la_CPPFLAGS = $(AM_CPPFLAGS) -DG_LOG_DOMAIN=\"CodeNavigation\"
 codenav_la_LIBADD = $(COMMONLIBS)
 
 

--- a/debugger/src/Makefile.am
+++ b/debugger/src/Makefile.am
@@ -73,6 +73,7 @@ debugger_la_SOURCES = \
 
 debugger_la_LIBADD = $(COMMONLIBS) $(VTE_LIBS) -lutil
 debugger_la_CFLAGS = $(AM_CFLAGS) $(VTE_CFLAGS) -DDBGPLUG_DATA_DIR=\"$(plugindatadir)\" -DPLUGIN_NAME=\"$(plugin)\"
+debugger_la_CPPFLAGS = $(AM_CPPFLAGS) -DG_LOG_DOMAIN=\"Debugger\"
 
 check_PROGRAMS = gdb_mi_test
 dist_check_SCRIPTS = tests/gdb_mi_test.sh

--- a/defineformat/src/Makefile.am
+++ b/defineformat/src/Makefile.am
@@ -3,6 +3,7 @@ include $(top_srcdir)/build/vars.build.mk
 geanyplugins_LTLIBRARIES = defineformat.la
 
 defineformat_la_SOURCES = defineformat.c
+defineformat_la_CPPFLAGS = $(AM_CPPFLAGS) -DG_LOG_DOMAIN=\"DefineFormat\"
 defineformat_la_LIBADD = $(COMMONLIBS)
 
 include $(top_srcdir)/build/cppcheck.mk

--- a/devhelp/src/Makefile.am
+++ b/devhelp/src/Makefile.am
@@ -16,6 +16,7 @@ noinst_HEADERS = \
 	dhp.h \
 	dhp-plugin.h
 
+devhelp_la_CPPFLAGS = $(AM_CPPFLAGS) -DG_LOG_DOMAIN=\"Devhelp\"
 devhelp_la_CFLAGS = \
 	$(AM_CFLAGS) \
 	-I$(top_srcdir)/devhelp \

--- a/geanydoc/src/Makefile.am
+++ b/geanydoc/src/Makefile.am
@@ -7,7 +7,7 @@ geanydoc_la_SOURCES = \
 	geanydoc.c \
 	geanydoc.h
 
-geanydoc_la_CFLAGS = $(AM_CFLAGS)
+geanydoc_la_CPPFLAGS = $(AM_CPPFLAGS) -DG_LOG_DOMAIN=\"GeanyDoc\"
 geanydoc_la_LIBADD = $(COMMONLIBS)
 
 include $(top_srcdir)/build/cppcheck.mk

--- a/geanyextrasel/src/Makefile.am
+++ b/geanyextrasel/src/Makefile.am
@@ -3,6 +3,7 @@ include $(top_srcdir)/build/vars.build.mk
 geanyplugins_LTLIBRARIES = geanyextrasel.la
 
 geanyextrasel_la_SOURCES = extrasel.c
+geanyextrasel_la_CPPFLAGS = $(AM_CPPFLAGS) -DG_LOG_DOMAIN=\"ExtraSelection\"
 geanyextrasel_la_LIBADD = $(COMMONLIBS)
 
 include $(top_srcdir)/build/cppcheck.mk

--- a/geanyinsertnum/src/Makefile.am
+++ b/geanyinsertnum/src/Makefile.am
@@ -3,6 +3,7 @@ include $(top_srcdir)/build/vars.build.mk
 geanyplugins_LTLIBRARIES = geanyinsertnum.la
 
 geanyinsertnum_la_SOURCES = insertnum.c
+geanyinsertnum_la_CPPFLAGS = $(AM_CPPFLAGS) -DG_LOG_DOMAIN=\"InsertNum\"
 geanyinsertnum_la_LIBADD = $(COMMONLIBS)
 
 include $(top_srcdir)/build/cppcheck.mk

--- a/geanylatex/src/Makefile.am
+++ b/geanylatex/src/Makefile.am
@@ -29,6 +29,7 @@ geanylatex_la_SOURCES = \
 	latexkeybindings.c \
 	letters.h
 
+geanylatex_la_CPPFLAGS = $(AM_CPPFLAGS) -DG_LOG_DOMAIN=\"GeanyLaTeX\"
 geanylatex_la_LIBADD = $(COMMONLIBS)
 
 include $(top_srcdir)/build/cppcheck.mk

--- a/geanylipsum/src/Makefile.am
+++ b/geanylipsum/src/Makefile.am
@@ -3,6 +3,7 @@ include $(top_srcdir)/build/vars.build.mk
 geanyplugins_LTLIBRARIES = geanylipsum.la
 
 geanylipsum_la_SOURCES = geanylipsum.c
+geanylipsum_la_CPPFLAGS = $(AM_CPPFLAGS) -DG_LOG_DOMAIN=\"GeanyLipsum\"
 geanylipsum_la_LIBADD = $(COMMONLIBS)
 
 include $(top_srcdir)/build/cppcheck.mk

--- a/geanylua/Makefile.am
+++ b/geanylua/Makefile.am
@@ -31,12 +31,14 @@ geanylua_la_CFLAGS = \
 	$(GMODULE_CFLAGS) \
 	$(LUA_CFLAGS)
 
+geanylua_la_CPPFLAGS = $(AM_CPPFLAGS) -DG_LOG_DOMAIN=\"GeanyLua\"
 geanylua_la_LIBADD = \
 	$(COMMONLIBS) \
 	$(GMODULE_LIBS) \
 	$(LUA_LIBS)
 
 libgeanylua_la_CFLAGS = $(geanylua_la_CFLAGS)
+libgeanylua_la_CPPFLAGS = $(AM_CPPFLAGS) -DG_LOG_DOMAIN=\"GeanyLua\"
 libgeanylua_la_LIBADD = $(geanylua_la_LIBADD)
 
 SUBDIRS = docs examples

--- a/geanymacro/src/Makefile.am
+++ b/geanymacro/src/Makefile.am
@@ -3,6 +3,7 @@ include $(top_srcdir)/build/vars.build.mk
 geanyplugins_LTLIBRARIES = geanymacro.la
 
 geanymacro_la_SOURCES = geanymacro.c
+geanymacro_la_CPPFLAGS = $(AM_CPPFLAGS) -DG_LOG_DOMAIN=\"GeanyMacro\"
 geanymacro_la_LIBADD = $(COMMONLIBS)
 
 include $(top_srcdir)/build/cppcheck.mk

--- a/geanyminiscript/src/Makefile.am
+++ b/geanyminiscript/src/Makefile.am
@@ -3,6 +3,7 @@ include $(top_srcdir)/build/vars.build.mk
 geanyplugins_LTLIBRARIES = geanyminiscript.la
 
 geanyminiscript_la_SOURCES = gms.c gms.h gms_gui.c gms_gui.h gms_debug.h
+geanyminiscript_la_CPPFLAGS = $(AM_CPPFLAGS) -DG_LOG_DOMAIN=\"GeanyMiniScript\"
 geanyminiscript_la_LIBADD = $(COMMONLIBS)
 
 include $(top_srcdir)/build/cppcheck.mk

--- a/geanynumberedbookmarks/src/Makefile.am
+++ b/geanynumberedbookmarks/src/Makefile.am
@@ -3,4 +3,5 @@ include $(top_srcdir)/build/vars.build.mk
 geanyplugins_LTLIBRARIES = geanynumberedbookmarks.la
 
 geanynumberedbookmarks_la_SOURCES = geanynumberedbookmarks.c
+geanynumberedbookmarks_la_CPPFLAGS = $(AM_CPPFLAGS) -DG_LOG_DOMAIN=\"GeanyNumberedBookmarks\"
 geanynumberedbookmarks_la_LIBADD = $(COMMONLIBS)

--- a/geanyprj/src/Makefile.am
+++ b/geanyprj/src/Makefile.am
@@ -11,6 +11,7 @@ geanyprj_la_SOURCES = geanyprj.c \
 	xproject.c
 
 geanyprj_la_CFLAGS = $(AM_CFLAGS)
+geanyprj_la_CPPFLAGS = $(AM_CPPFLAGS) -DG_LOG_DOMAIN=\"GeanyPrj\"
 geanyprj_la_LIBADD = $(COMMONLIBS)
 
 if UNITTESTS

--- a/geanysendmail/src/Makefile.am
+++ b/geanysendmail/src/Makefile.am
@@ -3,6 +3,7 @@ include $(top_srcdir)/build/vars.build.mk
 geanyplugins_LTLIBRARIES = geanysendmail.la
 
 geanysendmail_la_SOURCES = geanysendmail.c mail-icon.xpm
+geanysendmail_la_CPPFLAGS = $(AM_CPPFLAGS) -DG_LOG_DOMAIN=\"GeanySendMail\"
 geanysendmail_la_LIBADD = $(COMMONLIBS)
 
 include $(top_srcdir)/build/cppcheck.mk

--- a/geanyvc/src/Makefile.am
+++ b/geanyvc/src/Makefile.am
@@ -18,6 +18,7 @@ geanyvc_la_CFLAGS = \
 	$(AM_CFLAGS) \
 	$(GTKSPELL_CFLAGS)
 
+geanyvc_la_CPPFLAGS = $(AM_CPPFLAGS) -DG_LOG_DOMAIN=\"GeanyVC\"
 geanyvc_la_LIBADD = \
 	$(GTKSPELL_LIBS) \
 	$(COMMONLIBS)

--- a/lineoperations/src/Makefile.am
+++ b/lineoperations/src/Makefile.am
@@ -7,6 +7,7 @@ lineoperations_la_SOURCES = \
 	linefunctions.c \
 	lineoperations.c
 
+lineoperations_la_CPPFLAGS = $(AM_CPPFLAGS) -DG_LOG_DOMAIN=\"LineOperations\"
 lineoperations_la_LIBADD = $(COMMONLIBS)
 
 include $(top_srcdir)/build/cppcheck.mk

--- a/markdown/src/Makefile.am
+++ b/markdown/src/Makefile.am
@@ -22,6 +22,7 @@ markdown_la_CFLAGS = \
 	-DMARKDOWN_DOC_DIR=\"$(docdir)/markdown\" \
 	-DMARKDOWN_HELP_FILE=\"$(docdir)/markdown/html/help.html\"
 
+markdown_la_CPPFLAGS = $(AM_CPPFLAGS) -DG_LOG_DOMAIN=\"Markdown\"
 markdown_la_LIBADD = \
 	$(COMMONLIBS) \
 	$(MARKDOWN_LIBS)

--- a/multiterm/src/Makefile.am
+++ b/multiterm/src/Makefile.am
@@ -23,6 +23,7 @@ multiterm_la_SOURCES = \
 	tab-label.vala \
 	terminal.vala
 
+multiterm_la_CPPFLAGS = $(AM_CPPFLAGS) -DG_LOG_DOMAIN=\"MultiTerm\"
 multiterm_la_CFLAGS = \
 	-DGETTEXT_PACKAGE='"$(GETTEXT_PACKAGE)"' \
 	$(AM_CFLAGS) \

--- a/overview/overview/Makefile.am
+++ b/overview/overview/Makefile.am
@@ -18,6 +18,7 @@ overview_la_SOURCES = \
 	overviewui.c \
 	overviewui.h
 
+overview_la_CPPFLAGS = $(AM_CPPFLAGS) -DG_LOG_DOMAIN=\"Overview\"
 overview_la_CFLAGS = \
 	$(AM_CFLAGS) \
 	-I$(srcdir)/.. \

--- a/pairtaghighlighter/src/Makefile.am
+++ b/pairtaghighlighter/src/Makefile.am
@@ -4,6 +4,7 @@ geanyplugins_LTLIBRARIES = pairtaghighlighter.la
 
 pairtaghighlighter_la_SOURCES = pair_tag_highlighter.c
 
+pairtaghighlighter_la_CPPFLAGS = $(AM_CPPFLAGS) -DG_LOG_DOMAIN=\"PairTagHighlighter\"
 pairtaghighlighter_la_LIBADD = $(COMMONLIBS)
 
 include $(top_srcdir)/build/cppcheck.mk

--- a/pretty-printer/src/Makefile.am
+++ b/pretty-printer/src/Makefile.am
@@ -10,6 +10,7 @@ pretty_printer_la_SOURCES = \
 	ConfigUI.h \
 	ConfigUI.c
 
+pretty_printer_la_CPPFLAGS = $(AM_CPPFLAGS) -DG_LOG_DOMAIN=\"PrettyPrinter\"
 pretty_printer_la_CFLAGS = $(AM_CFLAGS) $(LIBXML_CFLAGS) -DHAVE_GLIB -DHAVE_LIBXML
 pretty_printer_la_LIBADD = $(COMMONLIBS) $(LIBXML_LIBS)
 

--- a/scope/src/Makefile.am
+++ b/scope/src/Makefile.am
@@ -53,6 +53,7 @@ scope_la_SOURCES = \
 
 scope_la_LIBADD = $(COMMONLIBS) $(VTE_LIBS) $(PTY_LIBS)
 
+scope_la_CPPFLAGS = $(AM_CPPFLAGS) -DG_LOG_DOMAIN=\"Scope\"
 scope_la_CFLAGS = $(AM_CFLAGS) $(VTE_CFLAGS) \
 	-DPLUGINDATADIR=\"$(plugindatadir)\" \
 	-DPLUGINHTMLDOCDIR=\"$(plugindocdir)/html\" \

--- a/shiftcolumn/src/Makefile.am
+++ b/shiftcolumn/src/Makefile.am
@@ -3,6 +3,7 @@ include $(top_srcdir)/build/vars.build.mk
 geanyplugins_LTLIBRARIES = shiftcolumn.la
 
 shiftcolumn_la_SOURCES = shiftcolumn.c
+shiftcolumn_la_CPPFLAGS = $(AM_CPPFLAGS) -DG_LOG_DOMAIN=\"ShiftColumn\"
 shiftcolumn_la_LIBADD = $(COMMONLIBS)
 
 include $(top_srcdir)/build/cppcheck.mk

--- a/tableconvert/src/Makefile.am
+++ b/tableconvert/src/Makefile.am
@@ -7,6 +7,7 @@ tableconvert_la_SOURCES = \
 	tableconvert.h \
 	tableconvert_ui.c \
 	tableconvert_ui.h
+tableconvert_la_CPPFLAGS = $(AM_CPPFLAGS) -DG_LOG_DOMAIN=\"TableConvert\"
 tableconvert_la_LIBADD = $(COMMONLIBS)
 
 include $(top_srcdir)/build/cppcheck.mk

--- a/treebrowser/src/Makefile.am
+++ b/treebrowser/src/Makefile.am
@@ -3,6 +3,7 @@ include $(top_srcdir)/build/vars.build.mk
 geanyplugins_LTLIBRARIES = treebrowser.la
 
 treebrowser_la_SOURCES = treebrowser.c
+treebrowser_la_CPPFLAGS = $(AM_CPPFLAGS) -DG_LOG_DOMAIN=\"TreeBrowser\"
 treebrowser_la_CFLAGS = $(AM_CFLAGS) $(GIO_CFLAGS)
 treebrowser_la_LIBADD = $(COMMONLIBS) $(GIO_LIBS)
 

--- a/xmlsnippets/src/Makefile.am
+++ b/xmlsnippets/src/Makefile.am
@@ -10,6 +10,7 @@ xmlsnippets_la_SOURCES = \
 	plugin.c plugin.h \
 	$(common_sources)
 
+xmlsnippets_la_CPPFLAGS = $(AM_CPPFLAGS) -DG_LOG_DOMAIN=\"XMLSnippets\"
 xmlsnippets_la_LIBADD = $(COMMONLIBS)
 
 xmlsnippets_check_SOURCES = \


### PR DESCRIPTION
This helps to get proper log messages prefixed with the plugin name
in Geany's Help->Debug Messages view as well as on console
logging.

For some plugins this might be unnecessary if they don't use any `g_message()`, `g_warning()` or similar functions but `G_LOG_DOMAIN` is also used by `g_return_if_fail()` and friends.
Defining it for all plugins at least reduces the chance to miss some plugin, also for the future.

Omitted the plugins GeanyPy and GeanyPG where seperate PRs exist (#371 and #370).