### PR TITLE
Add github names to maintainers file

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,4 +1,5 @@
 # P: Person
+# G: Github @name
 # M: Mail patches to: FullName <address@domain>
 # W: Web-page with status/info
 # S: Status, one of the following:
@@ -13,84 +14,98 @@
 
 addons
 P: Enrico Tröger <enrico.troeger@uvena.de>
+g: @eht16
 M: Enrico Tröger <enrico.troeger@uvena.de>
 W: http://plugins.geany.org/addons.html
 S: Maintained
 
 autoclose
 P: Pavel Roschin <rpg89(at)post(dot)ru>
+g: @scriptum
 M: Pavel Roschin <rpg89(at)post(dot)ru>
 W:
 S: Maintained
 
 automark
 P: Pavel Roschin <rpg89(at)post(dot)ru>
+g: @scriptum
 M: Pavel Roschin <rpg89(at)post(dot)ru>
 W:
 S: Maintained
 
 codenav
 P: Federico Reghenzani <federico(dot)dev(at)reghe(dot)net>
+g:
 M: Federico Reghenzani <federico(dot)dev(at)reghe(dot)net>
 W: http://plugins.geany.org/codenav.html
 S: Maintained
 
 commander
 P: Colomban Wendling <ban@herbesfolles.org>
+g: @b4n
 M: Colomban Wendling <ban@herbesfolles.org>
 W:
 S: Maintained
 
 debugger
 P: Alexander Petukhov <devel@apetukhov.ru>
+g: 
 M: Alexander Petukhov <devel@apetukhov.ru>
 W: http://plugins.geany.org/debugger.html
 S: Maintained
 
 defineformat
 P: Pavel Roschin <rpg89(at)post(dot)ru>
+g: @scriptum
 M: Pavel Roschin <rpg89(at)post(dot)ru>
 W: http://plugins.geany.org/defineformat.html
 S: Maintained
 
 devhelp
 P: Matthew Brush <matt@geany.org>
+g: @codebrainz
 M: Matthew Brush <matt@geany.org>
 W: http://plugins.geany.org/devhelp.html
 S: Maintained
 
 geanyctags
 P: Jiří Techet <techet@gmail.com>
+g: @techee
 M: Jiří Techet <techet@gmail.com>
 W: http://plugins.geany.org/geanyctags.html
 S: Maintained
 
 geanydoc
 P: Yura Siamashka <yurand2@gmail.com>
+g:
 M: Yura Siamashka <yurand2@gmail.com>
 W: http://plugins.geany.org/geanydoc.html
 S: Odd Fixes
 
 geanyextrasel
 P:
+g:
 M:
 W: http://plugins.geany.org/geanyextrasel.html
 S: Orphaned
 
 geanygendoc
 P: Colomban Wendling <ban@herbesfolles.org>
+g: @b4n
 M: Colomban Wendling <ban@herbesfolles.org>
 W: http://plugins.geany.org/geanygendoc.html
 S: Maintained
 
 geanyinsertnum
 P:
+g:
 M:
 W: http://plugins.geany.org/geanyinsertnum.html
 S: Orphaned
 
 latex
 P: Frank Lanitz <frank@frank.uvena.de>
+g: @frlan
 M: Frank Lanitz <frank@frank.uvena.de>
 W: http://frank.uvena.de/en/Geany/geanylatex/
 S: Maintained
@@ -98,108 +113,126 @@ S: Maintained
 
 geanylua
 P:
+g:
 M:
 W:
 S: Orphaned
 
 geanymacro
 P: William Fraser <william.fraser@virgin.net>
+g:
 M: William Fraser <william.fraser@virgin.net>
 W: http://plugins.geany.org/geanymacro.html
 S: Maintained
 
 geanyminiscript
 P: Eugene Arshinov <earshinov@gmail.com>
+g:
 M: Eugene Arshinov <earshinov@gmail.com>
 W:
 S: Maintained
 
 geanynumberedbookmarks
 P: William Fraser <william.fraser@virgin.net>
+g:
 M: William Fraser <william.fraser@virgin.net>
 W: http://plugins.geany.org/geanynumberedbookmarks.html
 S: Maintained
 
 geanypg
 P: Hans Alves <alves.h88@gmail.com>
+g:
 M: Hans Alves <alves.h88@gmail.com>
 W: http://plugins.geany.org/geanypg.html
 S: Odd Fixes
 
 geanyprj
 P: Donjan Rodic <bryonak@freenet.de>
+g:
 M: Donjan Rodic <bryonak@freenet.de>
 W: http://plugins.geany.org/geanyprj.html
 S: Odd Fixes
 
 geanypy
 P: Thomas Martitz <kugel@rockbox.org>
+g: @kugel-
 M: Thomas Martitz <kugel@rockbox.org>
 W: http://plugins.geany.org/geanypy.html
 S: Currently diverged from upstream
 
 geanysendmail
 P: Frank Lanitz <frank@frank.uvena.de>
