### PR TITLE
GeanyLua: Fix right-trim.lua

### DIFF
--- a/geanylua/examples/edit/right-trim.lua
+++ b/geanylua/examples/edit/right-trim.lua
@@ -5,9 +5,9 @@
 
 local s=geany.text()
 
-if (s and string.match(s, "[ \t]\n") )
+if (s and string.match(s, "[ \t][\r\n]") )
 then
-  geany.text(string.gsub(s,"[ \t]+\n", "\n"))
+  geany.text(string.gsub(s,"([ \t]+)([\r\n]+)", "%2"))
 else
   geany.message("Right trim:", "Match not found.")
 end


### PR DESCRIPTION
Now script works with files with CRLF too (and with CR only). ```right-trim.lua ``` is presented as example (_geanylua/**examples**/edit/right-trim.lua_), but very useful (IMHO :)).