### PR TITLE
Automark: Don't try to get some selection if line is empty

### DIFF
--- a/automark/src/automark.c
+++ b/automark/src/automark.c
@@ -87,6 +87,9 @@ get_current_word(ScintillaObject *sci)
 	gint start = SSM(sci, SCI_WORDSTARTPOSITION, pos, TRUE);
 	gint end = SSM(sci, SCI_WORDENDPOSITION, pos, TRUE);
 
+	if (end == start)
+		return NULL;
+
 	if ((guint)(end - start) >= GEANY_MAX_WORD_LENGTH)
 		end = start + (GEANY_MAX_WORD_LENGTH - 1);
 	return sci_get_contents_range(sci, start, end);


### PR DESCRIPTION
This PR should remove warnings like 

`(geany:7479): Geany-CRITICAL **: sci_get_contents_range: assertion 'start < end' failed`

Backtrace befre:

```
Thread 1 "geany" hit Breakpoint 1, handler_log (domain=0x7ffff7b64da2 "Geany", level=G_LOG_LEVEL_CRITICAL, 
    msg=0x55555651f800 "sci_get_contents_range: assertion 'start < end' failed", data=0x0) at log.c:121
121	{
(gdb) bt
#0  handler_log (domain=0x7ffff7b64da2 "Geany", level=G_LOG_LEVEL_CRITICAL, 
    msg=0x55555651f800 "sci_get_contents_range: assertion 'start < end' failed", data=0x0) at log.c:121
#1  0x00007ffff52bd5c4 in g_logv () from /lib/x86_64-linux-gnu/libglib-2.0.so.0
#2  0x00007ffff52bd7cf in g_log () from /lib/x86_64-linux-gnu/libglib-2.0.so.0
#3  0x00007ffff79bf94b in sci_get_contents_range (sci=sci@entry=0x555556373520, start=start@entry=11519, end=<optimized out>)
    at sciwrappers.c:990
#4  0x00007fffe5db8da8 in get_current_word (sci=0x555556373520) at automark.c:92
#5  automark (user_data=<optimized out>) at automark.c:117
#6  0x00007ffff52b66aa in g_main_context_dispatch () from /lib/x86_64-linux-gnu/libglib-2.0.so.0
#7  0x00007ffff52b6a60 in ?? () from /lib/x86_64-linux-gnu/libglib-2.0.so.0
#8  0x00007ffff52b6d82 in g_main_loop_run () from /lib/x86_64-linux-gnu/libglib-2.0.so.0
#9  0x00007ffff7251cc5 in gtk_main () from /usr/lib/x86_64-linux-gnu/libgtk-3.so.0
#10 0x00007ffff79ad097 in main_lib (argc=<optimized out>, argv=<optimized out>) at libmain.c:1233
#11 0x00007ffff4cd12b1 in __libc_start_main () from /lib/x86_64-linux-gnu/libc.so.6
#12 0x000055555555478a in _start ()
(gdb) r

```