### PR TITLE
Add travis status to README

### DIFF
--- a/README
+++ b/README
@@ -2,6 +2,12 @@
 Geany-Plugins
 ===============
 
+Status
+------
+
+.. image:: https://travis-ci.org/geany/geany-plugins.svg?branch=master
+    :target: https://travis-ci.org/geany/geany-plugins
+    
 Installation
 ------------
 


### PR DESCRIPTION
This PR adds the travis status icon to README. I do like it but this might leak information about our users to travis while loading the image e.g. during browsing README. 