### PR TITLE
debugger: Don't rely on an Automake test driver implementation detail

### DIFF
--- a/debugger/src/tests/gdb_mi_test.sh
+++ b/debugger/src/tests/gdb_mi_test.sh
@@ -9,11 +9,14 @@ strip_comments()
   ${SED:-sed} -e '/^#/d'
 }
 
-TMPOUT=tests/gdb_mi_test.output.tmp
-TMPEXCPT=tests/gdb_mi_test.expected.tmp
+SUBDIR=tests
+TMPOUT=$SUBDIR/gdb_mi_test.output.tmp
+TMPEXCPT=$SUBDIR/gdb_mi_test.expected.tmp
 
-trap 'rm -f "$TMPOUT" "$TMPEXCPT"' EXIT QUIT TERM INT
+trap 'rm -f "$TMPOUT" "$TMPEXCPT";
+      rmdir "$SUBDIR" 2>/dev/null || :' EXIT QUIT TERM INT
 
+test -d "$SUBDIR" || mkdir "$SUBDIR"
 strip_comments < "$srcdir/tests/gdb_mi_test.input" | ./gdb_mi_test 2> "$TMPOUT"
 strip_comments < "$srcdir/tests/gdb_mi_test.expected" > "$TMPEXCPT"
 diff -u "$TMPEXCPT" "$TMPOUT"


### PR DESCRIPTION
Don't rely on the test driver to create the subdirectory where we want
to write the tests temporary output to in `$builddir`.

Fixes tests under Ubuntu 12.04.

---

* before: https://travis-ci.org/b4n/geany-plugins/builds/114352090#L3722
* after: https://travis-ci.org/b4n/geany-plugins/builds/114358044#L3721