### PR TITLE
addons/markword: Deselect when the selection changes

### DIFF
--- a/addons/src/addons.c
+++ b/addons/src/addons.c
@@ -178,6 +178,8 @@ gboolean ao_editor_notify_cb(GObject *object, GeanyEditor *editor,
 							 SCNotification *nt, gpointer data)
 {
 	ao_bookmark_list_update_marker(ao_info->bookmarklist, editor, nt);
+	
+	ao_mark_editor_notify(ao_info->markword, editor, nt);
 
 	return FALSE;
 }

--- a/addons/src/ao_markword.c
+++ b/addons/src/ao_markword.c
@@ -182,6 +182,17 @@ void ao_mark_editor_notify(AoMarkWord *mw, GeanyEditor *editor, SCNotification *
 		
 		if(priv->enable_markword && priv->enable_single_click_deselect)
 			clear_marker();
+	} 
+	
+	// In single click deselect mode, clear the markers when the cursor moves
+	else if(nt->nmhdr.code == SCN_UPDATEUI && 
+		nt->updated == SC_UPDATE_SELECTION &&
+		!sci_has_selection(editor->sci)) 
+	{
+		AoMarkWordPrivate *priv = AO_MARKWORD_GET_PRIVATE(mw);
+		
+		if(priv->enable_markword && priv->enable_single_click_deselect)
+			clear_marker();
 	}
 }
 

--- a/addons/src/ao_markword.c
+++ b/addons/src/ao_markword.c
@@ -171,6 +171,20 @@ static gboolean on_editor_button_press_event(GtkWidget *widget, GdkEventButton *
 	return FALSE;
 }
 
+void ao_mark_editor_notify(AoMarkWord *mw, GeanyEditor *editor, SCNotification *nt)
+{
+	// If something is about to be deleted and there is selected text clear the markers
+	if(nt->nmhdr.code == SCN_MODIFIED &&
+		((nt->modificationType & SC_MOD_BEFOREDELETE) == SC_MOD_BEFOREDELETE) &&
+		sci_has_selection(editor->sci)) 
+	{
+		AoMarkWordPrivate *priv = AO_MARKWORD_GET_PRIVATE(mw);
+		
+		if(priv->enable_markword && priv->enable_single_click_deselect)
+			clear_marker();
+	}
+}
+
 
 void ao_mark_document_new(AoMarkWord *mw, GeanyDocument *document)
 {

--- a/addons/src/ao_markword.h
+++ b/addons/src/ao_markword.h
@@ -44,6 +44,8 @@ AoMarkWord*		ao_mark_word_new			(gboolean enable, gboolean single_click_deselect
 void			ao_mark_document_new		(AoMarkWord *mw, GeanyDocument *document);
 void			ao_mark_document_open		(AoMarkWord *mw, GeanyDocument *document);
 void			ao_mark_document_close		(AoMarkWord *mw, GeanyDocument *document);
+void 			ao_mark_editor_notify		(AoMarkWord *mw, GeanyEditor *editor,
+												SCNotification *nt);
 
 G_END_DECLS
 


### PR DESCRIPTION
Not sure if desired or not, but the marked results currently do not clear when the selected text is modified/deleted. The modification detects the deletion and clears the markers. Only works when single-click deselect is enabled.