### PR TITLE
Enable Mark Word also for newly opened documents

### DIFF
--- a/addons/src/addons.c
+++ b/addons/src/addons.c
@@ -104,6 +104,7 @@ static AddonsInfo *ao_info = NULL;
 static void ao_update_editor_menu_cb(GObject *obj, const gchar *word, gint pos,
 									 GeanyDocument *doc, gpointer data);
 static void ao_document_activate_cb(GObject *obj, GeanyDocument *doc, gpointer data);
+static void ao_document_new_cb(GObject *obj, GeanyDocument *doc, gpointer data);
 static void ao_document_open_cb(GObject *obj, GeanyDocument *doc, gpointer data);
 static void ao_document_save_cb(GObject *obj, GeanyDocument *doc, gpointer data);
 static void ao_document_before_save_cb(GObject *obj, GeanyDocument *doc, gpointer data);
@@ -120,6 +121,7 @@ PluginCallback plugin_callbacks[] =
 	{ "update-editor-menu", (GCallback) &ao_update_editor_menu_cb, FALSE, NULL },
 	{ "editor-notify", (GCallback) &ao_editor_notify_cb, TRUE, NULL },
 
+	{ "document-new", (GCallback) &ao_document_new_cb, TRUE, NULL },
 	{ "document-open", (GCallback) &ao_document_open_cb, TRUE, NULL },
 	{ "document-save", (GCallback) &ao_document_save_cb, TRUE, NULL },
 	{ "document-close", (GCallback) &ao_document_close_cb, TRUE, NULL },
@@ -196,6 +198,14 @@ static void ao_document_activate_cb(GObject *obj, GeanyDocument *doc, gpointer d
 
 	ao_bookmark_list_update(ao_info->bookmarklist, doc);
 	ao_tasks_update_single(ao_info->tasks, doc);
+}
+
+
+static void ao_document_new_cb(GObject *obj, GeanyDocument *doc, gpointer data)
+{
+	g_return_if_fail(doc != NULL && doc->is_valid);
+
+	ao_mark_document_new(ao_info->markword, doc);
 }
 
 

--- a/addons/src/ao_markword.c
+++ b/addons/src/ao_markword.c
@@ -172,6 +172,13 @@ static gboolean on_editor_button_press_event(GtkWidget *widget, GdkEventButton *
 }
 
 
+void ao_mark_document_new(AoMarkWord *mw, GeanyDocument *document)
+{
+	/* there is nothing different to handling open documents, so do the same */
+	ao_mark_document_open(mw, document);
+}
+
+
 void ao_mark_document_open(AoMarkWord *mw, GeanyDocument *document)
 {
 	g_return_if_fail(DOC_VALID(document));

--- a/addons/src/ao_markword.h
+++ b/addons/src/ao_markword.h
@@ -41,6 +41,7 @@ typedef struct _AoMarkWordClass			AoMarkWordClass;
 
 GType			ao_mark_word_get_type		(void);
 AoMarkWord*		ao_mark_word_new			(gboolean enable, gboolean single_click_deselect);
+void			ao_mark_document_new		(AoMarkWord *mw, GeanyDocument *document);
 void			ao_mark_document_open		(AoMarkWord *mw, GeanyDocument *document);
 void			ao_mark_document_close		(AoMarkWord *mw, GeanyDocument *document);
 


### PR DESCRIPTION
This broke in 26e6906ed5eeab0adf5c7ad0ea177f99a3e49ea5, before the
Addons' feature "Mark Word" was enabled for all documents but after
changing the trigger to button-press-event, we connected the signal only
on "document-open" not on "document-new".

Fixes #562.