### PR TITLE
workbench: make "live update"-feature depending on GIO and Glib version 2.46

### DIFF
--- a/build/workbench.m4
+++ b/build/workbench.m4
@@ -2,6 +2,12 @@ AC_DEFUN([GP_CHECK_WORKBENCH],
 [
     GP_ARG_DISABLE([Workbench], [auto])
     GP_CHECK_UTILSLIB([Workbench])
+
+    PKG_CHECK_MODULES([GIO], [gio-2.0],
+        [AC_DEFINE([HAVE_GIO], 1, [Whether we have GIO])
+         have_gio=yes],
+        [have_gio=no])
+
     GP_COMMIT_PLUGIN_STATUS([Workbench])
     AC_CONFIG_FILES([
         workbench/Makefile

--- a/workbench/src/dialogs.c
+++ b/workbench/src/dialogs.c
@@ -440,10 +440,19 @@ gboolean dialogs_workbench_settings(WORKBENCH *workbench)
 
 	w_enable_live_update = gtk_check_button_new_with_mnemonic(_("_Enable live update"));
 	ui_table_add_row(GTK_TABLE(table), 1, w_enable_live_update, NULL);
+#ifdef __WB_LIVE_UPDATE
 	gtk_widget_set_tooltip_text(w_enable_live_update,
 		_("If the option is activated (default), then the list of files and the sidebar"
 		  " will be updated automatically if a file or directory is created, removed or renamed."
 		  "A manual re-scan is not required if the option is enabled."));
+#else
+	gtk_widget_set_sensitive(w_enable_live_update, FALSE);
+	gtk_widget_set_tooltip_text(w_enable_live_update,
+		_("If the option is activated (default), then the list of files and the sidebar"
+		  " will be updated automatically if a file or directory is created, removed or renamed."
+		  "A manual re-scan is not required if the option is enabled.\n\n"
+		  "This feature has been disabled because it is not available on your system."));
+#endif
 	enable_live_update_old = workbench_get_enable_live_update(workbench);
 	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(w_enable_live_update), enable_live_update_old);
 

--- a/workbench/src/wb_monitor.c
+++ b/workbench/src/wb_monitor.c
@@ -31,6 +31,8 @@
 #include "wb_monitor.h"
 #include "utils.h"
 
+#ifdef __WB_LIVE_UPDATE
+
 struct S_WB_MONITOR
 {
 	GHashTable *monitors;
@@ -265,3 +267,4 @@ void wb_monitor_free(WB_MONITOR *monitor)
 		}
 	}
 }
+#endif

--- a/workbench/src/wb_monitor.h
+++ b/workbench/src/wb_monitor.h
@@ -22,12 +22,18 @@
 #include <glib.h>
 #include "wb_project.h"
 
+#if defined(HAVE_GIO) && GLIB_CHECK_VERSION (2, 46, 0)
+#define __WB_LIVE_UPDATE 1
+#endif
+
 typedef struct S_WB_MONITOR WB_MONITOR;
 
+#ifdef __WB_LIVE_UPDATE
 WB_MONITOR *wb_monitor_new(void);
 void wb_monitor_add_dir(WB_MONITOR *monitor, WB_PROJECT *prj,
 						WB_PROJECT_DIR *dir, const gchar *dirpath);
 gboolean wb_monitor_remove_dir(WB_MONITOR *monitor, const gchar *dirpath);
 void wb_monitor_free(WB_MONITOR *monitor);
+#endif
 
 #endif

--- a/workbench/src/wb_project.c
+++ b/workbench/src/wb_project.c
@@ -569,6 +569,7 @@ static guint wb_project_dir_rescan_int(WB_PROJECT *prj, WB_PROJECT_DIR *root)
 
 
 /* Add a new file to the project directory and update the sidebar. */
+#ifdef __WB_LIVE_UPDATE
 static void wb_project_dir_add_file_int(WB_PROJECT *prj, WB_PROJECT_DIR *root, const gchar *filepath)
 {
 	gboolean matches;
@@ -633,6 +634,8 @@ static void wb_project_dir_add_file_int(WB_PROJECT *prj, WB_PROJECT_DIR *root, c
 		g_slist_free(scanned);
 	}
 }
+#endif
+
 
 /** Add a new file to the project directory and update the sidebar.
  * 
@@ -643,6 +646,7 @@ static void wb_project_dir_add_file_int(WB_PROJECT *prj, WB_PROJECT_DIR *root, c
  * @param filepath The file to add.
  *
  **/
+#ifdef __WB_LIVE_UPDATE
 void wb_project_dir_add_file(WB_PROJECT *prj, WB_PROJECT_DIR *root, const gchar *filepath)
 {
 	wb_project_dir_add_file_int(prj, root, filepath);
@@ -650,9 +654,11 @@ void wb_project_dir_add_file(WB_PROJECT *prj, WB_PROJECT_DIR *root, const gchar 
 		root, NULL);
 
 }
+#endif
 
 
 /* Check if the filepath is equal for the length of the directory path in px_temp */
+#ifdef __WB_LIVE_UPDATE
 static gboolean wb_project_dir_remove_child (gpointer key, gpointer value, gpointer user_data)
 {
 	WB_PROJECT_TEMP_DATA *px_temp;
@@ -674,6 +680,7 @@ static gboolean wb_project_dir_remove_child (gpointer key, gpointer value, gpoin
 	}
 	return FALSE;
 }
+#endif
 
 
 /** Remove a file from the project directory and update the sidebar.
@@ -685,6 +692,7 @@ static gboolean wb_project_dir_remove_child (gpointer key, gpointer value, gpoin
  * @param filepath The file to remove.
  *
  **/
+#ifdef __WB_LIVE_UPDATE
 void wb_project_dir_remove_file(WB_PROJECT *prj, WB_PROJECT_DIR *root, const gchar *filepath)
 {
 	gboolean matches, was_dir;
@@ -760,6 +768,7 @@ void wb_project_dir_remove_file(WB_PROJECT *prj, WB_PROJECT_DIR *root, const gch
 		}
 	}
 }
