### PR TITLE
workbench: Increased required geany API version to 235 for usage of 'utils_get_real_path'.

### DIFF
--- a/workbench/src/plugin_main.c
+++ b/workbench/src/plugin_main.c
@@ -138,5 +138,5 @@ void geany_load_module(GeanyPlugin *plugin)
 	plugin->funcs->callbacks = plugin_workbench_callbacks;
 
 	/* Register! */
-	GEANY_PLUGIN_REGISTER(plugin, 225);
+	GEANY_PLUGIN_REGISTER(plugin, 235);
 }


### PR DESCRIPTION
Nothing more to say.