### PR TITLE
GeanyLua: Add filetype to set in geany.newfile()

### DIFF
--- a/geanylua/docs/geanylua-ref.html
+++ b/geanylua/docs/geanylua-ref.html
@@ -758,8 +758,7 @@ the selection is treated as <i>rectangular</i> rather than <i>linear</i>.<br>
 
 <a name="newfile"></a><hr><h3><tt>geany.newfile ( [filename [, filetype] )</tt></h3><p>
 <p>When called with no arguments, creates a new, untitled document.</p>
-<p>When called with one argument, creates a new document with the specified
-<tt>filename</tt>.</p>
+<p>When called with one argument, creates a new document with the specified <tt>filename</tt>.</p>
 <p>When called with two argument, creates a new document with the specified
 <tt>filename</tt> and <tt>filetype</tt> (a one-word description of the filetype,
 e.g. "C" or "Python".). If you want untitled document then set <tt>filename</tt> as <tt>""</tt>.</p>

--- a/geanylua/docs/geanylua-ref.html
+++ b/geanylua/docs/geanylua-ref.html
@@ -136,7 +136,7 @@ The Geany module provides these functions and variables...<br><br><br>
 </tr>
 
 <tr class="odd">
-  <td>&nbsp; function <a href="#newfile"><b>newfile</b></a> ( [filename] )<br></td>
+  <td>&nbsp; function <a href="#newfile"><b>newfile</b></a> ( [filename [, filetype] )<br></td>
   <td class="desc">-- Create a new document.</td>
 </tr>
 
@@ -756,11 +756,23 @@ the selection is treated as <i>rectangular</i> rather than <i>linear</i>.<br>
 <br><br>
 
 
-<a name="newfile"></a><hr><h3><tt>geany.newfile ( [filename] )</tt></h3><p>
-When called with one argument, creates a new document with the specified
-<tt>filename</tt>. </p><p>When called with no arguments, creates a new, untitled document.
-</p><br><br>
+<a name="newfile"></a><hr><h3><tt>geany.newfile ( [filename [, filetype] )</tt></h3><p>
+<p>When called with no arguments, creates a new, untitled document.</p>
+<p>When called with one argument, creates a new document with the specified
+<tt>filename</tt>.</p>
+<p>When called with two argument, creates a new document with the specified
+<tt>filename</tt> and <tt>filetype</tt> (a one-word description of the filetype,
+e.g. "C" or "Python".). If you want untitled document then set <tt>filename</tt> as <tt>""</tt>.</p>
+<p>So you can use it like this:</p>
+<pre>local s = geany.selection();
 
+if (s ~= "") and (s ~= nil) then
+  local t = geany.fileinfo();
+  geany.newfile("", t.type);
+  geany.selection(s);
+end</pre>
+<p>(create a new, untitled document, with selected text and auto set filetype).</p>
+<br><br>
 
 
 <a name="open"></a><hr><h3><tt>geany.open ( [filename]|[index] )</tt></h3><p>

--- a/geanylua/docs/geanylua-ref.html
+++ b/geanylua/docs/geanylua-ref.html
@@ -181,27 +181,27 @@ The Geany module provides these functions and variables...<br><br><br>
   <td class="desc">-- Send a GTK signal to a Geany interface widget.</td>
 </tr>
 
-<tr class="odd">
+<tr class="even">
   <td>&nbsp; function <a href="#status"><b>status</b></a> ( message )<br></td>
   <td class="desc">-- Send a string to display in the status tab of the messages window.</td>
 </tr>
 
-<tr class="even">
+<tr class="odd">
   <td>&nbsp; function <a href="#text"><b>text</b></a> ( [content] )<br></td>
   <td class="desc">-- Get or set the contents of the entire document.</td>
 </tr>
 
-<tr class="odd">
+<tr class="even">
   <td>&nbsp; function <a href="#word"><b>word</b></a> ( [position] )<br></td>
   <td class="desc">-- Get the word at the specified location.</td>
 </tr>
 
-<tr class="even">
+<tr class="odd">
   <td>&nbsp; function <a href="#xsel"><b>xsel</b></a> ( [text] )<br></td>
   <td class="desc">-- Get or set the contents of the primary X selection.</td>
 </tr>
 
-<tr class="odd">
+<tr class="even">
   <td>&nbsp; function <a href="#yield"><b>yield</b></a> ()<br></td>
   <td class="desc">-- Refreshes the user interface.</td>
 </tr>

--- a/geanylua/glspi_doc.c
+++ b/geanylua/glspi_doc.c
@@ -32,12 +32,23 @@ static gint glspi_filename(lua_State* L)
 static gint glspi_newfile(lua_State* L)
 {
 	const gchar *fn=NULL;
-	if (lua_gettop(L)>0) {
+	GeanyFiletype *ft=NULL;
+	switch (lua_gettop(L)) {
+	case 0: break;
+	case 2:
+		if (!lua_isstring(L, 2))	{ return FAIL_STRING_ARG(2); }
+		const gchar *tmp=lua_tostring(L, 2);
+		if ( '\0' == tmp[0] ) {
+			ft=NULL;
+		} else {
+			ft=filetypes_lookup_by_name(tmp);
+		}
+	default:
 		if (!lua_isstring(L, 1))	{ return FAIL_STRING_ARG(1); }
 		fn=lua_tostring(L, 1);
-		if ( '\0' == fn[0] ) { fn = NULL; }
+		if ( '\0' == fn[0] ) { fn=NULL; }
 	}
-	document_new_file(fn, NULL, NULL);
+	document_new_file(fn, ft, NULL);
 	return 0;
 }
 


### PR DESCRIPTION
It's continuation of the discussion #646 . Code example:
```lua
local s = geany.selection();

if (s ~= "") and (s ~= nil) then
  local t = geany.fileinfo();
  geany.newfile("", t.type);
  geany.selection(s);
end
```

Old/current scripts don't need to be updated, they will still work!