### PR TITLE
Commander: Add period to SEPARATORS

### DIFF
--- a/commander/src/commander-plugin.c
+++ b/commander/src/commander-plugin.c
@@ -114,7 +114,7 @@ enum {
 
 #define PATH_SEPARATOR " \342\206\222 " /* right arrow */
 
-#define SEPARATORS        " -_/\\\"'"
+#define SEPARATORS        " -_./\\\"'"
 #define IS_SEPARATOR(c)   (strchr (SEPARATORS, (c)) != NULL)
 #define next_separator(p) (strpbrk (p, SEPARATORS))
 


### PR DESCRIPTION
This makes it easier to switch between files. For example, if I have `xyzzy.c` and `xyzzy.h` open, I can switch to `xyzzy.h` by typing “x.h”.