### PR TITLE
addons/tasks: Small improvments

### DIFF
--- a/addons/src/ao_tasks.c
+++ b/addons/src/ao_tasks.c
@@ -559,7 +559,7 @@ static void create_task(AoTasks *t, GeanyDocument *doc, gint line, const gchar *
 static void update_tasks_for_doc(AoTasks *t, GeanyDocument *doc)
 {
 	gint lexer, lines, line, last_pos = 0, style;
-	gchar *line_buf, *display_name, *task_start;
+	gchar *line_buf, *display_name, *task_start, *closing_comment;
 	gchar **token;
 	AoTasksPrivate *priv = AO_TASKS_GET_PRIVATE(t);
 
@@ -588,6 +588,11 @@ static void update_tasks_for_doc(AoTasks *t, GeanyDocument *doc)
 				/* reset task_start in case there is no text following */
 				if (EMPTY(task_start))
 					task_start = line_buf;
+				else if ((EMPTY(doc->file_type->comment_single) ||
+					strstr(line_buf, doc->file_type->comment_single) == NULL) &&
+					!EMPTY(doc->file_type->comment_close) &&
+					(closing_comment = strstr(task_start, doc->file_type->comment_close)) != NULL)
+					*closing_comment = '\0';
 				/* create the task */
 				create_task(t, doc, line, *token, line_buf, task_start, display_name);
 				/* if we found a token, continue on next line */

--- a/addons/src/ao_tasks.c
+++ b/addons/src/ao_tasks.c
@@ -570,24 +570,24 @@ static void update_tasks_for_doc(AoTasks *t, GeanyDocument *doc)
 		for (line = 0; line < lines; line++)
 		{
 			line_buf = g_strstrip(sci_get_line(doc->editor->sci, line));
-			token = priv->tokens;
-			while (*token != NULL)
+			for (token = priv->tokens; *token != NULL; ++token)
 			{
-				if (!EMPTY(*token) && (task_start = strstr(line_buf, *token)) != NULL)
-				{
-					/* skip the token and additional whitespace */
-					task_start += strlen(*token);
-					while (*task_start == ' ' || *task_start == ':')
-						task_start++;
-					/* reset task_start in case there is no text following */
-					if (EMPTY(task_start))
-						task_start = line_buf;
-					/* create the task */
-					create_task(t, doc, line, *token, line_buf, task_start, display_name);
-					/* if we found a token, continue on next line */
-					break;
-				}
-				token++;
+				if (EMPTY(*token))
+					continue;
+				if ((task_start = strstr(line_buf, *token)) == NULL)
+					continue;
+
+				/* skip the token and additional whitespace */
+				task_start += strlen(*token);
+				while (*task_start == ' ' || *task_start == ':')
+					task_start++;
+				/* reset task_start in case there is no text following */
+				if (EMPTY(task_start))
+					task_start = line_buf;
+				/* create the task */
+				create_task(t, doc, line, *token, line_buf, task_start, display_name);
+				/* if we found a token, continue on next line */
+				break;
 			}
 			g_free(line_buf);
 		}


### PR DESCRIPTION
- Do not extract tokens from non-comments
- Strip the comment closing sequence from the text  
    Allows to use `/* TODO: some stuff */` without the extra `*/` being in the tasks list