### PR TITLE
Fix build failure if no translation matching LINGUAS

### DIFF
--- a/build/i18n.m4
+++ b/build/i18n.m4
@@ -1,14 +1,9 @@
 AC_DEFUN([GP_I18N],
 [
-    if test -n "${LINGUAS}"
-    then
-        ALL_LINGUAS="${LINGUAS}"
-    else
-        if test -z "$conf_dir" ; then
-            conf_dir="."
-        fi
-        ALL_LINGUAS=`cd "$conf_dir/po" 2>/dev/null && ls *.po 2>/dev/null | $AWK 'BEGIN { FS="."; ORS=" " } { print $[1] }'`
+    if test -z "$conf_dir" ; then
+        conf_dir="."
     fi
+    ALL_LINGUAS=`cd "$conf_dir/po" 2>/dev/null && ls *.po 2>/dev/null | $AWK 'BEGIN { FS="."; ORS=" " } { print $[1] }'`
     GETTEXT_PACKAGE=geany-plugins
     AC_SUBST(GETTEXT_PACKAGE)
     AC_DEFINE_UNQUOTED(


### PR DESCRIPTION
Testing files installed into /usr/share/locale/ with different values of environment variable LINGUAS:

```
LINGUAS="en_GB en"
None

LINGUAS="en_GB en es"
/usr/share/locale/es/LC_MESSAGES/geany-plugins.mo

LINGUAS undefined
/usr/share/locale/be/LC_MESSAGES/geany-plugins.mo
/usr/share/locale/ca/LC_MESSAGES/geany-plugins.mo
/usr/share/locale/da/LC_MESSAGES/geany-plugins.mo
/usr/share/locale/de/LC_MESSAGES/geany-plugins.mo
/usr/share/locale/es/LC_MESSAGES/geany-plugins.mo
/usr/share/locale/fr/LC_MESSAGES/geany-plugins.mo
/usr/share/locale/gl/LC_MESSAGES/geany-plugins.mo
/usr/share/locale/it/LC_MESSAGES/geany-plugins.mo
/usr/share/locale/ja/LC_MESSAGES/geany-plugins.mo
/usr/share/locale/kk/LC_MESSAGES/geany-plugins.mo
/usr/share/locale/nl/LC_MESSAGES/geany-plugins.mo
/usr/share/locale/pt/LC_MESSAGES/geany-plugins.mo
/usr/share/locale/pt_BR/LC_MESSAGES/geany-plugins.mo
/usr/share/locale/ru/LC_MESSAGES/geany-plugins.mo
/usr/share/locale/tr/LC_MESSAGES/geany-plugins.mo
/usr/share/locale/zh_CN/LC_MESSAGES/geany-plugins.mo

LINGUAS=""
/usr/share/locale/be/LC_MESSAGES/geany-plugins.mo
/usr/share/locale/ca/LC_MESSAGES/geany-plugins.mo
/usr/share/locale/da/LC_MESSAGES/geany-plugins.mo
/usr/share/locale/de/LC_MESSAGES/geany-plugins.mo
/usr/share/locale/es/LC_MESSAGES/geany-plugins.mo
/usr/share/locale/fr/LC_MESSAGES/geany-plugins.mo
/usr/share/locale/gl/LC_MESSAGES/geany-plugins.mo
/usr/share/locale/it/LC_MESSAGES/geany-plugins.mo
/usr/share/locale/ja/LC_MESSAGES/geany-plugins.mo
/usr/share/locale/kk/LC_MESSAGES/geany-plugins.mo
/usr/share/locale/nl/LC_MESSAGES/geany-plugins.mo
/usr/share/locale/pt/LC_MESSAGES/geany-plugins.mo
/usr/share/locale/pt_BR/LC_MESSAGES/geany-plugins.mo
/usr/share/locale/ru/LC_MESSAGES/geany-plugins.mo
/usr/share/locale/tr/LC_MESSAGES/geany-plugins.mo
/usr/share/locale/zh_CN/LC_MESSAGES/geany-plugins.mo
```
