### PR TITLE
workbench: correct/update README.

### DIFF
--- a/workbench/README
+++ b/workbench/README
@@ -19,7 +19,7 @@ Enabling the plugin
 -------------------
 The plugin can be enabled in the plugin manager. After enabling the plugin
 a new tab will be displayed in the Sidebar. There will also be a new entry
-in the menubar. Both are labeled "Workbench".
+in the "Tools" menu. Both are labeled "Workbench".
 
 The Workbench menu
 ------------------
@@ -30,13 +30,19 @@ simple text files containing key-value pairs.
 
 The complete managment of the Workbench file is done using the Workbench
 menu:
-- Item "New": as explained above, creates a new Workbench
-- Item "Open": open a Workbench
-- Item "Save": save the opened Workbench. This "only" saves any changes
+
+**Item "New"**
+  As explained above, creates a new Workbench.
+**Item "Open"**
+  Open a Workbench.
+**Item "Save"**
+  Save the opened Workbench. This "only" saves any changes
   in the Workbench file. It does not save any changes of the projects
   belonging to the Workbench.
-- Item "Settings": open the Workbench settings dialog.
-- Item "Close": closes the opened Workbench.
+**Item "Settings"**
+  Open the Workbench settings dialog.
+**Item "Close"**
+  Closes the opened Workbench.
 
 The new Workbench
 -----------------
@@ -52,68 +58,78 @@ The Workbench context menu:
 
 These are the available items:
 
-- "Add project":
+**Add project**
   Add an existing Geany project to the Workbench. Create your projects
   with Geany. The Workbench plugin does not help you with that. After
   adding a project you need to save the workbench settings by selecting
   "Workbench / Save" in the menubar.
-- "Save project":
+
+**Save project**
   Selecting this item will save the Workbench related project settings in
   the Geany project file. It is only available if you right clicked inside
   of a project. It will only save the settings of the project that you
   clicked on.
-- "Remove project":
+
+**Remove project**
   Remove the project from the Workbench. It is only available if you
   right clicked inside of a project.  After removing a project you need
   to save the workbench settings by selecting "Workbench / Save" in the
   menubar.
-- "Fold/unfold project":
+
+**Fold/unfold project**
   Fold or unfold the items belonging to the project. It is only available
   if you right clicked inside of a project.
 
-- "Add directory":
+**Add directory**
   Add a directory to the project. It is only available
   if you right clicked inside of a project. After selecting it a dialog
   will be opened. Chosse the directory which shall be added. After that
   the directory will be shown inside the project folder. After adding a
   new directory, all files and folders beneath the directory will be
   displayed. See "Directory settings" for more information.
-- "Remove directory":
+
+**Remove directory**
   Remove the directory from the project. It is only available if you
   right clicked inside of a project directory.
-- "Rescan directory":
+
+**Rescan directory**
   Rescan the directory for files and update the sidebar accordingly.
   It is only available if you right clicked inside of a project directory.
   If the content of a directory changes, e.g. a new file is added, then
   the new file will only be visible in the sidebar after a rescan.
-- "Directory settings":
+
+**Directory settings**
   Select this item to change the directory settings. It is only available
   if you right clicked inside of a project directory. In the directory
   settings you can set a filter which controls the files and folders
   that shall be displayed or not.
-- "Fold/unfold directory":
+
+**Fold/unfold directory**
   Fold or unfold the items belonging to the directory. It is only available
   if you right clicked inside of a directory.
 
-- "Unfold All":
+**Unfold All**
   Select this item to unfold all projects, directories and folders.
-- "Collapse All":
+
+**Collapse All**
   Select this item to collpase/fold all projects, directories and folders.
 
-- "Add to Workbench Bookmarks":
+**Add to Workbench Bookmarks**
   Add the file to the Workbench Bookmarks. It is only available
   if you right clicked on a file. After adding a file to the Workbench
   bookmarks a ribbon will be shown for the file in the Workbench sidebar
   tab in front of the first project. Clicking on it will open the file.
   Workbench bookmarks give you quick access to files which you often need.
-- "Add to Project Bookmarks":
+
+**Add to Project Bookmarks**
   Add the file to the Project Bookmarks. It is only available
   if you right clicked on a file. After adding a file to the Project
   bookmarks a ribbon will be shown for the file in the Workbench sidebar
   tab in front of the first directory of the project. Clicking on it will
   open the file. Project bookmarks give you quick access to files which
   you often need in that project.
-- "Remove from Bookmarks":
+
+**Remove from Bookmarks**
   Remove file from the Workbench or project bookmarks. It is only available
   if you right clicked on a bookmark.
 
@@ -134,15 +150,16 @@ code of this program.
 Downloads
 =========
 
-The Workbench plugin is not (yet) part of the combined Geany Plugins release.
-So please download it from the github page, see below.
+The Workbench plugin is part of the combined Geany Plugins release.
+For more information and downloads, please visit
+http://plugins.geany.org/geany-plugins/
 
 Development Code
 ================
 
 Get the code from::
 
-    git clone https://github.com/LarsGit223/geany-plugins
+    git clone https://github.com/geany/geany-plugins.git
 
 Ideas, questions, patches and bug reports
 =========================================


### PR DESCRIPTION
The following things have been changed in the README file:
- updated sections "Downloads" and "Development Code"
- corrected section "Enabling the plugin":
  The workbench menu is now placed inside the "Tools" menu.
- use definition lists instead of bulleted lists to describe the menu items.
  This makes the text more readable and also fixes errors in the ReStructuredText format.