### PR TITLE
spellcheck: Use <> to include Geany headers

### DIFF
--- a/spellcheck/src/gui.c
+++ b/spellcheck/src/gui.c
@@ -26,7 +26,7 @@
 # include "config.h"
 #endif
 
-#include "geanyplugin.h"
+#include <geanyplugin.h>
 
 #include <ctype.h>
 #include <string.h>

--- a/spellcheck/src/scplugin.c
+++ b/spellcheck/src/scplugin.c
@@ -27,7 +27,7 @@
 # include "config.h"
 #endif
 
-#include "geanyplugin.h"
+#include <geanyplugin.h>
 
 
 #include "scplugin.h"

--- a/spellcheck/src/speller.c
+++ b/spellcheck/src/speller.c
@@ -26,9 +26,8 @@
 # include "config.h"
 #endif
 
-#include "geanyplugin.h"
-
-#include "scintilla/SciLexer.h"
+#include <geanyplugin.h>
+#include <scintilla/SciLexer.h>
 
 #include <string.h>
 #include <ctype.h>


### PR DESCRIPTION
Apparently some older versions of cppcheck get stupid when passed extra
flags like `-D`, so try and make them happy by showing them those are
library (system-wide) headers rather than application (local) ones.