### PR TITLE
travis: Make the build more verbose

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -128,12 +128,11 @@ before_script:
   - export CFLAGS="-g -O2 -Werror=pointer-arith -Werror=aggregate-return -Werror=implicit-function-declaration"
 
 script:
-  - >
-    NOCONFIGURE=1 ./autogen.sh  &&
-    mkdir _build                &&
-    cd _build                   &&
-    ../configure                &&
-    make -j2                    &&
-    make -j2 check
+  - NOCONFIGURE=1 ./autogen.sh
+  - mkdir _build && cd _build
+  - ../configure
+  - make -j2
+  - make -j2 check
+
 after_script:
   - test -z "$TEMPDIR" || rm -rf "$TEMPDIR"

--- a/.travis.yml
+++ b/.travis.yml
@@ -130,7 +130,7 @@ before_script:
 script:
   - NOCONFIGURE=1 ./autogen.sh
   - mkdir _build && cd _build
-  - ../configure
+  - ../configure --disable-silent-rules
   - make -j2
   - make -j2 check
 


### PR DESCRIPTION
Show the actual commands Make runs instead of a pretty message, which while very cute is a lot less informative in case of error.

May help debugging https://travis-ci.org/geany/geany-plugins/jobs/115259916 (although it looks more like a very weird race condition than an actual issue)