### PR TITLE
Skip auto-generated C sources from translation setup

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -236,12 +236,6 @@ multiterm/src/plugin.vala
 multiterm/src/shell-config.vala
 multiterm/src/tab-label.vala
 multiterm/src/terminal.vala
-multiterm/src/config.c
-multiterm/src/context-menu.c
-multiterm/src/notebook.c
-multiterm/src/plugin.c
-multiterm/src/tab-label.c
-multiterm/src/terminal.c
 
 # Overview
 overview/overview/overviewcolor.c

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -3,5 +3,13 @@
 #geanyvc
 geanyvc/src/commit.glade
 
+# Multiterm
+multiterm/src/config.c
+multiterm/src/context-menu.c
+multiterm/src/notebook.c
+multiterm/src/plugin.c
+multiterm/src/tab-label.c
+multiterm/src/terminal.c
+
 # WebHelper
 webhelper/src/gwh-enum-types.c


### PR DESCRIPTION
Fixes `make check` when MultiTerm is not enabled.

Closes #390.