### PR TITLE
lineoperations: Fix a memory leak found by cppcheck

### DIFF
--- a/lineoperations/src/linefunctions.c
+++ b/lineoperations/src/linefunctions.c
@@ -286,17 +286,13 @@ void rmwhspln(GeanyDocument *doc) {
 
 /* Sort Lines Ascending and Descending */
 void sortlines(GeanyDocument *doc, gboolean asc) {
-	gint  total_num_chars;  /* number of characters in the document */
 	gint  total_num_lines;  /* number of lines in the document */
 	gchar **lines;          /* array to hold all lines in the document */
 	gchar *new_file;        /* *final* string to replace current document */
 	gint  i;                /* iterator */
 
-	total_num_chars = sci_get_length(doc->editor->sci);
 	total_num_lines = sci_get_line_count(doc->editor->sci);
 	lines           = g_malloc(sizeof(gchar *) * (total_num_lines+1));
-	new_file        = g_malloc(sizeof(gchar) * (total_num_chars+1));
-	new_file[0]     = '\0';
 
 	/* if file is not empty, ensure that the file ends with newline */
 	if(total_num_lines != 1)


### PR DESCRIPTION
`new_file` is [assigned again with the return value of `g_strjoinv()`](https://github.com/geany/geany-plugins/pull/391/files#diff-12783b0a2f2a5a415ec6f2505c90e634R315), thus leaking the previous value.