### PR TITLE
Workbench: cppcheck initialize loop vars

### DIFF
--- a/workbench/src/sidebar.c
+++ b/workbench/src/sidebar.c
@@ -95,7 +95,7 @@ static void sidebar_create_branch(gint level, const gchar *abs_base_dir, GSList 
 {
 	GSList *dir_list = NULL;
 	GSList *file_list = NULL;
-	GSList *elem;
+	GSList *elem = NULL;
 	gchar **path_arr;
 
 	foreach_slist (elem, leaf_list)
@@ -230,7 +230,7 @@ static void sidebar_insert_project_directory(WB_PROJECT *prj, WB_PROJECT_DIR *di
 {
 	GSList *lst = NULL;
 	GSList *path_list = NULL;
-	GSList *elem;
+	GSList *elem = NULL;
 	GHashTableIter iter;
 	gpointer key, value;
 	gchar *abs_base_dir;
@@ -267,7 +267,7 @@ static void sidebar_insert_project_directories (WB_PROJECT *project, GtkTreeIter
 {
 	GtkTreeIter iter;
 	GIcon *icon;
-	GSList *elem, *dirs;
+	GSList *elem = NULL, *dirs;
 
 	if (project == NULL)
 	{

--- a/workbench/src/utils.c
+++ b/workbench/src/utils.c
@@ -72,7 +72,7 @@ gchar *get_relative_path(const gchar *utf8_parent, const gchar *utf8_descendant)
  **/
 gboolean patterns_match(GSList *patterns, const gchar *str)
 {
-	GSList *elem;
+	GSList *elem = NULL;
 	foreach_slist (elem, patterns)
 	{
 		GPatternSpec *pattern = elem->data;

--- a/workbench/src/wb_project.c
+++ b/workbench/src/wb_project.c
@@ -229,7 +229,7 @@ static GSList *wb_project_dir_get_file_list(WB_PROJECT_DIR *root, const gchar *u
 	GSList *list = NULL;
 	GDir *dir;
 	gchar *locale_path = utils_get_locale_from_utf8(utf8_path);
-	gchar *real_path = tm_get_real_path(locale_path);
+	gchar *real_path = utils_get_real_path(locale_path);
 
 	dir = g_dir_open(locale_path, 0, NULL);
 	if (!dir || !real_path || g_hash_table_lookup(visited_paths, real_path))
@@ -518,8 +518,8 @@ static gint wb_project_dir_comparator(WB_PROJECT_DIR *a, WB_PROJECT_DIR *b)
 
 	a_locale_base_dir = utils_get_locale_from_utf8(a->base_dir);
 	b_locale_base_dir = utils_get_locale_from_utf8(b->base_dir);
-	a_realpath = tm_get_real_path(a_locale_base_dir);
-	b_realpath = tm_get_real_path(b_locale_base_dir);
+	a_realpath = utils_get_real_path(a_locale_base_dir);
+	b_realpath = utils_get_real_path(b_locale_base_dir);
 
 	res = g_strcmp0(a_realpath, b_realpath);
 

--- a/workbench/src/wb_project.c
+++ b/workbench/src/wb_project.c
@@ -535,7 +535,7 @@ static gint wb_project_dir_comparator(WB_PROJECT_DIR *a, WB_PROJECT_DIR *b)
 /* Get the file count of a project */
 static guint wb_project_get_file_count(WB_PROJECT *prj)
 {
-	GSList *elem;
+	GSList *elem = NULL;
 	guint filenum = 0;
 
 	foreach_slist(elem, prj->directories)
@@ -553,7 +553,7 @@ static guint wb_project_dir_rescan_int(WB_PROJECT *prj, WB_PROJECT_DIR *root)
 	GSList *ignored_file_list = NULL;
 	GHashTable *visited_paths;
 	GSList *lst;
-	GSList *elem;
+	GSList *elem = NULL;
 	guint filenum = 0;
 	gchar *searchdir;
 
@@ -717,7 +717,7 @@ guint wb_project_dir_rescan(WB_PROJECT *prj, WB_PROJECT_DIR *root)
  **/
 void wb_project_rescan(WB_PROJECT *prj)
 {
-	GSList *elem;
+	GSList *elem = NULL;
 	guint filenum = 0;
 
 	if (!prj)
@@ -772,7 +772,7 @@ gboolean wb_project_dir_file_is_included(WB_PROJECT_DIR *dir, const gchar *filen
  **/
 gboolean wb_project_file_is_included(WB_PROJECT *prj, const gchar *filename)
 {
-	GSList *elem;
+	GSList *elem = NULL;
 
 	if (prj == NULL)
 	{
@@ -793,7 +793,7 @@ gboolean wb_project_file_is_included(WB_PROJECT *prj, const gchar *filename)
 static gboolean add_tm_idle(gpointer foo)
 {
 	WB_PROJECT *prj;
-	GSList *elem2;
+	GSList *elem2 = NULL;
 
 	prj = (WB_PROJECT *)foo;
 	if (prj == NULL || prj->s_idle_add_funcs == NULL)
@@ -803,7 +803,7 @@ static gboolean add_tm_idle(gpointer foo)
 
 	foreach_slist (elem2, prj->s_idle_add_funcs)
 	{
-		GSList *elem;
+		GSList *elem = NULL;
 		gchar *utf8_fname = elem2->data;
 
 		foreach_slist (elem, prj->directories)
@@ -851,7 +851,7 @@ void wb_project_add_single_tm_file(WB_PROJECT *prj, const gchar *filename)
 static gboolean remove_tm_idle(gpointer foo)
 {
 	WB_PROJECT *prj;
-	GSList *elem2;
+	GSList *elem2 = NULL;
 
 	prj = (WB_PROJECT *)foo;
 	if (prj == NULL || prj->s_idle_remove_funcs == NULL)
@@ -861,7 +861,8 @@ static gboolean remove_tm_idle(gpointer foo)
 
 	foreach_slist (elem2, prj->s_idle_remove_funcs)
 	{
-		GSList *elem;
+
+		GSList *elem = NULL;
 		gchar *utf8_fname = elem2->data;
 
 		foreach_slist (elem, prj->directories)


### PR DESCRIPTION
For details about the uninitialized variables and why thise broke `make check` (and so the nightly builds,  http://nightly.geany.org/) see https://github.com/geany/geany-plugins/pull/590.

The other commit is just to replace the deprecated `tm_get_real_path` calls.