### PR TITLE
workbench: fixed tag-manager warning. Fixes #713.

### DIFF
--- a/workbench/src/wb_project.c
+++ b/workbench/src/wb_project.c
@@ -612,16 +612,19 @@ static void wb_project_dir_regenerate_tags(WB_PROJECT_DIR *root, G_GNUC_UNUSED g
 	g_hash_table_iter_init(&iter, root->file_table);
 	while (g_hash_table_iter_next(&iter, &key, &value))
 	{
-		TMSourceFile *sf;
-		gchar *utf8_path = key;
-		gchar *locale_path = utils_get_locale_from_utf8(utf8_path);
+		if (g_file_test(key, G_FILE_TEST_IS_REGULAR))
+		{
+			TMSourceFile *sf;
+			gchar *utf8_path = key;
+			gchar *locale_path = utils_get_locale_from_utf8(utf8_path);
 
-		sf = tm_source_file_new(locale_path, filetypes_detect(utf8_path)->name);
-		if (sf && !document_find_by_filename(utf8_path))
-			g_ptr_array_add(source_files, sf);
+			sf = tm_source_file_new(locale_path, filetypes_detect(utf8_path)->name);
+			if (sf && !document_find_by_filename(utf8_path))
+				g_ptr_array_add(source_files, sf);
 
-		g_hash_table_insert(file_table, g_strdup(utf8_path), sf);
-		g_free(locale_path);
+			g_hash_table_insert(file_table, g_strdup(utf8_path), sf);
+			g_free(locale_path);
+		}
 	}
 	g_hash_table_destroy(root->file_table);
 	root->file_table = file_table;


### PR DESCRIPTION
Prevent debug messages by checking if the file path is a regular file or not.