### PR TITLE
Use paths relative to the bundle on OS X

### DIFF
--- a/geniuspaste/src/geniuspaste.c
+++ b/geniuspaste/src/geniuspaste.c
@@ -244,17 +244,29 @@ static void load_pastebins_in_dir(const gchar *path)
     }
 }
 
+static gchar *get_data_dir_path(const gchar *filename)
+{
+    gchar *prefix = NULL;
+    gchar *path;
+
+#ifdef G_OS_WIN32
+    prefix = g_win32_get_package_installation_directory_of_module(NULL);
+#elif defined(__APPLE__)
+    if (g_getenv("GEANY_PLUGINS_SHARE_PATH"))
+        return g_build_filename(g_getenv("GEANY_PLUGINS_SHARE_PATH"), 
+                                PLUGIN, filename, NULL);
+#endif
+    path = g_build_filename(prefix ? prefix : "", PLUGINDATADIR, filename, NULL);
+    g_free(prefix);
+    return path;
+}
+
 static void load_all_pastebins(void)
 {
-#ifdef G_OS_WIN32
-    gchar *prefix = g_win32_get_package_installation_directory_of_module(NULL);
-#else
-    gchar *prefix = NULL;
-#endif
     gchar *paths[] = {
         g_build_filename(geany->app->configdir, "plugins", "geniuspaste",
                          "pastebins", NULL),
-        g_build_filename(prefix ? prefix : "", PLUGINDATADIR, "pastebins", NULL)
+        get_data_dir_path("pastebins")
     };
     guint i;
 
@@ -264,8 +276,6 @@ static void load_all_pastebins(void)
         g_free(paths[i]);
     }
     pastebins = g_slist_sort(pastebins, sort_pastebins);
-
-    g_free(prefix);
 }
 
 static void free_all_pastebins(void)

--- a/git-changebar/src/gcb-plugin.c
+++ b/git-changebar/src/gcb-plugin.c
@@ -1386,19 +1386,31 @@ on_plugin_configure_response (GtkDialog        *dialog,
   }
 }
 
+static gchar *
+get_data_dir_path (const gchar *filename)
+{
+  gchar *prefix = NULL;
+  gchar *path;
+
+#ifdef G_OS_WIN32
+  prefix = g_win32_get_package_installation_directory_of_module (NULL);
+#elif defined(__APPLE__)
+  if (g_getenv ("GEANY_PLUGINS_SHARE_PATH"))
+    return g_build_filename (g_getenv ("GEANY_PLUGINS_SHARE_PATH"), 
+                             PLUGIN, filename, NULL);
+#endif
+  path = g_build_filename (prefix ? prefix : "", PLUGINDATADIR, filename, NULL);
+  g_free (prefix);
+  return path;
+}
+
 GtkWidget *
 plugin_configure (GtkDialog *dialog)
 {
   GError     *error   = NULL;
   GtkWidget  *base    = NULL;
   GtkBuilder *builder = gtk_builder_new ();
-#ifdef G_OS_WIN32
-  gchar      *prefix  = g_win32_get_package_installation_directory_of_module (NULL);
-#else
-  gchar      *prefix  = NULL;
-#endif
-  gchar      *path    = g_build_filename (prefix ? prefix : "", PLUGINDATADIR,
-                                          "prefs.ui", NULL);
+  gchar      *path    = get_data_dir_path ("prefs.ui");
   
   gtk_builder_set_translation_domain (builder, GETTEXT_PACKAGE);
   if (! gtk_builder_add_from_file (builder, path, &error)) {
@@ -1444,7 +1456,6 @@ plugin_configure (GtkDialog *dialog)
   }
   
   g_free (path);
-  g_free (prefix);
   g_object_unref (builder);
   
   return base;

--- a/pohelper/src/gph-plugin.c
+++ b/pohelper/src/gph-plugin.c
@@ -1360,16 +1360,18 @@ on_color_button_color_notify (GtkWidget  *widget,
 static gchar *
 get_data_dir_path (const gchar *filename)
 {
-#ifdef G_OS_WIN32
-  gchar *prefix = g_win32_get_package_installation_directory_of_module (NULL);
-#else
   gchar *prefix = NULL;
+  gchar *path;
+
+#ifdef G_OS_WIN32
+  prefix = g_win32_get_package_installation_directory_of_module (NULL);
+#elif defined(__APPLE__)
+  if (g_getenv ("GEANY_PLUGINS_SHARE_PATH"))
+    return g_build_filename( g_getenv ("GEANY_PLUGINS_SHARE_PATH"), 
+                             PLUGIN, filename, NULL);
 #endif
-  gchar *path   = g_build_filename (prefix ? prefix : "", PLUGINDATADIR,
-                                    filename, NULL);
-  
+  path = g_build_filename (prefix ? prefix : "", PLUGINDATADIR, filename, NULL);
   g_free (prefix);
-  
   return path;
 }
 

--- a/scope/src/scope.c
+++ b/scope/src/scope.c
@@ -524,10 +524,27 @@ void configure_panel(void)
 	gtk_notebook_set_tab_pos(GTK_NOTEBOOK(debug_panel), pref_panel_tab_pos);
 }
 
+static gchar *get_data_dir_path(const gchar *filename)
+{
+	gchar *prefix = NULL;
+	gchar *path;
+
+#ifdef G_OS_WIN32
+	prefix = g_win32_get_package_installation_directory_of_module(NULL);
+#elif defined(__APPLE__)
+	if (g_getenv("GEANY_PLUGINS_SHARE_PATH"))
+		return g_build_filename(g_getenv("GEANY_PLUGINS_SHARE_PATH"), 
+								PLUGIN, filename, NULL);
+#endif
+	path = g_build_filename(prefix ? prefix : "", PLUGINDATADIR, filename, NULL);
+	g_free(prefix);
+	return path;
+}
+
 void plugin_init(G_GNUC_UNUSED GeanyData *gdata)
 {
 	GeanyKeyGroup *scope_key_group;
-	char *gladefile = g_build_filename(PLUGINDATADIR, "scope.glade", NULL);
+	char *gladefile = get_data_dir_path("scope.glade");
 	GError *gerror = NULL;
 	GtkWidget *menubar1 = ui_lookup_widget(geany->main_widgets->window, "menubar1");
 	guint item;


### PR DESCRIPTION
These patches try to fix the problems described in https://github.com/geany/geany-plugins/issues/507 for various plugins. They address only "serious" issues which prevent correct operation of the plugin like not locating .glade or .ui files, not "minor" problems like not showing documentation when clicking the Help button of the plugin.

There's the same function get_data_dir_path() in each plugin which locates the file in the correct directory for each platform. For OS X laucher script I added an environment variable GEANY_PLUGINS_SHARE_PATH which is set before the binary is started so it should be defined and can be used by the plugin.