### PR TITLE
Pass a GdkKeymap to gdk_keymap_* functions

### DIFF
--- a/geanylua/glspi_app.c
+++ b/geanylua/glspi_app.c
@@ -544,9 +544,10 @@ static GdkFilterReturn keygrab_cb(GdkXEvent *xevent, GdkEvent *event, gpointer d
 #include <gdk/gdkkeysyms.h>
 static gint init_key(guint keyval){
 	GdkKeymapKey *kmk=NULL;
+	GdkKeymap *gdk_key_map=gdk_keymap_get_default();
 	gint n_keys=0;
 	gint rv=0;
-	if (gdk_keymap_get_entries_for_keyval(NULL,keyval,&kmk,&n_keys)) {
+	if (gdk_keymap_get_entries_for_keyval(gdk_key_map,keyval,&kmk,&n_keys)) {
 		rv=kmk[0].keycode;
 		g_free(kmk);
 	}
@@ -560,6 +561,7 @@ static gint glspi_keygrab(lua_State* L)
 	GeanyDocument*doc=NULL;
 	const gchar*prompt=NULL;
 	GdkKeymapKey km={0,0,0};
+	GdkKeymap *gdk_key_map;
 	km.keycode=0;
 	km.group=0; /* Note: we hijack this field to use as a flag for first keydown. */
 	km.level=0;
@@ -595,7 +597,8 @@ static gint glspi_keygrab(lua_State* L)
 	sci_send_command(doc->editor->sci, SCI_CALLTIPCANCEL);
 	}
 	km.group=0; /* reset the hijacked flag before passing to GDK */
-	lua_pushstring(L, gdk_keyval_name(gdk_keymap_lookup_key(NULL, &km)));
+	gdk_key_map = gdk_keymap_get_default();
+	lua_pushstring(L, gdk_keyval_name(gdk_keymap_lookup_key(gdk_key_map, &km)));
 
 	return 1;
 }

--- a/geanymacro/src/geanymacro.c
+++ b/geanymacro/src/geanymacro.c
@@ -2200,6 +2200,7 @@ void plugin_init(GeanyData *data)
 {
 	gint i,k,iResults=0;
 	GdkKeymapKey *gdkkmkResults;
+	GdkKeymap *gdkKeyMap=gdk_keymap_get_default();
 
 	/* Load settings */
 	LoadSettings();
@@ -2216,7 +2217,7 @@ void plugin_init(GeanyData *data)
 	for(i=0;i<10;i++)
 	{
 		/* Get keymapkey data for number key */
-		k=gdk_keymap_get_entries_for_keyval(NULL,'0'+i,&gdkkmkResults,&iResults);
+		k=gdk_keymap_get_entries_for_keyval(gdkKeyMap,'0'+i,&gdkkmkResults,&iResults);
 		/* error retrieving hardware keycode, so leave as standard uk character for shift + number */
 		if(k==0)
 			continue;
@@ -2247,7 +2248,7 @@ void plugin_init(GeanyData *data)
 		/* set shift pressed */
 		gdkkmkResults[k].level=1;
 		/* now get keycode for shift + number */
-		iResults=gdk_keymap_lookup_key(NULL,&(gdkkmkResults[k]));
+		iResults=gdk_keymap_lookup_key(gdkKeyMap,&(gdkkmkResults[k]));
 		/* if valid keycode, enter into list of shift + numbers */
 		if(iResults!=0)
 			iShiftNumbers[i]=iResults;

--- a/geanynumberedbookmarks/src/geanynumberedbookmarks.c
+++ b/geanynumberedbookmarks/src/geanynumberedbookmarks.c
@@ -1475,6 +1475,7 @@ void plugin_init(GeanyData *data)
 {
 	gint i,k,iResults=0;
 	GdkKeymapKey *gdkkmkResults;
+	GdkKeymap *gdkKeyMap=gdk_keymap_get_default();
 
 	/* Load settings */
 	LoadSettings();
@@ -1490,7 +1491,7 @@ void plugin_init(GeanyData *data)
 	for(i=0;i<10;i++)
 	{
 		/* Get keymapkey data for number key */
-		k=gdk_keymap_get_entries_for_keyval(NULL,'0'+i,&gdkkmkResults,&iResults);
+		k=gdk_keymap_get_entries_for_keyval(gdkKeyMap,'0'+i,&gdkkmkResults,&iResults);
 		/* error retrieving hardware keycode, so leave as standard uk character for shift + number */
 		if(k==0)
 			continue;
@@ -1521,7 +1522,7 @@ void plugin_init(GeanyData *data)
 		/* set shift pressed */
 		gdkkmkResults[k].level=1;
 		/* now get keycode for shift + number */
-		iResults=gdk_keymap_lookup_key(NULL,&(gdkkmkResults[k]));
+		iResults=gdk_keymap_lookup_key(gdkKeyMap,&(gdkkmkResults[k]));
 		/* if valid keycode, enter into list of shift + numbers */
 		if(iResults!=0)
 			iShiftNumbers[i]=iResults;


### PR DESCRIPTION
This fixes crashes and critial warnings.
Fixes #585.

On Windows passing NULL as GdkKeymap crashed Geany, on other platforms there were "only" CRITICALs but possibly it could crash Geany there as well.
Using `gdk_keymap_get_default()` should suffice to use a valid GdkKeymap.