### PR TITLE
geanyprj/workingdir

### DIFF
--- a/geanyprj/src/geanyprj.c
+++ b/geanyprj/src/geanyprj.c
@@ -74,6 +74,7 @@ static void reload_project(void)
 	{
 		if (g_current_project)
 			xproject_close(TRUE);
+		set_non_ft_build_wdir((gchar*)"");
 		return;
 	}
 
@@ -86,6 +87,7 @@ static void reload_project(void)
 		xproject_close(TRUE);
 		xproject_open(proj);
 	}
+	set_non_ft_build_wdir(g_current_project->working_dir);
 	if (proj)
 		g_free(proj);
 }

--- a/geanyprj/src/geanyprj.h
+++ b/geanyprj/src/geanyprj.h
@@ -125,6 +125,7 @@ gchar *get_relative_path(const gchar *location, const gchar *path);
 gint config_length(GKeyFile *config, const gchar *section, const gchar *name);
 void save_config(GKeyFile *config, const gchar *path);
 GSList *get_file_list(const gchar *path, guint *length, gboolean(*func)(const gchar *), GError **error);
+void set_non_ft_build_wdir(gchar* wdir);
 
 
 extern struct GeanyPrj *g_current_project;

--- a/geanyprj/src/geanyprj.h
+++ b/geanyprj/src/geanyprj.h
@@ -57,6 +57,7 @@ struct GeanyPrj
 	gchar *description;
 	gchar *base_path;
 	gchar *run_cmd;
+	gchar *working_dir;
 
 	gboolean regenerate;
 	gint type;
@@ -86,6 +87,7 @@ void geany_project_set_regenerate(struct GeanyPrj *prj, gboolean val);
 void geany_project_set_description(struct GeanyPrj *prj, const gchar *description);
 void geany_project_set_base_path(struct GeanyPrj *prj, const gchar *base_path);
 void geany_project_set_run_cmd(struct GeanyPrj *prj, const gchar *run_cmd);
+void geany_project_set_working_dir(struct GeanyPrj *prj, const gchar *working_dir);
 void geany_project_set_tags_from_list(struct GeanyPrj *prj, GSList *files);
 
 

--- a/geanyprj/src/menu.c
+++ b/geanyprj/src/menu.c
@@ -177,6 +177,18 @@ static PropertyDialogElements *build_properties_dialog(gboolean properties)
 	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(e->regenerate), TRUE);
 	ui_table_add_row(GTK_TABLE(table), 3, label, e->regenerate, NULL);
 
+	/* add row for working directory */
+	label = gtk_label_new(_("Working Directory:"));
+	gtk_misc_set_alignment(GTK_MISC(label), 1, 0);
+
+	e->working_dir = gtk_entry_new();
+	gtk_widget_set_tooltip_text(e->working_dir,
+			     _("Working directory for run and build commands."));
+	bbox = ui_path_box_new(_("Choose Project working dirctory."),
+			       GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER, GTK_ENTRY(e->working_dir));
+	gtk_entry_set_text(GTK_ENTRY(e->working_dir), dir);
+
+	ui_table_add_row(GTK_TABLE(table), 4, label, bbox, NULL);
 
 	label = gtk_label_new(_("Type:"));
 	gtk_misc_set_alignment(GTK_MISC(label), 1, 0);
@@ -186,7 +198,7 @@ static PropertyDialogElements *build_properties_dialog(gboolean properties)
 		gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(e->type), project_type_string[i]);
 	gtk_combo_box_set_active(GTK_COMBO_BOX(e->type), 0);
 
-	ui_table_add_row(GTK_TABLE(table), 4, label, e->type, NULL);
+	ui_table_add_row(GTK_TABLE(table), 5, label, e->type, NULL);
 
 	gtk_container_add(GTK_CONTAINER(vbox), table);
 	g_free(dir);

--- a/geanyprj/src/menu.c
+++ b/geanyprj/src/menu.c
@@ -50,6 +50,7 @@ typedef struct _PropertyDialogElements
 	GtkWidget *description;
 	GtkWidget *file_name;
 	GtkWidget *base_path;
+	GtkWidget *working_dir;
 	GtkWidget *make_in_base_path;
 	GtkWidget *run_cmd;
 	GtkWidget *regenerate;
