### PR TITLE
Copy fix from upstream

### DIFF
--- a/geanypy/src/geanypy.h
+++ b/geanypy/src/geanypy.h
@@ -100,6 +100,9 @@ extern "C" {
 #include <Scintilla.h>
 #include <ScintillaWidget.h>
 
+/* Expansion of this Scintilla macro causes name clashes. */
+#undef NotifyHeader
+
 #include <geanyplugin.h>
 
 #ifndef G_LOG_DOMAIN


### PR DESCRIPTION
Copy fix for Scintilla macro name clash with geanypy