### PR TITLE
Updatechecker: remove deprecated soup call

### DIFF
--- a/build/updatechecker.m4
+++ b/build/updatechecker.m4
@@ -3,7 +3,7 @@ AC_DEFUN([GP_CHECK_UPDATECHECKER],
     GP_ARG_DISABLE([Updatechecker], [auto])
 
     GP_CHECK_PLUGIN_DEPS([Updatechecker], UPDATECHECKER,
-                         [libsoup-2.4 >= 2.4.0])
+                         [libsoup-2.4 >= 2.42])
 
     GP_COMMIT_PLUGIN_STATUS([Updatechecker])
 

--- a/updatechecker/README
+++ b/updatechecker/README
@@ -40,7 +40,7 @@ Updatechecker depends on a recent version of Geany (0.20 or above)
 as well as on:
 
 * GTK >= 2.12
-* libsoup 2.4 >= 2.4.0
+* libsoup 2.4 >= 2.42
 
 To compile it on your own you will need the devel packages for these.
 

--- a/updatechecker/src/updatechecker.c
+++ b/updatechecker/src/updatechecker.c
@@ -83,7 +83,7 @@ static void update_check(gint type)
                                      GEANY_VERSION, NULL);
 
     g_message("Checking for updates (querying URL \"%s\")", UPDATE_CHECK_URL);
-    soup = soup_session_async_new_with_options(
+    soup = soup_session_new_with_options(
             SOUP_SESSION_USER_AGENT, user_agent,
             SOUP_SESSION_TIMEOUT, 10,
             NULL);


### PR DESCRIPTION
This should fix deprecated warnings on more recent soup versions.