### PR TITLE
scope: Fix validate_number()

### DIFF
--- a/scope/src/utils.c
+++ b/scope/src/utils.c
@@ -651,7 +651,7 @@ static gchar *validate_number(gchar *text)
 	for (s = text; isdigit(*s); s++);
 	*s = '\0';
 	return *text && (s - text < 10 ||
-		(s - text == 10 && strcmp(text, "2147483648")) < 0) ? text : NULL;
+		(s - text == 10 && strcmp(text, "2147483648") < 0)) ? text : NULL;
 }
 
 gchar *validate_column(gchar *text, gboolean string)


### PR DESCRIPTION
The brackets are apparently wrong - the check that should happen is

strcmp(text, "2147483648") < 0

but instead the whole expression

(s - text == 10 && strcmp(text, "2147483648"))

is compared if it's less than zero.

Noticed by LLVM:

```
utils.c:654:50: warning: comparison of constant 0 with boolean expression is always false
      [-Wtautological-constant-out-of-range-compare]
                (s - text == 10 && strcmp(text, "2147483648")) < 0) ? text : NULL;
                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^ ~
```