### PR TITLE
Geniuspaste: Enable HTTPS for pastebin.geany.org

### DIFF
--- a/geniuspaste/data/pastebin.geany.org.conf
+++ b/geniuspaste/data/pastebin.geany.org.conf
@@ -1,6 +1,6 @@
 [pastebin]
 name=pastebin.geany.org
-url=http://pastebin.geany.org/api/
+url=https://pastebin.geany.org/api/
 
 [format]
 content=%contents%


### PR DESCRIPTION
Nothing critical but probably won't hurt.