### PR TITLE
Fix crash in projectorganizer's crash-fix

### DIFF
--- a/projectorganizer/src/prjorg-sidebar.c
+++ b/projectorganizer/src/prjorg-sidebar.c
@@ -1221,7 +1221,10 @@ static gboolean expand_on_idle(ExpandData *expand_data)
 {
 	GeanyDocument *doc = document_get_current();
 
-	if (prj_org && geany_data->app->project == expand_data->project &&
+	if (!prj_org)
+		return FALSE;
+
+	if (geany_data->app->project == expand_data->project &&
 		expand_data->expanded_paths)
 	{
 		gchar *item;


### PR DESCRIPTION
Well, yeah, there was a NULL check missing in the previous pull request. No make it clear what has changed I kept the previous patch and added another patch which fixes the crash when no project is open.