### PR TITLE
Improve the error message on attempt to run gdb

### DIFF
--- a/scope/src/debug.c
+++ b/scope/src/debug.c
@@ -458,7 +458,7 @@ static void load_program(void)
 	}
 	else
 	{
-		show_error(_("%s."), gerror->message);
+		show_error(_("%s: %s."), pref_gdb_executable, gerror->message);
 		g_error_free(gerror);
 	}
 


### PR DESCRIPTION
On failure to run gdb, Scope displays only the generic error message, such as "The system cannot find the file specified", giving the impression that the executable to be debugged is missing or has some other problem. This patch changes the message to "<gdb name>: <error>", for example "gdb: The system cannot find the file specified" (unlikely under *nix, but gdb may be missing from the PATH under Windows).

Closes https://github.com/geany/geany-plugins/issues/337