### PR TITLE
Markdown: Allow exporting Markdown as HTML

### DIFF
--- a/markdown/src/viewer.c
+++ b/markdown/src/viewer.c
@@ -309,7 +309,7 @@ on_webview_load_status_notify(WebKitWebView *view, GParamSpec *pspec,
   }
 }
 
-static gchar *
+gchar *
 markdown_viewer_get_html(MarkdownViewer *self)
 {
   gchar *md_as_html, *html = NULL;

--- a/markdown/src/viewer.h
+++ b/markdown/src/viewer.h
@@ -56,6 +56,7 @@ GtkWidget *markdown_viewer_new(MarkdownConfig *conf);
 void markdown_viewer_set_markdown(MarkdownViewer *self, const gchar *text,
   const gchar *encoding);
 void markdown_viewer_queue_update(MarkdownViewer *self);
+gchar *markdown_viewer_get_html(MarkdownViewer *self);
 
 G_END_DECLS
 


### PR DESCRIPTION
Add a Tools menu item "Export Markdown as HTML" to allow saving of the rendered HTML to disk instead of just the live preview.

Closes #497