### PR TITLE
projectorganizer: Close dir created with g_dir_open() in some special cases

### DIFF
--- a/projectorganizer/src/prjorg-project.c
+++ b/projectorganizer/src/prjorg-project.c
@@ -74,6 +74,9 @@ static GSList *get_file_list(const gchar *utf8_path, GSList *patterns,
 {
 	GSList *list = NULL;
 	GDir *dir;
+	const gchar *child_name;
+	GSList *child;
+	GSList *children = NULL;
 	gchar *locale_path = utils_get_locale_from_utf8(utf8_path);
 	gchar *real_path = tm_get_real_path(locale_path);
 
@@ -89,14 +92,17 @@ static GSList *get_file_list(const gchar *utf8_path, GSList *patterns,
 
 	g_hash_table_insert(visited_paths, real_path, GINT_TO_POINTER(1));
 
-	while (TRUE)
+	while ((child_name = g_dir_read_name(dir)))
+		children = g_slist_prepend(children, g_strdup(child_name));
+
+	g_dir_close(dir);
+
+	foreach_slist(child, children)
 	{
 		const gchar *locale_name;
 		gchar *locale_filename, *utf8_filename, *utf8_name;
 
-		locale_name = g_dir_read_name(dir);
-		if (!locale_name)
-			break;
+		locale_name = child->data;
 
 		utf8_name = utils_get_utf8_from_locale(locale_name);
 		locale_filename = g_build_filename(locale_path, locale_name, NULL);
@@ -125,7 +131,7 @@ static GSList *get_file_list(const gchar *utf8_path, GSList *patterns,
 		g_free(utf8_name);
 	}
 
-	g_dir_close(dir);
+	g_slist_free_full(children, g_free);
 	g_free(locale_path);
 
 	return list;

--- a/projectorganizer/src/prjorg-project.c
+++ b/projectorganizer/src/prjorg-project.c
@@ -82,6 +82,8 @@ static GSList *get_file_list(const gchar *utf8_path, GSList *patterns,
 	{
 		g_free(locale_path);
 		g_free(real_path);
+		if (dir)
+			g_dir_close(dir);
 		return NULL;
 	}
 


### PR DESCRIPTION
At the moment the directory isn't closed when tm_get_real_path() returns
NULL or when the given path was already visited (happens e.g. with
symlink loops).