### PR TITLE
Fix cppcheck warnings

### DIFF
--- a/projectorganizer/src/prjorg-menu.c
+++ b/projectorganizer/src/prjorg-menu.c
@@ -114,7 +114,7 @@ static void on_swap_header_source(G_GNUC_UNUSED GtkMenuItem * menuitem, G_GNUC_U
 	if (known_type)
 	{
 		gboolean swapped;
-		GSList *elem, *list = NULL;
+		GSList *elem = NULL, *list = NULL;
 		guint i = 0;
 
 		foreach_document(i)

--- a/xmlsnippets/src/Makefile.am
+++ b/xmlsnippets/src/Makefile.am
@@ -21,5 +21,6 @@ xmlsnippets_check_SOURCES = \
 
 xmlsnippets_check_CPPFLAGS = -DTEST
 xmlsnippets_check_LDADD = $(COMMONLIBS)
+TESTS = $(check_PROGRAMS)
 
 include $(top_srcdir)/build/cppcheck.mk

--- a/xmlsnippets/src/tests.c
+++ b/xmlsnippets/src/tests.c
@@ -80,7 +80,7 @@ static gboolean test(gint ordinal, const gchar *input, const gchar *completion_n
 	else if (!completion_needed && !success)
 		return TRUE;
 
-	if (strcmp(c.completion, completion_needed) != 0)
+	if (g_strcmp0(c.completion, completion_needed) != 0)
 	{
 		g_warning(
 			"Test %d: FAIL\n"


### PR DESCRIPTION
Is 26fd7328cd409ceb16557a0fe637d5c028c0598f enough for properly enabling the test program on `make check`? To me it seems, it was just missing or was it intentional that the test program isn't run on `make check`?