### PR TITLE
fixed exec syntax

### DIFF
--- a/geanypy/geany/console.py
+++ b/geanypy/geany/console.py
@@ -584,7 +584,7 @@ class _Console(_ReadLine, code.InteractiveInterpreter):
         except: pass
 
         try:
-            exec "import __builtin__" in self.locals
+            exec("import __builtin__" in self.locals)
             strings.extend(eval("dir(__builtin__)", self.locals))
         except:
             pass


### PR DESCRIPTION
Haven't used exec myself, but geanypy will not compile for me without this change.

-Dave