+g: @frlan
 M: Frank Lanitz <frank@frank.uvena.de>
 W: http://plugins.geany.org/geanysendmail.html
 S: Maintained
 
 geanyvc
 P: Yura Siamashka <yurand2@gmail.com>
+g:
 M: Yura Siamashka <yurand2@gmail.com>
 W: http://plugins.geany.org/geanyvc.html
 S: Odd Fixes
 
 geniuspaste
 P: Enrico Trotta <enrico.trt@gmail.com>
+g:
 M: Enrico Trotta <enrico.trt@gmail.com>
 W:
 S: Maintained
 
 git-changebar
 P: Colomban Wendling <ban@herbesfolles.org>
+g: @b4n
 M: Colomban Wendling <ban@herbesfolles.org>
 W: http://plugins.geany.org/git-changebar.html
 S: Maintained
 
 keyrecord
 P: Artur Riazanov <tunyash@gmail.com>
+g:
 M: Artur Riazanov <tunyash@gmail.com>
 W: 
 S: Maintained
 
 lineoperations
 P: Sylvan Mostert <smostert.dev@gmail.com>
+g:
 M: Sylvan Mostert <smostert.dev@gmail.com>
 W:
 S: Maintained
 
 lipsum
 P: Frank Lanitz <frank@frank.uvena.de>
+g: @frlan
 M: Frank Lanitz <frank@frank.uvena.de>
 W: http://plugins.geany.org/lipsum.html
 S: Maintained
 
 markdown
 P: Matthew Brush <matt@geany.org>
+g: @codebrainz
 M: Matthew Brush <matt@geany.org>
 W:
 S: Maintained
 
 multiterm
 P: Matthew Brush <matt@geany.org>
+g: @codebrainz
 M: Matthew Brush <matt@geany.org>
 W: http://plugins.geany.org/multiterm.html
 S: Maintained
 
 overview
 P: Matthew Brush <matt@geany.org>
+g: @codebrainz
 M: Matthew Brush <matt@geany.org>
 W: https://github.com/codebrainz/overview-plugin
 S: Maintained
 
 pairtaghighlighter
 P: Volodymyr Kononenko <vm@kononenko.ws>
+g:
 M: Volodymyr Kononenko <vm@kononenko.ws>
 W:
 S: Maintained
@@ -212,60 +245,70 @@ S: Orphaned
 
 projectorganizer
 P: Jiří Techet <techet@gmail.com>
+g: @techee
 M: Jiří Techet <techet@gmail.com>
 W: http://plugins.geany.org/projectorganizer.html
 S: Maintained
 
 pohelper
 P: Colomban Wendling <ban@herbesfolles.org>
+g: @b4n
 M: Colomban Wendling <ban@herbesfolles.org>
 W: http://plugins.geany.org/pohelper.html
 S: Maintained
 
 scope
 P:
+g:
 M:
 W: http://plugins.geany.org/scope.html
 S: Orphaned
 
 shiftcolumn
 P:
+g:
 M:
 W:
 S: Orphaned
 
 spellcheck
 P: Enrico Tröger <enrico.troeger@uvena.de>
+g: @eht16
 M: Enrico Tröger <enrico.troeger@uvena.de>
 W: http://plugins.geany.org/spellcheck.html
 S: Maintained
 
 tableconvert
 P: Frank Lanitz <frank@frank.uvena.de>
+g: @frlan
 M: Frank Lanitz <frank@frank.uvena.de>
 W: http://plugins.geany.org/tableconvert.html
 S: Maintained
 
 treebrowser
 P: Adam Dingle <adam@medovina.org>
+g:
 M: Adam Dingle <adam@medovina.org>
 W: http://plugins.geany.org/treebrowser.html
 S: Maintained
 
 updatechecker
 P: Frank Lanitz <frank@frank.uvena.de>
+g: @frlan
 M: Frank Lanitz <frank@frank.uvena.de>
 W: http://plugins.geany.org/updatechecker.html
 S: Maintained
 
 webhelper
 P: Colomban Wendling <ban@herbesfolles.org>
+g: @b4n
 M: Colomban Wendling <ban@herbesfolles.org>
 W: http://plugins.geany.org/webhelper.html
 S: Maintained
 
 xmlsnippets
 P: Eugene Arshinov <earshinov@gmail.com>
+g: @earshinov
 M: Eugene Arshinov <earshinov@gmail.com>
 W: http://plugins.geany.org/xmlsnippets.html
 S: Maintained


### PR DESCRIPTION
Have the maintainers github user name recorded somewhere so they can be pinged by users rather than waiting for them to notice an issue for their plugin was posted.

I have filled in the ones I know for sure, to everybody else, no offense, I am working from memory.