### PR TITLE
Port both webhelper and markdown to webkit2gtk

### DIFF
--- a/build/markdown.m4
+++ b/build/markdown.m4
@@ -49,8 +49,8 @@ AC_DEFUN([GP_CHECK_MARKDOWN],
     GTK_VERSION=2.16
     WEBKIT_VERSION=1.1.13
 
-    GP_CHECK_GTK3([webkit_package=webkitgtk-3.0],
-                  [webkit_package=webkit-1.0])
+    GP_CHECK_GTK3([webkit_package=webkit2gtk-4.0],
+                  [webkit_package=webkit2gtk-4.0])
 
     GP_CHECK_PLUGIN_DEPS([markdown], [MARKDOWN],
                          [$GP_GTK_PACKAGE >= ${GTK_VERSION}

--- a/build/webhelper.m4
+++ b/build/webhelper.m4
@@ -20,7 +20,7 @@ AC_DEFUN([GP_CHECK_WEBHELPER],
     fi
 
     GP_CHECK_GTK3([webkit_package=webkit2gtk-4.0],
-                  [webkit_package=webkit-1.0])
+                  [webkit_package=webkit2gtk-4.0])
     GP_CHECK_PLUGIN_DEPS([WebHelper], [WEBHELPER],
                          [$GP_GTK_PACKAGE >= ${GTK_VERSION}
                           glib-2.0 >= ${GLIB_VERSION}

--- a/build/webhelper.m4
+++ b/build/webhelper.m4
@@ -19,7 +19,7 @@ AC_DEFUN([GP_CHECK_WEBHELPER],
         fi
     fi
 
-    GP_CHECK_GTK3([webkit_package=webkitgtk-3.0],
+    GP_CHECK_GTK3([webkit_package=webkit2gtk-4.0],
                   [webkit_package=webkit-1.0])
     GP_CHECK_PLUGIN_DEPS([WebHelper], [WEBHELPER],
                          [$GP_GTK_PACKAGE >= ${GTK_VERSION}

--- a/markdown/src/viewer.c
+++ b/markdown/src/viewer.c
@@ -297,15 +297,15 @@ pop_scroll_pos(MarkdownViewer *self)
 }
 
 static void
-on_webview_load_status_notify(WebKitWebView *view, GParamSpec *pspec,
+on_webview_is_loading_notify(WebKitWebView *view, GParamSpec *pspec,
   MarkdownViewer *self)
 {
-  WebKitLoadEvent load_status;
+  gboolean load_status;
 
-  g_object_get(view, "load-status", &load_status, NULL);
+  g_object_get(view, "is-loading", &load_status, NULL);
 
   /* When the webkit is done loading, reset the scroll position. */
-  if (load_status == WEBKIT_LOAD_FINISHED) {
+  if (!load_status) {
     pop_scroll_pos(self);
   }
 }
@@ -389,8 +389,8 @@ markdown_viewer_update_view(MarkdownViewer *self)
      * position once the webview is reloaded. */
     if (self->priv->load_handle == 0) {
       self->priv->load_handle =
-        g_signal_connect_swapped(WEBKIT_WEB_VIEW(self), "notify::load-status",
-          G_CALLBACK(on_webview_load_status_notify), self);
+        g_signal_connect_swapped(WEBKIT_WEB_VIEW(self), "notify::is-loading",
+          G_CALLBACK(on_webview_is_loading_notify), self);
     }
 
     webkit_web_view_load_html(WEBKIT_WEB_VIEW(self), html, base_uri);

--- a/markdown/src/viewer.c
+++ b/markdown/src/viewer.c
@@ -22,7 +22,7 @@
 #include "config.h"
 #include <string.h>
 #include <gtk/gtk.h>
-#include <webkit/webkitwebview.h>
+#include <webkit2/webkit2.h>
 #include <geanyplugin.h>
 #ifndef FULL_PRICE
 # include <mkdio.h>
@@ -300,7 +300,7 @@ static void
 on_webview_load_status_notify(WebKitWebView *view, GParamSpec *pspec,
   MarkdownViewer *self)
 {
-  WebKitLoadStatus load_status;
+  WebKitLoadEvent load_status;
 
   g_object_get(view, "load-status", &load_status, NULL);
 
@@ -393,8 +393,7 @@ markdown_viewer_update_view(MarkdownViewer *self)
           G_CALLBACK(on_webview_load_status_notify), self);
     }
 
-    webkit_web_view_load_string(WEBKIT_WEB_VIEW(self), html, "text/html",
-      self->priv->enc, base_uri);
+    webkit_web_view_load_html(WEBKIT_WEB_VIEW(self), html, base_uri);
 
     g_free(base_uri);
     g_free(html);

--- a/markdown/src/viewer.h
+++ b/markdown/src/viewer.h
@@ -23,7 +23,7 @@
 #define MARKDOWN_VIEWER_H 1
 
 #include <gtk/gtk.h>
-#include <webkit/webkitwebview.h>
+#include <webkit2/webkit2.h>
 
 G_BEGIN_DECLS
 

--- a/webhelper/src/Makefile.am
+++ b/webhelper/src/Makefile.am
@@ -34,7 +34,8 @@ webhelper_la_CPPFLAGS = $(AM_CPPFLAGS) \
 webhelper_la_CFLAGS   = $(AM_CFLAGS) \
                         $(WEBHELPER_CFLAGS)
 webhelper_la_LIBADD   = $(COMMONLIBS) \
-                        $(WEBHELPER_LIBS)
+                        $(WEBHELPER_LIBS) \
+                        -lm
 
 # These are generated in $(srcdir) because they are part of the distribution,
 # and should anyway only be regenerated if the .tpl changes, which is a

--- a/webhelper/src/gwh-browser.c
+++ b/webhelper/src/gwh-browser.c
@@ -1124,6 +1124,7 @@ gwh_browser_init (GwhBrowser *self)
 {
   GtkWidget          *scrolled;
   WebKitSettings     *wkws;
+  WebKitWebContext   *wkcontext;
   gboolean            inspector_detached;
   
   self->priv = G_TYPE_INSTANCE_GET_PRIVATE (self, GWH_TYPE_BROWSER,
@@ -1134,6 +1135,9 @@ gwh_browser_init (GwhBrowser *self)
   self->priv->web_view = webkit_web_view_new ();
   wkws = webkit_web_view_get_settings (WEBKIT_WEB_VIEW (self->priv->web_view));
   g_object_set (wkws, "enable-developer-extras", TRUE, NULL);
+
+  wkcontext = webkit_web_view_get_context (WEBKIT_WEB_VIEW (self->priv->web_view));
+  webkit_web_context_set_favicon_database_directory (wkcontext, NULL);
   
   self->priv->settings = gwh_settings_get_default ();
   g_object_get (self->priv->settings,

--- a/webhelper/src/gwh-browser.c
+++ b/webhelper/src/gwh-browser.c
@@ -976,18 +976,24 @@ get_statusbar_context_id (GtkStatusbar *statusbar)
 }
 
 static void
-on_web_view_hovering_over_link (WebKitWebView *view,
-                                gchar         *title,
-                                gchar         *uri,
-                                GwhBrowser    *self)
+on_web_view_mouse_target_changed (WebKitWebView       *view,
+                                  WebKitHitTestResult *hit_test_result,
+                                  guint                modifiers,
+                                  GwhBrowser          *self)
 {
   GtkStatusbar *statusbar = GTK_STATUSBAR (self->priv->statusbar);
-  
+  const gchar *uri;
+
   if (self->priv->hovered_link) {
     gtk_statusbar_pop (statusbar, get_statusbar_context_id (statusbar));
     g_free (self->priv->hovered_link);
     self->priv->hovered_link = NULL;
   }
+
+  if (!webkit_hit_test_result_context_is_link (hit_test_result))
+    return;
+
+  uri = webkit_hit_test_result_get_link_uri (hit_test_result);
   if (uri && *uri) {
     self->priv->hovered_link = g_strdup (uri);
     gtk_statusbar_push (statusbar, get_statusbar_context_id (statusbar),
@@ -1107,8 +1113,8 @@ gwh_browser_init (GwhBrowser *self)
                     G_CALLBACK (on_web_view_context_menu), self);
   g_signal_connect (G_OBJECT (self->priv->web_view), "scroll-event",
                     G_CALLBACK (on_web_view_scroll_event), self);
-  g_signal_connect (G_OBJECT (self->priv->web_view), "hovering-over-link",
-                    G_CALLBACK (on_web_view_hovering_over_link), self);
+  g_signal_connect (G_OBJECT (self->priv->web_view), "mouse-target-changed",
+                    G_CALLBACK (on_web_view_mouse_target_changed), self);
   g_signal_connect (G_OBJECT (self->priv->web_view), "leave-notify-event",
                     G_CALLBACK (on_web_view_leave_notify_event), self);
   g_signal_connect (G_OBJECT (self->priv->web_view), "enter-notify-event",

--- a/webhelper/src/gwh-browser.h
+++ b/webhelper/src/gwh-browser.h
@@ -56,8 +56,8 @@ struct _GwhBrowserClass
 {
   GtkVBoxClass parent_class;
   
-  void        (*populate_popup)       (GwhBrowser *browser,
-                                       GtkMenu    *menu);
+  void        (*populate_popup)       (GwhBrowser        *browser,
+                                       WebKitContextMenu *menu);
 };
 
 

--- a/webhelper/src/gwh-browser.h
+++ b/webhelper/src/gwh-browser.h
@@ -22,7 +22,7 @@
 
 #include <glib.h>
 #include <gtk/gtk.h>
-#include <webkit/webkit.h>
+#include <webkit2/webkit2.h>
 
 G_BEGIN_DECLS
 


### PR DESCRIPTION
This is a port of both webhelper and markdown to webkit2gtk (webkit2gtk-4.0). webkitgtk-1.0 is now deprecated, as is webkitgtk-3.0. Unfortunately, this also means that gtk2 is no longer supported for these plugins. This PR also includes changes from https://github.com/geany/geany-plugins/pull/656.

I can reintroduce the old webkitgtk-1.0 code, but it's going to involve quite a bit of ugly #ifdef-ing because quite a number of things have changed (most of the signals have been completely reorganized to have different meanings and function signatures, so a separate set of callbacks for both the old and new ones would need to be included).

@b4n 