### PR TITLE
Set docdir on Windows builds

### DIFF
--- a/build/common.m4
+++ b/build/common.m4
@@ -65,7 +65,7 @@ AC_DEFUN([GP_COMMIT_PLUGIN_STATUS],
     GP_STATUS_PLUGIN_ADD([$1], [$m4_tolower(AS_TR_SH(enable_$1))])
 ])
 
-dnl GEANY_CHECK_MINGW
+dnl GP_CHECK_MINGW
 dnl Checks whether we're building for MinGW, and defines appropriate stuff
 dnl if it is the case.
 dnl Most importantly, AM_CODITIONALs MINGW

--- a/build/vars.build.mk
+++ b/build/vars.build.mk
@@ -2,11 +2,11 @@ if MINGW
 LOCAL_AM_CFLAGS = \
 	-DLOCALEDIR=\""share/locale"\" \
 	-DPREFIX=\"\" \
-	-DDOCDIR=\"\" \
-	-DGEANYPLUGINS_DATADIR=\"share\" \
+	-DDOCDIR=\""share/doc/geany-plugins"\" \
+	-DGEANYPLUGINS_DATADIR=\""share"\" \
 	-DPKGDATADIR=\""share/geany-plugins"\" \
 	-DLIBDIR=\""lib"\" \
-	-DPKGLIBDIR=\"\"
+	-DPKGLIBDIR=\""lib/geany-plugins"\"
 else
 LOCAL_AM_CFLAGS = \
 	-DLOCALEDIR=\""$(LOCALEDIR)"\" \
@@ -22,7 +22,7 @@ AM_CFLAGS = \
 	${LOCAL_AM_CFLAGS} \
 	$(GEANY_CFLAGS) \
 	$(GP_CFLAGS)
-	
+
 
 AM_LDFLAGS = -module -avoid-version -no-undefined $(GP_LDFLAGS)
 


### PR DESCRIPTION
And remove unused define PKGLIBDIR and quote paths even.

As continuation of #374 after more testing on Windows.
These should be last bits regarding Waf->Autotools migration for G-P on Windows, so I hope.

As we all know, I'm not an Autotools expert: maybe there is a better way/location to overwrite `docdir` than in `GP_CHECK_MINGW`.