### PR TITLE
Strip single quotes from words' beginning and end

### DIFF
--- a/spellcheck/src/speller.c
+++ b/spellcheck/src/speller.c
@@ -53,7 +53,7 @@ static void dict_describe(const gchar* const lang, const gchar* const name,
 
 static gboolean is_word_sep(gunichar c)
 {
-	return (g_unichar_isspace(c) || g_unichar_ispunct(c)) && c != (gunichar)'\'';
+	return g_unichar_isspace(c) || g_unichar_ispunct(c);
 }
 
 


### PR DESCRIPTION
Skipping quotes on word stripping should not be necessary any longer
since we add the single quote character to the wordchars list
(eaad256).

Fixes #484.