### PR TITLE
Enable Travis CI v2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,106 @@
+language: c
+
+sudo: false
+
+compiler:
+  - gcc
+
+env:
+  - GTK3=no
+  - GTK3=yes
+
+cache:
+  ccache: true
+  directories:
+    - $HOME/geany/gtk3
+    - $HOME/geany/gtk2
+
+addons:
+  apt:
+    packages:
+    - libgtk2.0-dev
+    - libgtk-3-dev
+    - intltool
+    - libtool
+    - python-docutils
+    - check
+    # FIXME: there are weird error with spellcheck and Ubuntu 12.04's version of cppcheck (1.52)
+    - cppcheck
+    # debugger
+    - libvte-dev
+    # devhelp
+    - libwebkitgtk-dev
+    - libwnck-dev
+    - libgconf2-dev
+    - zlib1g-dev
+    # geanygendoc
+    - libctpl-dev
+    # geanylua
+    - liblua5.1-0-dev
+    # geanypg
+    - libgpgme11-dev
+    # geanypy
+    # FIXME: Ubuntu 12.04 doesn't seem to have it
+    #- libpython-dev
+    # geanyvc
+    - libgtkspell-dev
+    - libgtkspell-3-dev
+    # geaniuspaste/updatechecker
+    - libsoup2.4-dev
+    # git-changebar
+    # FIXME: Ubuntu 12.04 doesn't seem to have it, 14.04 has a too old one
+    #- libgit2-dev
+    # markdown
+    - libmarkdown2-dev
+    # markdown/webhelper
+    - libwebkitgtk-3.0-dev
+    # multiterm
+    - valac
+    # pretty-printer
+    - libxml2-dev
+    # spellcheck
+    - libenchant-dev
+
+before_install:
+  # build Geany
+  - TEMPDIR=$(mktemp -d)
+  - git clone git://github.com/geany/geany.git "$TEMPDIR/geany"
+  - geany_commit=$(cd "$TEMPDIR/geany" && git rev-parse HEAD)
+  - gtkver=gtk2
+  - test "x$GTK3" = xno || gtkver=gtk3
+  - cachedir="$HOME/geany/$gtkver/"
+  - cache_id=$(cat "$cachedir/commit-id" 2>/dev/null || echo "none")
+  # check if the cache is up-to-date, and either use it, or (re-)create it
+  - >
+    if test "$geany_commit" = "$cache_id"; then
+      echo "Cache '$cachedir' looks good, using it (ID: $cache_id).";
+    else
+      echo "Cache '$cachedir' is missing, outdated or invalid, dropping it.";
+      echo "  Cache ID: $cache_id";
+      echo "  Geany ID: $geany_commit";
+      rm "$cachedir" -rf || exit 1;
+      ( cd "$TEMPDIR/geany"                                   &&
+        NOCONFIGURE=1 ./autogen.sh                            &&
+        ./configure --prefix="$cachedir" --enable-gtk3=$GTK3  &&
+        make -j2                                              &&
+        make install || exit 1;
+        git rev-parse HEAD > "$cachedir/commit-id" || exit 2;
+      ) || exit $?;
+    fi
+  - export PKG_CONFIG_PATH="$cachedir/lib/pkgconfig:$PKG_CONFIG_PATH"
+  - export LD_LIBRARY_PATH="$cachedir/lib:$LD_LIBRARY_PATH"
+
+before_script:
+  # prepare for GP
+  - export CFLAGS="-g -O2 -Werror=pointer-arith -Werror=aggregate-return -Werror=implicit-function-declaration"
+
+script:
+  - >
+    NOCONFIGURE=1 ./autogen.sh  &&
+    mkdir _build                &&
+    cd _build                   &&
+    ../configure                &&
+    make -j2                    &&
+    make -j2 check
+after_script:
+  - test -z "$TEMPDIR" || rm -rf "$TEMPDIR"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,18 @@ compiler:
   - gcc
 
 env:
-  - GTK3=no
-  - GTK3=yes
+  global:
+    - LIBGIT2_VERSION=0.21.5
+  matrix:
+    - GTK3=no
+    - GTK3=yes
 
 cache:
   ccache: true
   directories:
     - $HOME/geany/gtk3
     - $HOME/geany/gtk2
+    - $HOME/libgit2-$LIBGIT2_VERSION
 
 addons:
   apt:
@@ -48,7 +52,8 @@ addons:
     # geaniuspaste/updatechecker
     - libsoup2.4-dev
     # git-changebar
-    # FIXME: Ubuntu 12.04 doesn't seem to have it, 14.04 has a too old one
+    # Ubuntu 12.04 doesn't have libgit2, 14.04 has a too old one, so we build
+    # our own for now.
     #- libgit2-dev
     # markdown
     - libmarkdown2-dev
@@ -60,6 +65,9 @@ addons:
     - libxml2-dev
     # spellcheck
     - libenchant-dev
+
+    # for libgit2 build
+    - cmake
 
 before_install:
   # build Geany
@@ -87,8 +95,33 @@ before_install:
         git rev-parse HEAD > "$cachedir/commit-id" || exit 2;
       ) || exit $?;
     fi
+  - test -z "$TEMPDIR" || rm -rf "$TEMPDIR"
   - export PKG_CONFIG_PATH="$cachedir/lib/pkgconfig:$PKG_CONFIG_PATH"
   - export LD_LIBRARY_PATH="$cachedir/lib:$LD_LIBRARY_PATH"