+#endif
 
 
 /* Stolen and modified version from Geany. The only difference is that Geany
@@ -923,6 +932,7 @@ void wb_project_rescan(WB_PROJECT *prj)
 	}
 
 	/* Create file monitors for directories. */
+#ifdef __WB_LIVE_UPDATE
 	if (workbench_get_enable_live_update(wb_globals.opened_wb) == TRUE)
 	{
 		WB_MONITOR *monitor;
@@ -952,6 +962,7 @@ void wb_project_rescan(WB_PROJECT *prj)
 			}
 		}
 	}
+#endif
 }
 
 

--- a/workbench/src/workbench.c
+++ b/workbench/src/workbench.c
@@ -92,7 +92,9 @@ WORKBENCH *workbench_new(void)
 	new_wb->enable_live_update = TRUE;
 	new_wb->projects = g_ptr_array_new();
 	new_wb->bookmarks = g_ptr_array_new();
+#ifdef __WB_LIVE_UPDATE
 	new_wb->monitor = wb_monitor_new();
+#endif
 
 	return new_wb;
 }
@@ -123,7 +125,9 @@ void workbench_free(WORKBENCH *wb)
 		}
 	}
 
+#ifdef __WB_LIVE_UPDATE
 	wb_monitor_free(wb->monitor);
+#endif
 	g_ptr_array_free (wb->projects, TRUE);
 	g_free(wb);
 }
@@ -916,6 +920,7 @@ static gboolean workbench_references_are_valid(WORKBENCH *wb, WB_PROJECT *prj, W
  * @param file The new file to add to project/directory
  *
  **/
+#ifdef __WB_LIVE_UPDATE
 void workbench_process_add_file_event(WORKBENCH *wb, WB_PROJECT *prj, WB_PROJECT_DIR *dir, const gchar *file)
 {
 	if (workbench_references_are_valid(wb, prj, dir) == FALSE)
@@ -928,6 +933,7 @@ void workbench_process_add_file_event(WORKBENCH *wb, WB_PROJECT *prj, WB_PROJECT
 
 	wb_project_dir_add_file(prj, dir, file);
 }
+#endif
 
 
 /** Process the remove file event.
@@ -942,6 +948,7 @@ void workbench_process_add_file_event(WORKBENCH *wb, WB_PROJECT *prj, WB_PROJECT
  * @param file The file to remove from project/directory
  *
  **/
+#ifdef __WB_LIVE_UPDATE
 void workbench_process_remove_file_event(WORKBENCH *wb, WB_PROJECT *prj, WB_PROJECT_DIR *dir, const gchar *file)
 {
 	if (workbench_references_are_valid(wb, prj, dir) == FALSE)
@@ -954,9 +961,11 @@ void workbench_process_remove_file_event(WORKBENCH *wb, WB_PROJECT *prj, WB_PROJ
 
 	wb_project_dir_remove_file(prj, dir, file);
 }
+#endif
 
 
 /* Foreach callback function for creating file monitors. */
+#ifdef __WB_LIVE_UPDATE
 static void workbench_enable_live_update_foreach_cb(SIDEBAR_CONTEXT *context,
 													gpointer userdata)
 {
@@ -986,6 +995,7 @@ static void workbench_enable_live_update_foreach_cb(SIDEBAR_CONTEXT *context,
 
 	g_free(abs_path);
 }
+#endif
 
 
 /** Enable live update.
@@ -998,6 +1008,7 @@ static void workbench_enable_live_update_foreach_cb(SIDEBAR_CONTEXT *context,
  **/
 void workbench_enable_live_update(WORKBENCH *wb)
 {
+#ifdef __WB_LIVE_UPDATE
 	if (wb != NULL)
 	{
 		sidebar_call_foreach(DATA_ID_DIRECTORY,
@@ -1005,6 +1016,7 @@ void workbench_enable_live_update(WORKBENCH *wb)
 		sidebar_call_foreach(DATA_ID_SUB_DIRECTORY,
 			workbench_enable_live_update_foreach_cb, wb->monitor);
 	}
+#endif
 }
 
 
@@ -1018,8 +1030,10 @@ void workbench_enable_live_update(WORKBENCH *wb)
  **/
 void workbench_disable_live_update(WORKBENCH *wb)
 {
+#ifdef __WB_LIVE_UPDATE
 	if (wb != NULL)
 	{
 		wb_monitor_free(wb->monitor);
 	}
+#endif
 }


### PR DESCRIPTION
This hopefully fixes some Travis CI problems.

If GIO is not available and the GLib version is older than 2.46 then the feature "Live Update" will be disabled. Everything else works normal. In the "Settings"-Dialog the option do enable/disable the feature is grayed out and the tooltip text for the option informs the user that the feature is not available on the system.