### PR TITLE
workbench: import base path on "Add project..."

### DIFF
--- a/workbench/src/wb_project.c
+++ b/workbench/src/wb_project.c
@@ -1286,7 +1286,7 @@ gboolean wb_project_save(WB_PROJECT *prj, GError **error)
  * @return TRUE on success, FALSE otherwise
  *
  **/
-gboolean wb_project_load(WB_PROJECT *prj, gchar *filename, GError **error)
+gboolean wb_project_load(WB_PROJECT *prj, const gchar *filename, GError **error)
 {
 	GKeyFile *kf;
 	guint	 index;

--- a/workbench/src/wb_project.h
+++ b/workbench/src/wb_project.h
@@ -63,7 +63,7 @@ gchar *wb_project_get_bookmark_at_index (WB_PROJECT *prj, guint index);
 guint wb_project_get_bookmarks_count(WB_PROJECT *prj);
 
 gboolean wb_project_save(WB_PROJECT *prj, GError **error);
-gboolean wb_project_load(WB_PROJECT *prj, gchar *filename, GError **error);
+gboolean wb_project_load(WB_PROJECT *prj, const gchar *filename, GError **error);
 
 gchar *wb_project_get_info (WB_PROJECT *prj);
 

--- a/workbench/src/workbench.c
+++ b/workbench/src/workbench.c
@@ -398,6 +398,9 @@ gboolean workbench_add_project(WORKBENCH *wb, const gchar *filename)
 		}
 		g_ptr_array_add (wb->projects, entry);
 
+		/* Load project to import base path. */
+		wb_project_load(project, filename, NULL);
+
 		wb->modified = TRUE;
 		return TRUE;
 	}


### PR DESCRIPTION
Import the base path on adding a project by calling "wb_project_load()".
This prevents the user from having to close and re-open the workbench
once to have the base path imported. Fixes #709.