@@ -226,6 +227,7 @@ void on_new_project(G_GNUC_UNUSED GtkMenuItem *menuitem, G_GNUC_UNUSED gpointer 
 		geany_project_set_name(prj, gtk_entry_get_text(GTK_ENTRY(e->name)));
 		geany_project_set_description(prj, "");
 		geany_project_set_run_cmd(prj, "");
+		geany_project_set_working_dir(prj, gtk_entry_get_text(GTK_ENTRY(e->working_dir)));
 		geany_project_set_type_int(prj, gtk_combo_box_get_active(GTK_COMBO_BOX(e->type)));
 		geany_project_set_regenerate(prj,
 					     gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON
@@ -255,6 +257,7 @@ void on_preferences(G_GNUC_UNUSED GtkMenuItem *menuitem, G_GNUC_UNUSED gpointer 
 	gtk_entry_set_text(GTK_ENTRY(e->file_name), project_dir);
 	gtk_entry_set_text(GTK_ENTRY(e->name), g_current_project->name);
 	gtk_entry_set_text(GTK_ENTRY(e->base_path), g_current_project->base_path);
+	gtk_entry_set_text(GTK_ENTRY(e->working_dir), g_current_project->working_dir);
 	gtk_combo_box_set_active(GTK_COMBO_BOX(e->type), g_current_project->type);
 	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(e->regenerate),
 				     g_current_project->regenerate);
@@ -269,6 +272,7 @@ void on_preferences(G_GNUC_UNUSED GtkMenuItem *menuitem, G_GNUC_UNUSED gpointer 
 		geany_project_set_name(g_current_project, gtk_entry_get_text(GTK_ENTRY(e->name)));
 		geany_project_set_description(g_current_project, "");
 		geany_project_set_run_cmd(g_current_project, "");
+		geany_project_set_working_dir(g_current_project,  gtk_entry_get_text(GTK_ENTRY(e->working_dir)));
 		geany_project_set_type_int(g_current_project,
 					   gtk_combo_box_get_active(GTK_COMBO_BOX(e->type)));
 		geany_project_set_regenerate(g_current_project,

--- a/geanyprj/src/project.c
+++ b/geanyprj/src/project.c
@@ -145,6 +145,10 @@ struct GeanyPrj *geany_project_load(const gchar *path)
 	geany_project_set_run_cmd(ret, tmp);
 	g_free(tmp);
 
+	tmp = utils_get_setting_string(config, "project", "working_dir", "");
+	geany_project_set_working_dir(ret, tmp);
+	g_free(tmp);
+
 	geany_project_set_type_string(ret,
 				      utils_get_setting_string(config, "project", "type",
 							       project_type_string[0]));
@@ -311,6 +315,14 @@ void geany_project_set_run_cmd(struct GeanyPrj *prj, const gchar *run_cmd)
 }
 
 
+void geany_project_set_working_dir(struct GeanyPrj *prj, const gchar *working_dir)
+{
+	if (prj->working_dir)
+		g_free(prj->working_dir);
+	prj->working_dir = g_strdup(working_dir);
+}
+
+
 /* list in utf8 */
 void geany_project_set_tags_from_list(struct GeanyPrj *prj, GSList *files)
 {
@@ -353,6 +365,8 @@ void geany_project_free(struct GeanyPrj *prj)
 		g_free(prj->base_path);
 	if (prj->run_cmd)
 		g_free(prj->run_cmd);
+	if (prj->working_dir)
+		g_free(prj->working_dir);
 	if (prj->tags)
 	{
 		remove_all_tags(prj);
@@ -452,6 +466,7 @@ void geany_project_save(struct GeanyPrj *prj)
 	g_key_file_set_string(config, "project", "run_cmd", prj->run_cmd);
 	g_key_file_set_boolean(config, "project", "regenerate", prj->regenerate);
 	g_key_file_set_string(config, "project", "type", project_type_string[prj->type]);
+	g_key_file_set_string(config, "project", "working_dir", prj->working_dir);
 
 	data.prj = prj;
 	data.config = config;

--- a/geanyprj/src/project.c
+++ b/geanyprj/src/project.c
@@ -478,5 +478,6 @@ void geany_project_save(struct GeanyPrj *prj)
 		g_hash_table_foreach(prj->tags, geany_project_save_files, &data);
 	}
 	save_config(config, prj->path);
+	set_non_ft_build_wdir(g_current_project->working_dir);
 	g_free(base_path);
 }

--- a/geanyprj/src/utils.c
+++ b/geanyprj/src/utils.c
@@ -275,3 +275,13 @@ GSList *get_file_list(const gchar *path, guint * length, gboolean(*func)(const g
 	return list;
 }
 
+/* update Geany's non-filetype working directories in the build menu to wdir */
+void set_non_ft_build_wdir(gchar* wdir) {
+	gint i;
+	for(i = 0; i < build_get_group_count(GEANY_GBG_NON_FT); ++i)
+		build_set_menu_item(GEANY_BCS_PREF, /* medium priority */
+							GEANY_GBG_NON_FT, /* non-filetype build entries */
+							i,
+							GEANY_BC_WORKING_DIR, /* working dir field */
+							wdir);
+}


### PR DESCRIPTION
This implements working directories in the geanyprj plugin.
The motivation is to be able to 'make' via build menu shortcut within Geany when the project is set up with CMake and uses some far away build directory.
It syncs with Geany's own build menu working directories, while giving precedence to the main project system.

Comments/improvements welcome.