### PR TITLE
Use online version of plugin help

### DIFF
--- a/geanyctags/src/geanyctags.c
+++ b/geanyctags/src/geanyctags.c
@@ -112,7 +112,7 @@ PluginCallback plugin_callbacks[] = {
 
 void plugin_help (void)
 {
-	utils_open_browser (DOCDIR "/" PLUGIN "/README");
+	utils_open_browser("http://plugins.geany.org/geanyctags.html");
 }
 
 static void spawn_cmd(const gchar *cmd, const gchar *dir)

--- a/projectorganizer/src/prjorg-main.c
+++ b/projectorganizer/src/prjorg-main.c
@@ -219,5 +219,5 @@ void plugin_cleanup(void)
 
 void plugin_help (void)
 {
-	utils_open_browser (DOCDIR "/" PLUGIN "/README");
+	utils_open_browser("http://plugins.geany.org/projectorganizer.html");
 }


### PR DESCRIPTION
This avoids platform-specific paths to the documentation and the html formating is also nicer.