### PR TITLE
scope: Fix dependencies checks on Windows

### DIFF
--- a/build/scope.m4
+++ b/build/scope.m4
@@ -3,17 +3,22 @@ AC_DEFUN([GP_CHECK_SCOPE],
     GP_ARG_DISABLE([Scope], [auto])
     GP_CHECK_PLUGIN_GTK2_ONLY([Scope])
 
-    GP_CHECK_PLUGIN_DEPS([scope], [VTE],
-                         [vte >= 0.17])
-    AC_CHECK_HEADERS([util.h pty.h libutil.h])
-    GP_COMMIT_PLUGIN_STATUS([Scope])
-
     case "$host_os" in
-        cygwin* | mingw* | win32*) PTY_LIBS="" ;;
-        *) PTY_LIBS="-lutil" ;;
+        cygwin* | mingw* | win32*)
+            PTY_LIBS=""
+            ;;
+
+        *)
+            GP_CHECK_PLUGIN_DEPS([scope], [VTE],
+                                 [vte >= 0.17])
+            AC_CHECK_HEADERS([util.h pty.h libutil.h])
+            PTY_LIBS="-lutil"
+            ;;
     esac
 
     AC_SUBST(PTY_LIBS)
+
+    GP_COMMIT_PLUGIN_STATUS([Scope])
 
     AC_CONFIG_FILES([
         scope/Makefile


### PR DESCRIPTION
On Windows Scope doesn't need neither VTE nor pty.h, so drop the incorrect checks there.