+
+  # build libgit2
+  - TEMPDIR=$(mktemp -d)
+  - libgit2dir="libgit2-$LIBGIT2_VERSION"
+  - >
+    if test -f "$HOME/$libgit2dir/lib/pkgconfig/libgit2.pc"; then
+      echo "Using pre-built libgit2 v$LIBGIT2_VERSION.";
+    else
+      ( cd $TEMPDIR || exit 1;
+        wget -q "https://github.com/libgit2/libgit2/archive/v$LIBGIT2_VERSION.tar.gz" -O - |
+          tar -xz "$libgit2dir" || exit 2;
+        cd "$libgit2dir" || exit 3;
+        cmake .                                       \
+          -DCMAKE_INSTALL_PREFIX="$HOME/$libgit2dir"  \
+          -DCMAKE_RULE_MESSAGES=OFF                   \
+          -DBUILD_CLAR=OFF                            \
+          -DBUILD_SHARED_LIBS=ON                      \
+          || exit 4;
+        cmake --build . --target install -- -j2 || exit 5;
+      ) || exit $?;
+    fi
+  - test -z "$TEMPDIR" || rm -rf "$TEMPDIR"
+  - export PKG_CONFIG_PATH="$HOME/$libgit2dir/lib/pkgconfig:$PKG_CONFIG_PATH"
+  - export LD_LIBRARY_PATH="$HOME/$libgit2dir/lib:$LD_LIBRARY_PATH"
 
 before_script:
   # prepare for GP

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,8 +40,8 @@ addons:
     # geanypg
     - libgpgme11-dev
     # geanypy
-    # FIXME: Ubuntu 12.04 doesn't seem to have it
-    #- libpython-dev
+    - python-dev
+    - python-gtk2-dev
     # geanyvc
     - libgtkspell-dev
     - libgtkspell-3-dev


### PR DESCRIPTION
Would replace #172, which see also.

This is a new shot at enabling Travis CI on Geany-Plugins.  This time, it uses the new-style infrastructure which enables caching and is quite faster to start up.

* Pros:
  * Faster to start up
  * Has cache support
    * We can build Geany and cache the result, meaning we can rebuild it only when it has changed.  This makes me think its better than using nightly *.deb*s, as we have the real latest version in all cases, and zero OS package compatibility issue.
    * *ccache* support, meaning faster rebuilds
  
* Cons:
  * No sudo, which means:
    * We need their approval for new packages.  We currently miss:
      * [ ] [*libvte-dev*](https://github.com/travis-ci/apt-package-whitelist/issues/2675) (for several plugins, incl. *Debugger*, *Scope* and *MultiTerm*)
      * [ ] [*libwnck-dev*](https://github.com/travis-ci/apt-package-whitelist/issues/2677) (for *DevHelp*)
      * [ ] [*libgtkspell-dev*](https://github.com/travis-ci/apt-package-whitelist/issues/2678) (for *GeanyVC*'s spellchecking support on GTK2)
      * [ ] [*libgtkspell-3-dev*](https://github.com/travis-ci/apt-package-whitelist/issues/2679) (for *GeanyVC*'s spellchecking support on GTK3)
      * [ ] [*python-gtk2-dev*](https://github.com/travis-ci/apt-package-whitelist/issues/2680) (for *GeanyPy*)
      
      this can however probably be addressed by using they approval procedure for those packages.  If we chose this version, I'll submit the requests there.
    
    * No 3rd party repositories (e.g. we have to build Geany there too).  This should not be a real problem with the caching, in my tests I saw it wasting about 7s when the cache is available, and something like 2 minutes without cache.

IMO, the pros clearly beat the cons -- unless we really can't get the needed packages, but I'm confident we can.

---

Unrelated to whether we use the new infrastructure or the old one, we run on Ubuntu 12.04.  This is good in the sense we test an old-ish system; but it's bad as in it doesn't have ~~*libpython-dev* (for *GeanyPy*) nor~~ *libgit2-dev >= 0.21* (for *GitChangeBar*).

We *could* try and use their [beta Ubuntu 14.04 builders](https://docs.travis-ci.com/user/trusty-ci-environment/), which allows `sudo`, *and* has cache.  Sounds nice, but:

* It's quite a bit slower than their 12.04 "new" infrastructure (build takes minutes to start, not seconds: not sure about speed after startup)
* Ubuntu 14.04's *libgit2-dev* is too old (0.19) for *GitChangeBar*, ~~so we "only" gain *GeanyPy*~~
* Newer system, while good, also means less backward compatibility checks.

I didn't pursue it for the moment because of these which make me think we should at least wait for their setup to get faster seeing the limited benefits.

---

Setting up this, I found 4 blocker issues, including 3 actual bugs:
- [x] #392: `make check` breaks if MultiTerm is disabled.  So actually missing *libvte-dev* was useful :)
- [x] #393: Ubuntu 12.04's cppcheck is stupid
- [x] #391: Ubuntu 12.04's cppcheck is clever
- [x] #395: Incorrect build system assumption from a *Debugger* test script (won't be a problem until we have [*libvte*](https://github.com/travis-ci/apt-package-whitelist/issues/2675) though)

---

Enough chatter, whatcha guys thinkin'?