### PR TITLE
scope: code re-factoring to prevent false positive from cppcheck.

### DIFF
--- a/scope/src/Makefile.am
+++ b/scope/src/Makefile.am
@@ -58,7 +58,4 @@ scope_la_CFLAGS = $(AM_CFLAGS) $(VTE_CFLAGS) \
 	-DPLUGINHTMLDOCDIR=\"$(plugindocdir)/html\" \
 	-Wno-shadow
 
-# http://trac.cppcheck.net/ticket/7243
-AM_CPPCHECKFLAGS = --suppress='unknownEvaluationOrder:$(srcdir)/store/scptreestore.c:909'
-
 include $(top_srcdir)/build/cppcheck.mk

--- a/scope/src/store/scptreestore.c
+++ b/scope/src/store/scptreestore.c
@@ -906,7 +906,7 @@ GtkTreePath *scp_tree_store_get_path(VALIDATE_ONLY ScpTreeStore *store, GtkTreeI
 	{
 		gtk_tree_path_append_index(path, ITER_INDEX(iter));
 
-		while ((elem = elem->parent), elem->parent)
+		for (elem = elem->parent; elem->parent; elem = elem->parent)
 		{
 			gint index = scp_ptr_array_find(elem->parent->children, elem);
 


### PR DESCRIPTION
Closes #398.

This reverts the makefile change from #397 and applies the change suggested by @b4n. There is no maintainer for scope right now and so I thought just let's do the change and we can close #398 so that it does not stay open forever.