### PR TITLE
Geniuspaste: Install a custom URL handler for Paste link

### DIFF
--- a/geniuspaste/src/geniuspaste.c
+++ b/geniuspaste/src/geniuspaste.c
@@ -578,12 +578,30 @@ static gchar *pastebin_parse_response(const Pastebin  *pastebin,
     return url;
 }
 
+static gboolean message_dialog_label_link_activated(GtkLabel *label, gchar *uri, gpointer user_data)
+{
+    utils_open_browser(uri);
+    return TRUE;
+}
+
+static void message_dialog_label_set_url_hook(GtkWidget *widget, gpointer data)
+{
+    if (GTK_IS_LABEL(widget))
+    {
+        g_signal_connect(widget,
+                         "activate-link",
+                         G_CALLBACK(message_dialog_label_link_activated),
+                         NULL);
+    }
+}
+
 G_GNUC_PRINTF (4, 5)
 static void show_msgbox(GtkMessageType type, GtkButtonsType buttons,
                         const gchar *main_text,
                         const gchar *secondary_markup, ...)
 {
     GtkWidget *dlg;
+    GtkWidget *dlg_vbox;
     va_list ap;
     gchar *markup;
 
@@ -601,6 +619,12 @@ static void show_msgbox(GtkMessageType type, GtkButtonsType buttons,
                        "secondary-text", markup,
                        "secondary-use-markup", TRUE,
                        NULL);
+    /* fetch the message area of the dialog and attach a custom URL hook to the labels */
+    dlg_vbox = gtk_message_dialog_get_message_area(GTK_MESSAGE_DIALOG(dlg));
+    gtk_container_foreach(GTK_CONTAINER(dlg_vbox),
+                          message_dialog_label_set_url_hook,
+                          NULL);
+    /* run the dialog */
     gtk_dialog_run(GTK_DIALOG(dlg));
     gtk_widget_destroy(dlg);
 }


### PR DESCRIPTION
This workarounds a strange crash on Windows when the default GTK
URL handler is called.
We need the URL handler only on the secondary text label but we
cannot access it directly, so iterate over all labels of the message
dialog's message area and attach the custom handler to all of the
labels. This shouldn't harm much as only the secondary label contains
a link.

Here is the gdb backtrace from running on Windows:
```
Thread 1 received signal SIGSEGV, Segmentation fault.
0x61a3ca04 in ?? () from H:\all\bin\libgtk-win32-2.0-0.dll
(gdb) bt
#0  0x61a3ca04 in ?? () from H:\all\bin\libgtk-win32-2.0-0.dll
#1  0x61a4f96c in ?? () from H:\all\bin\libgtk-win32-2.0-0.dll
#2  0x63c45fd2 in ?? () from H:\all\bin\libgobject-2.0-0.dll
#3  0x63c57c26 in ?? () from H:\all\bin\libgobject-2.0-0.dll
#4  0x63c5f31a in ?? () from H:\all\bin\libgobject-2.0-0.dll
#5  0x63c5faf7 in ?? () from H:\all\bin\libgobject-2.0-0.dll
#6  0x61a3fd4e in ?? () from H:\all\bin\libgtk-win32-2.0-0.dll
#7  0x61a42c16 in ?? () from H:\all\bin\libgtk-win32-2.0-0.dll
#8  0x61a4e72c in ?? () from H:\all\bin\libgtk-win32-2.0-0.dll
#9  0x63c45f1c in ?? () from H:\all\bin\libgobject-2.0-0.dll
#10 0x63c57c26 in ?? () from H:\all\bin\libgobject-2.0-0.dll
#11 0x63c5f31a in ?? () from H:\all\bin\libgobject-2.0-0.dll
#12 0x63c5faf7 in ?? () from H:\all\bin\libgobject-2.0-0.dll
#13 0x61b691e3 in ?? () from H:\all\bin\libgtk-win32-2.0-0.dll
#14 0x61a4cdb0 in ?? () from H:\all\bin\libgtk-win32-2.0-0.dll
#15 0x61a4d15c in ?? () from H:\all\bin\libgtk-win32-2.0-0.dll
#16 0x6c5791c4 in ?? () from H:\all\bin\libgdk-win32-2.0-0.dll
#17 0x687f3783 in ?? () from H:\all\bin\libglib-2.0-0.dll
#18 0x687f39dc in ?? () from H:\all\bin\libglib-2.0-0.dll
#19 0x687f3e93 in ?? () from H:\all\bin\libglib-2.0-0.dll
#20 0x619d2c7c in ?? () from H:\all\bin\libgtk-win32-2.0-0.dll
#21 0x02fc29d9 in show_msgbox () from H:\all\lib\geany\geniuspaste.dll
#22 0x02fc2e8e in paste () from H:\all\lib\geany\geniuspaste.dll
#23 0x02fc2f0e in item_activate () from H:\all\lib\geany\geniuspaste.dll
#24 0x63c45fd2 in ?? () from H:\all\bin\libgobject-2.0-0.dll
#25 0x63c57871 in ?? () from H:\all\bin\libgobject-2.0-0.dll
#26 0x63c5f890 in ?? () from H:\all\bin\libgobject-2.0-0.dll
#27 0x63c5faf7 in ?? () from H:\all\bin\libgobject-2.0-0.dll
#28 0x61b67fad in ?? () from H:\all\bin\libgtk-win32-2.0-0.dll
#29 0x61a60ae7 in ?? () from H:\all\bin\libgtk-win32-2.0-0.dll
#30 0x61a60e20 in ?? () from H:\all\bin\libgtk-win32-2.0-0.dll
#31 0x61a4e72c in ?? () from H:\all\bin\libgtk-win32-2.0-0.dll
#32 0x63c45fd2 in ?? () from H:\all\bin\libgobject-2.0-0.dll
#33 0x63c57c26 in ?? () from H:\all\bin\libgobject-2.0-0.dll
#34 0x63c5f31a in ?? () from H:\all\bin\libgobject-2.0-0.dll
#35 0x63c5faf7 in ?? () from H:\all\bin\libgobject-2.0-0.dll
#36 0x61b691e3 in ?? () from H:\all\bin\libgtk-win32-2.0-0.dll
#37 0x61a4cdb0 in ?? () from H:\all\bin\libgtk-win32-2.0-0.dll
#38 0x61a4d15c in ?? () from H:\all\bin\libgtk-win32-2.0-0.dll
#39 0x6c5791c4 in ?? () from H:\all\bin\libgdk-win32-2.0-0.dll
#40 0x687f3783 in ?? () from H:\all\bin\libglib-2.0-0.dll
#41 0x687f39dc in ?? () from H:\all\bin\libglib-2.0-0.dll
#42 0x687f3e93 in ?? () from H:\all\bin\libglib-2.0-0.dll
---Type <return> to continue, or q <return> to quit---
#43 0x61a4c11f in ?? () from H:\all\bin\libgtk-win32-2.0-0.dll
#44 0x6a181c39 in main_lib (argc=1, argv=0x4dec90) at libmain.c:1229
#45 0x00401650 in main (argc=3, argv=0x4dec90) at main.c:27
(gdb)
```
which doesn't really help much. Unfortunately, I don't have a GTK runtime with debug symbols.

Anyway, using `utils_open_browser()` has the nice side effect that the link will be opened with the browser configured in Geany.