### PR TITLE
Addons: Implement deselect with single click

### DIFF
--- a/addons/src/ao_markword.h
+++ b/addons/src/ao_markword.h
@@ -40,9 +40,9 @@ typedef struct _AoMarkWord				AoMarkWord;
 typedef struct _AoMarkWordClass			AoMarkWordClass;
 
 GType			ao_mark_word_get_type		(void);
-AoMarkWord*		ao_mark_word_new			(gboolean enable);
-void			ao_mark_word_check			(AoMarkWord *bm, GeanyEditor *editor,
-											 SCNotification *nt);
+AoMarkWord*		ao_mark_word_new			(gboolean enable, gboolean single_click_deselect);
+void			ao_mark_document_open		(AoMarkWord *mw, GeanyDocument *document);
+void			ao_mark_document_close		(AoMarkWord *mw, GeanyDocument *document);
 
 G_END_DECLS
 


### PR DESCRIPTION
For this to work, we need to connect to the "button-press-event" for
each document and then differentiate between single and double
clicks, using a timeout handler which is triggered first after the GTK
double-click-time has passed, i.e. GTK won't recognise the event as part
of a double click.

I didn't find a easier solution to differentiate between single and double click.
Better ideas are welcome.

Closes #445.