### PR TITLE
geanylua: Fix build with latest Scintilla

### DIFF
--- a/geanylua/glspi_sci.c
+++ b/geanylua/glspi_sci.c
@@ -739,7 +739,7 @@ static gint glspi_scintilla(lua_State* L)
 
 static gint glspi_find(lua_State* L)
 {
-	struct TextToFind ttf;
+	struct Sci_TextToFind ttf;
 
 	gint flags=0;
 	gint i,n;
@@ -820,7 +820,7 @@ struct CharacterRange {
 */
 
 /*
-struct TextToFind {
+struct Sci_TextToFind {
 		struct CharacterRange chrg;     // range to search
 		char *lpstrText;                // the search pattern (zero terminated)
 		struct CharacterRange chrgText; // returned as position of matching text


### PR DESCRIPTION
When not defining `INCLUDE_DEPRECATED_FEATURES`, unprefixed structure names are not available anymore.  Thus, use prefixed names.


---
Since the last Scintilla update in Geany (3.7.1) unprefixed structure names are hidden.  This is good in theory, and will avoid thinks like 87d4bbcd16a41fce93b7da20c2135ff728b25791 in the future, but GeanyLua used unprefixed names.

So, in addition to the fix, do we want to restore the old names, or break API to reflect those are now removed, or do we consider it's not part of our API and thus don't care?  Of course as it's a structure name, it only affects building the code, the generated one is still binary compatible anyway.
@elextr @codebrainz @frlan 