### PR TITLE
Fix implicit function declarations by including appropriate headers

### DIFF
--- a/codenav/src/utils.c
+++ b/codenav/src/utils.c
@@ -21,6 +21,8 @@
 
 #include "utils.h"
 
+#include <geanyplugin.h>
+
  /**
  * @brief	Function which returns the extension of the file path which 
  * 			is given, or NULL if it did not found any extension.

--- a/shiftcolumn/src/shiftcolumn.c
+++ b/shiftcolumn/src/shiftcolumn.c
@@ -23,18 +23,11 @@
 # include "config.h"
 #endif
 
-#include "geany.h"
-#include "support.h"
+#include <geanyplugin.h>
 
 #ifdef HAVE_LOCALE_H
 # include <locale.h>
 #endif
-
-#include "ui_utils.h"
-
-#include "document.h"
-#include "keybindings.h"
-#include "plugindata.h"
 
 #include <glib.h>
 #include <glib/gprintf.h>


### PR DESCRIPTION
Introduced my legacy inclusion removal in 25e3c8851a5113423ce16a6b8008.