### PR TITLE
projectorganizer: Fix multiple tabs in Project Properties

### DIFF
--- a/projectorganizer/src/prjorg-main.c
+++ b/projectorganizer/src/prjorg-main.c
@@ -42,7 +42,7 @@ PLUGIN_SET_TRANSLATABLE_INFO(
 	VERSION,
 	"Jiri Techet <techet@gmail.com>")
 
-static gint page_index = -1;
+static GtkWidget *properties_tab = NULL;
 
 
 static void on_doc_open(G_GNUC_UNUSED GObject * obj, G_GNUC_UNUSED GeanyDocument * doc,
@@ -96,8 +96,8 @@ static void on_build_start(GObject *obj, gpointer user_data)
 static void on_project_dialog_open(G_GNUC_UNUSED GObject * obj, GtkWidget * notebook,
 		G_GNUC_UNUSED gpointer user_data)
 {
-	if (prj_org && page_index == -1)
-		page_index = prjorg_project_add_properties_tab(notebook);
+	if (prj_org && !properties_tab)
+		properties_tab = prjorg_project_add_properties_tab(notebook);
 }
 
 
@@ -115,10 +115,10 @@ static void on_project_dialog_confirmed(G_GNUC_UNUSED GObject * obj, GtkWidget *
 static void on_project_dialog_close(G_GNUC_UNUSED GObject * obj, GtkWidget * notebook,
 		G_GNUC_UNUSED gpointer user_data)
 {
-	if (page_index != -1)
+	if (properties_tab)
 	{
-		gtk_notebook_remove_page(GTK_NOTEBOOK(notebook), page_index);
-		page_index = -1;
+		gtk_widget_destroy(properties_tab);
+		properties_tab = NULL;
 	}
 }
 

--- a/projectorganizer/src/prjorg-project.c
+++ b/projectorganizer/src/prjorg-project.c
@@ -555,13 +555,12 @@ void prjorg_project_read_properties_tab(void)
 }
 
 
-gint prjorg_project_add_properties_tab(GtkWidget *notebook)
+GtkWidget *prjorg_project_add_properties_tab(GtkWidget *notebook)
 {
 	GtkWidget *vbox, *hbox, *hbox1;
 	GtkWidget *table;
 	GtkWidget *label;
 	gchar *str;
-	gint page_index;
 
 	e = g_new0(PropertyDialogElements, 1);
 
@@ -645,10 +644,10 @@ gint prjorg_project_add_properties_tab(GtkWidget *notebook)
 	hbox = gtk_hbox_new(FALSE, 0);
 	gtk_box_pack_start(GTK_BOX(hbox), vbox, TRUE, TRUE, 6);
 
-	page_index = gtk_notebook_append_page(GTK_NOTEBOOK(notebook), hbox, label);
+	gtk_notebook_append_page(GTK_NOTEBOOK(notebook), hbox, label);
 	gtk_widget_show_all(notebook);
 
-	return page_index;
+	return hbox;
 }
 
 

--- a/projectorganizer/src/prjorg-project.h
+++ b/projectorganizer/src/prjorg-project.h
@@ -47,7 +47,7 @@ extern PrjOrg *prj_org;
 
 void prjorg_project_open(GKeyFile * key_file);
 
-gint prjorg_project_add_properties_tab(GtkWidget *notebook);
+GtkWidget *prjorg_project_add_properties_tab(GtkWidget *notebook);
 
 void prjorg_project_close(void);
 


### PR DESCRIPTION
There is a problem when there are multiple tabs added by plugins: if
on_project_dialog_open() is called and Project Organizer stores
the index of the tab and then another plugin adds a tab before the
Project Organizer's tab, then the stored index becomes invalid which
can lead to not correctly removing the tab from the dialog.

Instead store a pointer of the added tab widget and remove the widget
when the properties dialog is closed.

Fixes #444 