### PR TITLE
Remove -Werror=aggregate-return from travis flags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -125,7 +125,7 @@ before_install:
 
 before_script:
   # prepare for GP
-  - export CFLAGS="-g -O2 -Werror=pointer-arith -Werror=aggregate-return -Werror=implicit-function-declaration"
+  - export CFLAGS="-g -O2 -Werror=pointer-arith -Werror=implicit-function-declaration"
 
 script:
   - NOCONFIGURE=1 ./autogen.sh


### PR DESCRIPTION
While in general one should avoid returning big structs for performance
reasons, it's no big problem for small structs and it can lead to more
readable code.

Having this check on for everything seems to be too strict - if someone
is returning big structs like crazy, someone will probably notice during
the review. Otherwise it's no problem.