### PR TITLE
git-changebar: Add the possibility to undo hunk at cursor position

### DIFF
--- a/git-changebar/README
+++ b/git-changebar/README
@@ -8,8 +8,8 @@ Git Change Bar
 About
 =====
 
-This plugin highlights uncommitted changes to files tracked with Git, and
-allows to navigate through the hunks.
+This plugin highlights uncommitted changes to files tracked with Git,
+allows to navigate through the hunks and undo them.
 
 
 Requirements
@@ -38,6 +38,10 @@ To navigate through the hunks of the current file, you need to configure the
 plugin's *Go to next hunk* and *Go to previous hunk* keybindings in Geany's
 preferences dialog.
 
+Hunks can also be undone by either setting a cursor at a line with a hunk and
+invoking the *Undo hunk at the cursor position* or by right-clicking in the
+editor where the hunk is located and selecting *Undo Git hunk* from the popup
+menu.
 
 License
 =======

--- a/git-changebar/src/gcb-plugin.c
+++ b/git-changebar/src/gcb-plugin.c
@@ -602,7 +602,7 @@ release_resources (ScintillaObject *sci)
 
 /* checks whether @encoding needs to be converted to UTF-8 */
 static gboolean
-encoding_needs_coversion (const gchar *encoding)
+encoding_needs_conversion (const gchar *encoding)
 {
   return (encoding &&
           ! utils_str_equal (encoding, "UTF-8") &&
@@ -705,7 +705,7 @@ diff_buf_to_doc (const git_buf   *old_buf,
     free_buf = add_utf8_bom (&buf, &len, free_buf);
   }
   /* convert the buffer back to in-file encoding if necessary */
-  if (encoding_needs_coversion (doc->encoding)) {
+  if (encoding_needs_conversion (doc->encoding)) {
     free_buf = convert_encoding_inplace (&buf, &len, free_buf,
                                          doc->encoding, "UTF-8", NULL);
   }
@@ -785,7 +785,7 @@ get_widget_for_buf_range (GeanyDocument *doc,
   }
   
   /* convert the buffer to UTF-8 if necessary */
-  if (encoding_needs_coversion (doc->encoding)) {
+  if (encoding_needs_conversion (doc->encoding)) {
     free_buf = convert_encoding_inplace (&buf, &buf_len, free_buf,
                                          "UTF-8", doc->encoding, NULL);
   }
@@ -1121,7 +1121,7 @@ insert_buf_range (GeanyDocument *doc,
   gchar           *old_range;
   
   /* convert the buffer to UTF-8 if necessary */
-  if (encoding_needs_coversion (doc->encoding)) {
+  if (encoding_needs_conversion (doc->encoding)) {
     free_buf = convert_encoding_inplace (&old_buf, &old_buf_len, free_buf,
                                          "UTF-8", doc->encoding, NULL);
   }

--- a/git-changebar/src/gcb-plugin.c
+++ b/git-changebar/src/gcb-plugin.c
@@ -1190,11 +1190,11 @@ undo_hunk_cb (const gchar *path,
     if (data->found) {
       ScintillaObject  *sci   = doc->editor->sci;
       gint              line  = data->new_start - (data->new_lines ? 1 : 0);
+      gint              pos   = sci_get_position_from_line (sci, line);
 
       sci_start_undo_action (sci);
 
       if (data->new_lines > 0) {
-        gint pos = sci_get_position_from_line (sci, line);
         sci_set_target_start (sci, pos);
         pos = sci_get_position_from_line (sci, line + data->new_lines);
         sci_set_target_end (sci, pos);
@@ -1202,16 +1202,18 @@ undo_hunk_cb (const gchar *path,
       }
 
       if (data->old_lines > 0) {
-        gint pos = sci_get_position_from_line (sci, line);
-
+        pos = sci_get_position_from_line (sci, line);
         insert_buf_range (doc, contents, pos,
                           data->old_start - 1,
                           data->old_lines);
+
+        pos = sci_get_position_from_line (sci, line + data->old_lines);
+        sci_set_current_position (sci, pos, FALSE);
       }
 
       scintilla_send_message (sci, SCI_SCROLLRANGE,
-                              sci_get_position_from_line (sci, line + data->old_lines),
-                              sci_get_position_from_line (sci, line));
+                              sci_get_position_from_line (sci, line),
+                              pos);
 
       sci_end_undo_action (sci);
     }

--- a/git-changebar/src/gcb-plugin.c
+++ b/git-changebar/src/gcb-plugin.c
@@ -73,6 +73,8 @@ PLUGIN_SET_TRANSLATABLE_INFO (
 #define DOC_ID_QTAG \
   (g_quark_from_string (PLUGIN"/git-doc-id"))
 
+#define REMOVED_MARKER_POS(pos) \
+    ((pos) == 0 ? 0 : (pos) - 1)
 
 enum {
   MARKER_LINE_ADDED,
@@ -745,7 +747,7 @@ diff_hunk_cb (const git_diff_delta *delta,
       scintilla_send_message (sci, SCI_MARKERADD, line - 1, G_markers[marker].num);
     }
   } else {
-    line = (hunk->new_start == 0) ? 0 : hunk->new_start - 1;
+    line = REMOVED_MARKER_POS (hunk->new_start);
     scintilla_send_message (sci, SCI_MARKERADD, line,
                             G_markers[MARKER_LINE_REMOVED].num);
   }
@@ -1061,13 +1063,13 @@ goto_next_hunk_diff_hunk_cb (const git_diff_delta *delta,
       if (data->next_line >= 0) {
         return 1;
       } else if (data->line < hunk->new_start - 1) {
-        data->next_line = (hunk->new_start == 0) ? 0 : hunk->new_start - 1;
+        data->next_line = REMOVED_MARKER_POS (hunk->new_start);
       }
       break;
     
     case KB_GOTO_PREV_HUNK:
       if (data->line > hunk->new_start - 1 + MAX (hunk->new_lines - 1, 0)) {
-        data->next_line = (hunk->new_start == 0) ? 0 : hunk->new_start - 1;
+        data->next_line = REMOVED_MARKER_POS (hunk->new_start);
       }
       break;
   }


### PR DESCRIPTION
The patch adds a new keybinding action for undoing hunks. When cursor is
placed at a line with a diff and the keybinding is invoked, the
corresponding hunk is undone.

To get the previous contents at the given position, a temporary Scintilla
instance is used into which the previous state of the document is loaded
and the corresponding text from the previous state of the document is
extracted. This temporary Scintilla object is then destroyed.