### PR TITLE
workbench: pass error=NULL to "g_key_file_get_string_list()" for key "Bookmarks"

### DIFF
--- a/workbench/src/wb_project.c
+++ b/workbench/src/wb_project.c
@@ -1355,7 +1355,7 @@ gboolean wb_project_load(WB_PROJECT *prj, gchar *filename, GError **error)
 		gchar **bookmarks_strings;
 
 		/* Load project bookmarks from string list */
-		bookmarks_strings = g_key_file_get_string_list (kf, "Workbench", "Bookmarks", NULL, error);
+		bookmarks_strings = g_key_file_get_string_list (kf, "Workbench", "Bookmarks", NULL, NULL);
 		if (bookmarks_strings != NULL)
 		{
 			gchar **file, *abs_path;


### PR DESCRIPTION
The key "Bookmarks" can be missing and that is not an error. So pass "NULL" for
parameter "error" on calling ```g_key_file_get_string_list()```. This prevents multiple
error messages from being written to one ```GErrror``` and so causing a GLib warning in
the debug messages. Fixes #714.