### PR TITLE
SpellCheck: Support Enchant 2.0 and later

### DIFF
--- a/build/spellcheck.m4
+++ b/build/spellcheck.m4
@@ -3,14 +3,19 @@ AC_DEFUN([GP_CHECK_SPELLCHECK],
     GP_ARG_DISABLE([spellcheck], [auto])
 
     ENCHANT_VERSION=1.3
-    OPT_ENCHANT_VERSION=1.5
-    PKG_CHECK_MODULES([ENCHANT], [enchant >= ${OPT_ENCHANT_VERSION}],
+    ENCHANT_VERSION_1_5=1.5
+    ENCHANT_VERSION_2_0=2.0
+    PKG_CHECK_MODULES([ENCHANT_1_5], [enchant >= ${ENCHANT_VERSION_1_5}],
                       have_enchant_1_5=yes,
                       have_enchant_1_5=no)
+    PKG_CHECK_MODULES([ENCHANT_2_0], [enchant >= ${ENCHANT_VERSION_2_0}],
+                      have_enchant_2_0=yes,
+                      have_enchant_2_0=no)
     GP_CHECK_PLUGIN_DEPS([spellcheck], [ENCHANT],
                          [enchant >= ${ENCHANT_VERSION}])
 
     AM_CONDITIONAL([HAVE_ENCHANT_1_5], [test "$have_enchant_1_5" = yes])
+    AM_CONDITIONAL([HAVE_ENCHANT_2_0], [test "$have_enchant_2_0" = yes])
     GP_COMMIT_PLUGIN_STATUS([Spellcheck])
 
     AC_CONFIG_FILES([

--- a/spellcheck/README
+++ b/spellcheck/README
@@ -34,26 +34,32 @@ assign a keyboard shortcut in Geany's preferences dialog to perform a
 spell check.
 
 
-Configuring dictionaries on Windows
------------------------------------
-On Windows, you might need to install the dictionaries (the files
+Configuring custom dictionaries
+-------------------------------
+Especially Windows, you might need to install the dictionaries (the files
 containing the information for spell checking) manually.
 First, you need to download the dictionary files for the
 languages you want, e.g. from
-http://extensions.services.openoffice.org/en/dictionaries.
-Be sure to download the "Spelling" archives from this site. The
-downloaded archive should contain one or more .dic and .aff files.
+https://cgit.freedesktop.org/libreoffice/dictionaries/tree/ or
+https://addons.mozilla.org/en-US/firefox/language-tools/.
+The downloaded archives should contain one or more .dic and .aff files.
 
 Instructions:
 
 1. Download the archive you want to use
-2. The downloaded archive with the extension .oxt is actually a ZIP
+2. The downloaded archive with extensions like .xpi or .oxt is actually a ZIP
    archive, so extract it as usual (e.g. with 7-Zip or another ZIP
    unpacker). Extract the contents into a folder of your choice,
    e.g. C:\dictionaries
 3. Then open to the Spell Check plugin preferences dialog in Geany and
    choose the folder you just created. You may need to restart Geany
    and then the installed dictionaries should be available
+
+Note: if you are using Enchant 2.0 or later (the library used by the SpellCheck
+plugin), you need to move the dictionaries into a subfolder called "hunspell"
+in the directory you created above.
+To check which Enchant version you are using, check "Help->Debug Messages" in
+Geany and find the appropriate log message telling about the Enchant version.
 
 
 Known issues

--- a/spellcheck/src/Makefile.am
+++ b/spellcheck/src/Makefile.am
@@ -22,6 +22,10 @@ if HAVE_ENCHANT_1_5
 spellcheck_la_CFLAGS += -DHAVE_ENCHANT_1_5
 endif
 
+if HAVE_ENCHANT_2_0
+spellcheck_la_CFLAGS += -DHAVE_ENCHANT_2_0
+endif
+
 spellcheck_la_LIBADD = \
 	$(COMMONLIBS) \
 	$(ENCHANT_LIBS)

--- a/spellcheck/src/scplugin.c
+++ b/spellcheck/src/scplugin.c
@@ -268,14 +268,14 @@ static void configure_frame_editor_menu_toggled_cb(GtkToggleButton *togglebutton
 
 GtkWidget *plugin_configure(GtkDialog *dialog)
 {
-	GtkWidget *label_language, *label_dir, *vbox;
+	GtkWidget *label_language, *vbox;
 	GtkWidget *combo, *check_type, *check_on_open, *check_msgwin, *check_toolbar;
 	GtkWidget *frame_editor_menu, *check_editor_menu;
 	GtkWidget *check_editor_menu_sub_menu, *align_editor_menu_sub_menu;
 	GtkWidget *vbox_interface, *frame_interface, *label_interface;
 	GtkWidget *vbox_behavior, *frame_behavior, *label_behavior;
 #ifdef HAVE_ENCHANT_1_5
-	GtkWidget *entry_dir, *hbox, *button, *image;
+	GtkWidget *entry_dir, *label_dir, *hbox, *button, *image;
 #endif
 
 	vbox = gtk_vbox_new(FALSE, 6);
@@ -352,7 +352,9 @@ GtkWidget *plugin_configure(GtkDialog *dialog)
 	gtk_label_set_mnemonic_widget(GTK_LABEL(label_dir), entry_dir);
 	gtk_widget_set_tooltip_text(entry_dir,
 		_("Read additional dictionary files from this directory. "
-		  "For now, this only works with myspell dictionaries."));
+		  "For now, this only works with hunspell dictionaries. "
+		  "With Enchant 2.0 or later, the dictionaries are searched "
+		  "in a subfolder called \"hunspell\". See the plugin's Help for details."));
 	if (! EMPTY(sc_info->dictionary_dir))
 		gtk_entry_set_text(GTK_ENTRY(entry_dir), sc_info->dictionary_dir);
 


### PR DESCRIPTION
Enchant 2.0 dropped some deprecated API and especially introduced
setting custom config/dictionary paths via an environment variable.
So, handle the API differences between Enchant 1.3, 1.5 and 2.0 and
document the changed custom dictionary behavior with 2.0 and later.