### PR TITLE
geanygendoc: Work around an rst2html 0.8.1 bug

### DIFF
--- a/geanygendoc/docs/Makefile.am
+++ b/geanygendoc/docs/Makefile.am
@@ -15,6 +15,6 @@ dist_pluginhtmldoc_DATA = \
 if BUILD_RST
 manual.html: manual.rst manual.css html4css1.css
 	$(AM_V_GEN) $(RST2HTML) -d --strict \
-		--stylesheet-path $(srcdir)/html4css1.css,$(srcdir)/manual.css \
+		--stylesheet-path $(abs_srcdir)/html4css1.css,$(abs_srcdir)/manual.css \
 		$(srcdir)/manual.rst $@
 endif BUILD_RST


### PR DESCRIPTION
Apparently rst2html 0.8.1 from Ubuntu 12.04 incorrectly resolves
relative paths to the stylesheets listed in `--stylesheet-path` but the
first one.

Work around this by providing absolute paths to the stylesheets.

---

Should fix the intermittent Travis failures we have.  I still don't know why sometimes that target is built (it shouldn't, as it's up2date -- maybe the buildbot has an incorrect system date?), but at least with this fix building it succeeds.