### PR TITLE
Translatability of several plugins

### DIFF
--- a/devhelp/src/dhp-plugin.c
+++ b/devhelp/src/dhp-plugin.c
@@ -38,7 +38,9 @@
 
 PLUGIN_VERSION_CHECK(200)
 
-PLUGIN_SET_INFO(
+PLUGIN_SET_TRANSLATABLE_INFO(
+	LOCALEDIR,
+	GETTEXT_PACKAGE,
 	_("Devhelp Plugin"),
 	_("Adds support for looking up documentation in Devhelp, manual pages, and "
 	  "Google Code Search in the integrated viewer."),

--- a/geanyctags/src/geanyctags.c
+++ b/geanyctags/src/geanyctags.c
@@ -47,7 +47,8 @@
 
 
 PLUGIN_VERSION_CHECK(211)
-PLUGIN_SET_INFO("GeanyCtags",
+PLUGIN_SET_TRANSLATABLE_INFO(LOCALEDIR, GETTEXT_PACKAGE,
+	"GeanyCtags",
 	_("Ctags generation and search plugin for geany projects"),
 	VERSION,
 	"Jiri Techet <techet@gmail.com>")

--- a/geanydoc/src/geanydoc.c
+++ b/geanydoc/src/geanydoc.c
@@ -47,8 +47,9 @@ static GtkWidget *keyb2;
  * for binary compatibility. */
 PLUGIN_VERSION_CHECK(128)
 /* All plugins must set name, description, version and author. */
-	PLUGIN_SET_INFO(_("Doc"), _("Call documentation viewer on current symbol."), VERSION,
-		"Yura Siamshka <yurand2@gmail.com>")
+PLUGIN_SET_TRANSLATABLE_INFO(LOCALEDIR, GETTEXT_PACKAGE,
+	_("Doc"), _("Call documentation viewer on current symbol."), VERSION,
+	"Yura Siamshka <yurand2@gmail.com>")
 
 /* Keybinding(s) */
      enum
@@ -436,7 +437,6 @@ plugin_init(G_GNUC_UNUSED GeanyData * data)
 	gchar *kb_label1;
 	gchar *kb_label2;
 
-	main_locale_init(LOCALEDIR, GETTEXT_PACKAGE);
 	kb_label1 = _("Document current word");
 	kb_label2 = _("Document interactive");
 

--- a/geanyextrasel/src/extrasel.c
+++ b/geanyextrasel/src/extrasel.c
@@ -31,7 +31,8 @@ GeanyFunctions	*geany_functions;
 
 PLUGIN_VERSION_CHECK(189)
 
-PLUGIN_SET_INFO(_("Extra Selection"), _("Column mode, select to line / brace / anchor."),
+PLUGIN_SET_TRANSLATABLE_INFO(LOCALEDIR, GETTEXT_PACKAGE,
+	_("Extra Selection"), _("Column mode, select to line / brace / anchor."),
 	"0.52", "Dimitar Toshkov Zhekov <dimitar.zhekov@gmail.com>")
 
 /* Keybinding(s) */
@@ -496,7 +497,6 @@ void plugin_init(G_GNUC_UNUSED GeanyData *data)
 	GtkWidget *item;
 	GeanyKeyGroup *plugin_key_group;
 
-	main_locale_init(LOCALEDIR, GETTEXT_PACKAGE);
 	plugin_key_group = plugin_set_key_group(geany_plugin, "extra_select", COUNT_KB, NULL);
 
 	item = gtk_menu_item_new_with_mnemonic(_("E_xtra Selection"));

--- a/geanyinsertnum/src/insertnum.c
+++ b/geanyinsertnum/src/insertnum.c
@@ -41,7 +41,8 @@ GeanyFunctions	*geany_functions;
 
 PLUGIN_VERSION_CHECK(189)
 
-PLUGIN_SET_INFO(_("Insert Numbers"), _("Insert/Fill columns with numbers."),
+PLUGIN_SET_TRANSLATABLE_INFO(LOCALEDIR, GETTEXT_PACKAGE,
+	_("Insert Numbers"), _("Insert/Fill columns with numbers."),
 	"0.2.2", "Dimitar Toshkov Zhekov <dimitar.zhekov@gmail.com>")
 
 /* Keybinding(s) */
@@ -468,7 +469,6 @@ void plugin_init(G_GNUC_UNUSED GeanyData *data)
 {
 	GeanyKeyGroup *plugin_key_group;
 
-	main_locale_init(LOCALEDIR, GETTEXT_PACKAGE);
 	plugin_key_group = plugin_set_key_group(geany_plugin, "insert_numbers", COUNT_KB, NULL);
 
 	start_value = 1;

--- a/geanylatex/src/geanylatex.c
+++ b/geanylatex/src/geanylatex.c
@@ -2367,8 +2367,6 @@ plugin_init(G_GNUC_UNUSED GeanyData * data)
 
 	doc = document_get_current();
 
-	main_locale_init(LOCALEDIR, GETTEXT_PACKAGE);
-
 	glatex_init_configuration();
 	glatex_init_encodings_latex();
 

--- a/geanylipsum/src/geanylipsum.c
+++ b/geanylipsum/src/geanylipsum.c
@@ -147,8 +147,6 @@ plugin_init(G_GNUC_UNUSED GeanyData *data)
 	gchar *config_file = NULL;
 	GeanyKeyGroup *key_group;
 
-	main_locale_init(LOCALEDIR, GETTEXT_PACKAGE);
-
 	config_file = g_strconcat(geany->app->configdir,
 		G_DIR_SEPARATOR_S, "plugins", G_DIR_SEPARATOR_S,
 		"geanylipsum", G_DIR_SEPARATOR_S, "lipsum.conf", NULL);

--- a/geanymacro/src/geanymacro.c
+++ b/geanymacro/src/geanymacro.c
@@ -178,8 +178,9 @@ GeanyFunctions  *geany_functions;
 
 PLUGIN_VERSION_CHECK(147)
 
-PLUGIN_SET_INFO(_("Macros"),_("Macros for Geany"),
-                "1.1","William Fraser <william.fraser@virgin.net>")
+PLUGIN_SET_TRANSLATABLE_INFO(LOCALEDIR, GETTEXT_PACKAGE,
+                             _("Macros"),_("Macros for Geany"),
+                             "1.1","William Fraser <william.fraser@virgin.net>")
 
 /* Plugin user alterable settings */
 static gboolean bSaveMacros=TRUE;

--- a/geanyprj/src/geanyprj.c
+++ b/geanyprj/src/geanyprj.c
@@ -35,8 +35,9 @@
 #include "geanyprj.h"
 
 PLUGIN_VERSION_CHECK(221)
-PLUGIN_SET_INFO("GeanyPrj", _("Alternative project support."), VERSION,
-		"Yura Siamashka <yurand2@gmail.com>")
+PLUGIN_SET_TRANSLATABLE_INFO(LOCALEDIR, GETTEXT_PACKAGE,
+			     "GeanyPrj", _("Alternative project support."), VERSION,
+			     "Yura Siamashka <yurand2@gmail.com>")
 
 GeanyData      *geany_data;
 GeanyFunctions *geany_functions;
@@ -210,7 +211,6 @@ static void on_configure_response(G_GNUC_UNUSED GtkDialog *dialog, G_GNUC_UNUSED
 /* Called by Geany to initialize the plugin */
 void plugin_init(G_GNUC_UNUSED GeanyData *data)
 {
-	main_locale_init(LOCALEDIR, GETTEXT_PACKAGE);
 	load_settings();
 	tools_menu_init();
 

--- a/geniuspaste/src/geniuspaste.c
+++ b/geniuspaste/src/geniuspaste.c
@@ -827,7 +827,6 @@ void plugin_init(GeanyData * data)
 {
     load_all_pastebins();
     load_settings();
-    main_locale_init(LOCALEDIR, GETTEXT_PACKAGE);
     add_menu_item();
 }
 

--- a/overview/overview/overviewplugin.c
+++ b/overview/overview/overviewplugin.c
@@ -44,7 +44,9 @@ PLUGIN_VERSION_CHECK (224)
 PLUGIN_VERSION_CHECK (211)
 #endif
 
-PLUGIN_SET_INFO (
+PLUGIN_SET_TRANSLATABLE_INFO (
+  LOCALEDIR,
+  GETTEXT_PACKAGE,
   "Overview",
   _("Provides an overview of the active document"),
   "0.01",

--- a/pretty-printer/src/PluginEntry.c
+++ b/pretty-printer/src/PluginEntry.c
@@ -55,9 +55,6 @@ void plugin_init(GeanyData *data)
     /* initializes the libxml2 */
     LIBXML_TEST_VERSION
 
-    /* mutilanguage support */
-    main_locale_init(LOCALEDIR, GETTEXT_PACKAGE);
-
     /* put the menu into the Tools */
     main_menu_item = gtk_menu_item_new_with_mnemonic(_("PrettyPrinter XML"));
     ui_add_document_sensitive(main_menu_item);

--- a/scope/src/scope.c
+++ b/scope/src/scope.c
@@ -535,7 +535,6 @@ void plugin_init(G_GNUC_UNUSED GeanyData *gdata)
 	ToolItem *tool_item = toolbar_items;
 	const ScopeCallback *scb;
 
-	main_locale_init(LOCALEDIR, GETTEXT_PACKAGE);
 	scope_key_group = plugin_set_key_group(geany_plugin, "scope", COUNT_KB, NULL);
 	builder = gtk_builder_new();
 	gtk_builder_set_translation_domain(builder, GETTEXT_PACKAGE);

--- a/shiftcolumn/src/shiftcolumn.c
+++ b/shiftcolumn/src/shiftcolumn.c
@@ -46,9 +46,10 @@ GeanyData       *geany_data;
 GeanyFunctions  *geany_functions;
 
 PLUGIN_VERSION_CHECK(130)
-PLUGIN_SET_INFO(_("Shift Column"),
-                _("Shift a selection left and right"),
-                VERSION, "Andrew L Janke <a.janke@gmail.com>")
+PLUGIN_SET_TRANSLATABLE_INFO(LOCALEDIR, GETTEXT_PACKAGE,
+                             _("Shift Column"),
+                             _("Shift a selection left and right"),
+                             VERSION, "Andrew L Janke <a.janke@gmail.com>")
 
 
 static GtkWidget *menu_item_shift_left = NULL;
@@ -373,9 +374,6 @@ static void kb_shift_right(G_GNUC_UNUSED guint key_id){
    }
 
 void plugin_init(G_GNUC_UNUSED GeanyData *data){
-
-   /* init gettext and friends */
-   main_locale_init(LOCALEDIR, GETTEXT_PACKAGE);
 
    menu_item_shift_left = gtk_menu_item_new_with_mnemonic(_("Shift Left"));
    gtk_widget_show(menu_item_shift_left);


### PR DESCRIPTION
Fix "translatability" of several plugins, either overall (*GeanyCTags*, *DevHelp*, *GeanyMacro*, *Overview*), only the infos, and remove redundant localization init in some plugins.
Symptoms are that translation might not work in certain cases i.e. if the plugin is loaded first (or alone), or only one from GP installed.

*GeanyPy* also suffers from the non-translatability, but it doesn't have `LOCALEDIR` and `GETTEXT_PACKAGE`properly set from it's build system so it's not as straightforward to fix. @codebrainz 