### PR TITLE
Initialize loop variables to make cppcheck happy

### DIFF
--- a/addons/src/ao_tasks.c
+++ b/addons/src/ao_tasks.c
@@ -693,7 +693,7 @@ void ao_tasks_update(AoTasks *t, GeanyDocument *cur_doc)
 	}
 	else
 	{
-		guint i;
+		guint i = 0;
 		/* clear all */
 		gtk_list_store_clear(priv->store);
 		/* iterate over all docs */

--- a/autoclose/src/autoclose.c
+++ b/autoclose/src/autoclose.c
@@ -899,7 +899,7 @@ configure_response_cb(GtkDialog *dialog, gint response, gpointer user_data)
 void
 plugin_init(G_GNUC_UNUSED GeanyData *data)
 {
-	guint i;
+	guint i = 0;
 
 	foreach_document(i)
 	{
@@ -1120,7 +1120,7 @@ plugin_configure(GtkDialog *dialog)
 static void
 autoclose_cleanup(void)
 {
-	guint i;
+	guint i = 0;
 
 	foreach_document(i)
 	{

--- a/commander/src/commander-plugin.c
+++ b/commander/src/commander-plugin.c
@@ -397,7 +397,7 @@ static void
 fill_store (GtkListStore *store)
 {
   GtkWidget  *menubar;
-  guint       i;
+  guint       i = 0;
   
   /* menu items */
   menubar = find_menubar (GTK_CONTAINER (geany_data->main_widgets->window));

--- a/geanyextrasel/src/extrasel.c
+++ b/geanyextrasel/src/extrasel.c
@@ -564,7 +564,7 @@ void plugin_init(G_GNUC_UNUSED GeanyData *data)
 
 void plugin_cleanup(void)
 {
-	guint i;
+	guint i = 0;
 
 	gtk_widget_destroy(main_menu_item);
 	column_mode = FALSE;

--- a/geanygendoc/src/ggd-tag-utils.c
+++ b/geanygendoc/src/ggd-tag-utils.c
@@ -121,8 +121,8 @@ ggd_tag_sort_by_line_to_list (const GPtrArray  *tags,
                               gint              direction)
 {
   GList  *children = NULL;
-  guint   i;
-  TMTag  *el;
+  guint   i = 0;
+  TMTag  *el = NULL;
   
   g_return_val_if_fail (tags != NULL, NULL);
   g_return_val_if_fail (direction != 0, NULL);
@@ -152,8 +152,8 @@ ggd_tag_find_from_line (const GPtrArray  *tags,
                         gulong            line)
 {
   TMTag    *tag = NULL;
-  TMTag    *el;
-  guint     i;
+  TMTag    *el = NULL;
+  guint     i = 0;
   
   g_return_val_if_fail (tags != NULL, NULL);
   
@@ -217,8 +217,8 @@ ggd_tag_find_parent (const GPtrArray *tags,
     gchar        *parent_scope = NULL;
     const gchar  *parent_name;
     const gchar  *tmp;
-    guint         i;
-    TMTag        *el;
+    guint         i = 0;
+    TMTag        *el = NULL;
     const gchar  *separator;
     gsize         separator_len;
     
@@ -407,8 +407,8 @@ ggd_tag_find_from_name (const GPtrArray *tags,
                         const gchar     *name)
 {
   TMTag  *tag = NULL;
-  guint   i;
-  TMTag  *el;
+  guint   i = 0;
+  TMTag  *el = NULL;
   
   g_return_val_if_fail (tags != NULL, NULL);
   g_return_val_if_fail (name != NULL, NULL);
@@ -444,8 +444,8 @@ ggd_tag_find_children_filtered (const GPtrArray *tags,
                                 TMTagType        filter)
 {
   GList  *children = NULL;
-  guint   i;
-  TMTag  *el;
+  guint   i = 0;
+  TMTag  *el = NULL;
   
   g_return_val_if_fail (tags != NULL, NULL);
   g_return_val_if_fail (parent != NULL, NULL);

--- a/geanylatex/src/geanylatex.c
+++ b/geanylatex/src/geanylatex.c
@@ -1283,7 +1283,7 @@ on_insert_bibtex_dialog_activate(G_GNUC_UNUSED GtkMenuItem *menuitem,
 	{
 		GDir *dir;
 		gchar *tmp_dir;
-		const gchar *filename;
+		const gchar *filename = NULL;
 
 		tmp_dir = g_path_get_dirname(doc->real_path);
 		dir = g_dir_open(tmp_dir, 0, NULL);

--- a/geanylua/glspi_doc.c
+++ b/geanylua/glspi_doc.c
@@ -50,7 +50,7 @@ static gint glspi_newfile(lua_State* L)
 static gint filename_to_doc_idx(const gchar*fn)
 {
 	if (fn && *fn) {
-		guint i;
+		guint i=0;
 		foreach_document(i)
 		{
 			if fncmp(fn,documents[i]->file_name) {return i; }
@@ -172,7 +172,7 @@ static gint glspi_documents(lua_State *L)
 /* Returns the number of open documents */
 static gint glspi_count(lua_State* L)
 {
-	guint i, n=0;
+	guint i=0, n=0;
 	foreach_document(i)
 	{
 		if (documents[i]->is_valid){n++;}

--- a/git-changebar/src/gcb-plugin.c
+++ b/git-changebar/src/gcb-plugin.c
@@ -1297,7 +1297,7 @@ plugin_init (GeanyData *data)
 void
 plugin_cleanup (void)
 {
-  guint i;
+  guint i = 0;
   
   if (G_source_id) {
     g_source_remove (G_source_id);
@@ -1363,7 +1363,7 @@ on_plugin_configure_response (GtkDialog        *dialog,
   switch (response) {
     case GTK_RESPONSE_APPLY:
     case GTK_RESPONSE_OK: {
-      guint           i;
+      guint           i = 0;
       GdkColor        color;
       GeanyDocument  *doc = document_get_current ();
       

--- a/keyrecord/src/keyrecord.c
+++ b/keyrecord/src/keyrecord.c
@@ -158,7 +158,7 @@ static gboolean keyrecord_init(GeanyPlugin *plugin, gpointer data)
     GeanyData* geany_data = plugin->geany_data;
     recorded_pattern = g_new0(GdkEventKey*, CAPACITY);
 
-	guint i;
+	guint i = 0;
 	foreach_document(i) {
 		 on_document_open(NULL, documents[i], NULL);
 	}

--- a/overview/overview/overviewui.c
+++ b/overview/overview/overviewui.c
@@ -42,7 +42,7 @@ static GtkWidget     *overview_ui_menu_item = NULL;
 static inline void
 overview_ui_scintilla_foreach (DocForEachFunc callback)
 {
-  guint i;
+  guint i = 0;
   foreach_document (i)
     {
       GeanyDocument     *doc = documents[i];

--- a/projectorganizer/src/prjorg-main.c
+++ b/projectorganizer/src/prjorg-main.c
@@ -83,7 +83,7 @@ static void on_doc_close(G_GNUC_UNUSED GObject * obj, GeanyDocument * doc,
 
 static void on_build_start(GObject *obj, gpointer user_data)
 {
-	guint i;
+	guint i = 0;
 
 	foreach_document(i)
 	{

--- a/projectorganizer/src/prjorg-menu.c
+++ b/projectorganizer/src/prjorg-menu.c
@@ -52,7 +52,7 @@ static GtkWidget *s_fif_item, *s_ff_item, *s_ft_item, *s_shs_item, *s_sep_item, 
 static gboolean try_swap_header_source(gchar *utf8_file_name, gboolean is_header, GSList *file_list, GSList *header_patterns, GSList *source_patterns)
 {
 	gchar *name_pattern;
-	GSList *elem;
+	GSList *elem = NULL;
 	GPatternSpec *pattern;
 	gboolean found = FALSE;
 
@@ -115,7 +115,7 @@ static void on_swap_header_source(G_GNUC_UNUSED GtkMenuItem * menuitem, G_GNUC_U
 	{
 		gboolean swapped;
 		GSList *elem, *list = NULL;
-		guint i;
+		guint i = 0;
 
 		foreach_document(i)
 		{
@@ -296,7 +296,7 @@ static void on_open_selected_file(GtkMenuItem *menuitem, gpointer user_data)
 
 		if (g_strcmp0(utf8_path, "") != 0)
 		{
-			GSList *elem;
+			GSList *elem = NULL;
 			const gchar *found_path = NULL;
 
 			foreach_slist (elem, prj_org->roots)

--- a/projectorganizer/src/prjorg-project.c
+++ b/projectorganizer/src/prjorg-project.c
@@ -138,7 +138,7 @@ static gint prjorg_project_rescan_root(PrjOrgRoot *root)
 	GSList *ignored_file_list = NULL;
 	GHashTable *visited_paths;
 	GSList *lst;
-	GSList *elem;
+	GSList *elem = NULL;
 	gint filenum = 0;
 
 	source_files = g_ptr_array_new();
@@ -346,7 +346,7 @@ static void update_project(
 void prjorg_project_save(GKeyFile * key_file)
 {
 	GPtrArray *array;
-	GSList *elem, *lst;
+	GSList *elem = NULL, *lst;
 
 	if (!prj_org)
 		return;
@@ -456,7 +456,7 @@ void prjorg_project_open(GKeyFile * key_file)
 {
 	gchar **source_patterns, **header_patterns, **ignored_dirs_patterns, **ignored_file_patterns, **external_dirs, **dir_ptr, *last_name;
 	gint generate_tag_prefs;
-	GSList *elem, *ext_list = NULL;
+	GSList *elem = NULL, *ext_list = NULL;
 	gchar *utf8_base_path;
 
 	if (prj_org != NULL)
@@ -674,7 +674,7 @@ void prjorg_project_close(void)
 
 gboolean prjorg_project_is_in_project(const gchar *utf8_filename)
 {
-	GSList *elem;
+	GSList *elem = NULL;
 
 	if (!utf8_filename || !prj_org || !geany_data->app->project || !prj_org->roots)
 		return FALSE;
@@ -692,14 +692,14 @@ gboolean prjorg_project_is_in_project(const gchar *utf8_filename)
 
 static gboolean add_tm_idle(gpointer foo)
 {
-	GSList *elem2;
+	GSList *elem2 = NULL;
 
 	if (!prj_org || !s_idle_add_funcs)
 		return FALSE;
 
 	foreach_slist (elem2, s_idle_add_funcs)
 	{
-		GSList *elem;
+		GSList *elem = NULL;
 		gchar *utf8_fname = elem2->data;
 
 		foreach_slist (elem, prj_org->roots)
@@ -739,14 +739,14 @@ void prjorg_project_add_single_tm_file(gchar *utf8_filename)
 
 static gboolean remove_tm_idle(gpointer foo)
 {
-	GSList *elem2;
+	GSList *elem2 = NULL;
 
 	if (!prj_org || !s_idle_remove_funcs)
 		return FALSE;
 
 	foreach_slist (elem2, s_idle_remove_funcs)
 	{
-		GSList *elem;
+		GSList *elem = NULL;
 		gchar *utf8_fname = elem2->data;
 
 		foreach_slist (elem, prj_org->roots)

--- a/projectorganizer/src/prjorg-sidebar.c
+++ b/projectorganizer/src/prjorg-sidebar.c
@@ -883,7 +883,7 @@ static void create_branch(gint level, GSList *leaf_list, GtkTreeIter *parent,
 {
 	GSList *dir_list = NULL;
 	GSList *file_list = NULL;
-	GSList *elem;
+	GSList *elem = NULL;
 
 	foreach_slist (elem, leaf_list)
 	{
@@ -1030,7 +1030,7 @@ static void load_project_root(PrjOrgRoot *root, GtkTreeIter *parent, GSList *hea
 {
 	GSList *lst = NULL;
 	GSList *path_list = NULL;
-	GSList *elem;
+	GSList *elem = NULL;
 	GHashTableIter iter;
 	gpointer key, value;
 
@@ -1077,7 +1077,7 @@ static void load_project_root(PrjOrgRoot *root, GtkTreeIter *parent, GSList *hea
 
 static void load_project(void)
 {
-	GSList *elem, *header_patterns, *source_patterns;
+	GSList *elem = NULL, *header_patterns, *source_patterns;
 	GtkTreeIter iter;
 	gboolean first = TRUE;
 	GIcon *icon_dir;
@@ -1167,7 +1167,7 @@ static gboolean expand_path(gchar *utf8_expanded_path, gboolean select)
 	GtkTreeIter root_iter, found_iter;
 	gchar *utf8_path = NULL;
 	gchar **path_split;
-	GSList *elem;
+	GSList *elem = NULL;
 	GtkTreeModel *model;
 
 	model = GTK_TREE_MODEL(s_file_store);

--- a/projectorganizer/src/prjorg-utils.c
+++ b/projectorganizer/src/prjorg-utils.c
@@ -70,7 +70,7 @@ GSList *get_precompiled_patterns(gchar **patterns)
 
 gboolean patterns_match(GSList *patterns, const gchar *str)
 {
-	GSList *elem;
+	GSList *elem = NULL;
 	foreach_slist (elem, patterns)
 	{
 		GPatternSpec *pattern = elem->data;

--- a/scope/src/scope.c
+++ b/scope/src/scope.c
@@ -89,7 +89,7 @@ static void on_scope_reset_markers(G_GNUC_UNUSED const MenuItem *menu_item)
 
 static void on_scope_cleanup_files(G_GNUC_UNUSED const MenuItem *menu_item)
 {
-	guint i;
+	guint i = 0;
 
 	foreach_document(i)
 	{
@@ -315,7 +315,7 @@ static void on_document_open(G_GNUC_UNUSED GObject *obj, GeanyDocument *doc,
 
 static gboolean settings_saved(gpointer gdata)
 {
-	guint i;
+	guint i = 0;
 
 	foreach_document(i)
 	{
@@ -334,7 +334,7 @@ static gboolean settings_saved(gpointer gdata)
 
 static void schedule_settings_saved(gboolean conterm)
 {
-	guint i;
+	guint i = 0;
 
 	plugin_idle_add(geany_plugin, settings_saved, GINT_TO_POINTER(conterm));
 

--- a/scope/src/utils.c
+++ b/scope/src/utils.c
@@ -727,7 +727,7 @@ void utils_init(void)
 
 void utils_finalize(void)
 {
-	guint i;
+	guint i = 0;
 	DebugState state = debug_state();
 
 	foreach_document(i)

--- a/spellcheck/src/gui.c
+++ b/spellcheck/src/gui.c
@@ -303,7 +303,7 @@ static void menu_item_ref(GtkWidget *menu_item)
 static void update_editor_menu_items(const gchar *search_word, const gchar **suggs, gsize n_suggs)
 {
 	GtkWidget *menu_item, *menu, *sub_menu;
-	GSList *node;
+	GSList *node = NULL;
 	gchar *label;
 	gsize i;
 


### PR DESCRIPTION
It seems newer cppcheck versions are too sensible to uninitialized loop
variables when the loop is created by a macro.
This might be a bug in cppcheck or it just cannot check the loop
properly. By initializing the affected variables explicitly, cppcheck
is happy while the unnecessary initialization should not have any
impacts.

The nightly builds for Debian Unstable are currently broken because of this.