### PR TITLE
geanylua: Increased required geany API version to 235 for usage of 'utils_get_real_path'.

### DIFF
--- a/geanylua/glspi_ver.h
+++ b/geanylua/glspi_ver.h
@@ -12,7 +12,7 @@
 
 #define PLUGIN_AUTHOR "Jeff Pohlmeyer"
 
-#define MY_GEANY_API_VER 224
+#define MY_GEANY_API_VER 235
 
 #define LUA_MODULE_NAME "geany"
 


### PR DESCRIPTION
Nothing more to say.