### PR TITLE
workbench: use simple/old file monitor events only

### DIFF
--- a/build/workbench.m4
+++ b/build/workbench.m4
@@ -3,11 +3,6 @@ AC_DEFUN([GP_CHECK_WORKBENCH],
     GP_ARG_DISABLE([Workbench], [auto])
     GP_CHECK_UTILSLIB([Workbench])
 
-    PKG_CHECK_MODULES([GIO], [gio-2.0],
-        [AC_DEFINE([HAVE_GIO], 1, [Whether we have GIO])
-         have_gio=yes],
-        [have_gio=no])
-
     GP_COMMIT_PLUGIN_STATUS([Workbench])
     AC_CONFIG_FILES([
         workbench/Makefile

--- a/workbench/src/dialogs.c
+++ b/workbench/src/dialogs.c
@@ -440,19 +440,10 @@ gboolean dialogs_workbench_settings(WORKBENCH *workbench)
 
 	w_enable_live_update = gtk_check_button_new_with_mnemonic(_("_Enable live update"));
 	ui_table_add_row(GTK_TABLE(table), 1, w_enable_live_update, NULL);
-#ifdef __WB_LIVE_UPDATE
 	gtk_widget_set_tooltip_text(w_enable_live_update,
 		_("If the option is activated (default), then the list of files and the sidebar"
 		  " will be updated automatically if a file or directory is created, removed or renamed."
 		  "A manual re-scan is not required if the option is enabled."));
-#else
-	gtk_widget_set_sensitive(w_enable_live_update, FALSE);
-	gtk_widget_set_tooltip_text(w_enable_live_update,
-		_("If the option is activated (default), then the list of files and the sidebar"
-		  " will be updated automatically if a file or directory is created, removed or renamed."
-		  "A manual re-scan is not required if the option is enabled.\n\n"
-		  "This feature has been disabled because it is not available on your system."));
-#endif
 	enable_live_update_old = workbench_get_enable_live_update(workbench);
 	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(w_enable_live_update), enable_live_update_old);
 

--- a/workbench/src/plugin_main.c
+++ b/workbench/src/plugin_main.c
@@ -130,7 +130,7 @@ void geany_load_module(GeanyPlugin *plugin)
 	/* Set metadata */
 	plugin->info->name = _("Workbench");
 	plugin->info->description = _("Manage and customize multiple projects.");
-	plugin->info->version = "1.03";
+	plugin->info->version = "1.04";
 	plugin->info->author = "LarsGit223";
 
 	/* Set functions */

--- a/workbench/src/wb_monitor.c
+++ b/workbench/src/wb_monitor.c
@@ -31,7 +31,6 @@
 #include "wb_monitor.h"
 #include "utils.h"
 
-#ifdef __WB_LIVE_UPDATE
 
 struct S_WB_MONITOR
 {
@@ -247,4 +246,3 @@ void wb_monitor_free(WB_MONITOR *monitor)
 		}
 	}
 }
-#endif

--- a/workbench/src/wb_monitor.c
+++ b/workbench/src/wb_monitor.c
@@ -122,26 +122,6 @@ static void wb_monitor_file_changed_cb(G_GNUC_UNUSED GFileMonitor *monitor,
 				entry->prj, entry->dir, file_path);
 			break;
 
-		case G_FILE_MONITOR_EVENT_RENAMED:
-			event_string = "FILE_RENAMED";
-			workbench_process_remove_file_event (wb_globals.opened_wb,
-				entry->prj, entry->dir, file_path);
-			workbench_process_add_file_event (wb_globals.opened_wb,
-				entry->prj, entry->dir, other_file_path);
-			break;
-
-		case G_FILE_MONITOR_EVENT_MOVED_IN:
-			event_string = "FILE_MOVED_IN";
-			workbench_process_add_file_event (wb_globals.opened_wb,
-				entry->prj, entry->dir, file_path);
-			break;
-
-		case G_FILE_MONITOR_EVENT_MOVED_OUT:
-			event_string = "FILE_MOVED_OUT";
-			workbench_process_remove_file_event (wb_globals.opened_wb,
-				entry->prj, entry->dir, file_path);
-			break;
-
 		default:
 			break;
 	}
@@ -204,7 +184,7 @@ void wb_monitor_add_dir(WB_MONITOR *monitor, WB_PROJECT *prj,
 	/* Setup file monitor for directory */
 	file = g_file_new_for_path(dirpath);
 	newmon = g_file_monitor_directory
-		(file, G_FILE_MONITOR_WATCH_MOVES, NULL, &error);
+		(file, G_FILE_MONITOR_NONE, NULL, &error);
 	if (newmon == NULL)
 	{
 		/* Create monitor failed. Report error. */

--- a/workbench/src/wb_monitor.h
+++ b/workbench/src/wb_monitor.h
@@ -22,18 +22,12 @@
 #include <glib.h>
 #include "wb_project.h"
 
-#if defined(HAVE_GIO)
-#define __WB_LIVE_UPDATE 1
-#endif
-
 typedef struct S_WB_MONITOR WB_MONITOR;
 
-#ifdef __WB_LIVE_UPDATE
 WB_MONITOR *wb_monitor_new(void);
 void wb_monitor_add_dir(WB_MONITOR *monitor, WB_PROJECT *prj,
 						WB_PROJECT_DIR *dir, const gchar *dirpath);
 gboolean wb_monitor_remove_dir(WB_MONITOR *monitor, const gchar *dirpath);
 void wb_monitor_free(WB_MONITOR *monitor);
-#endif
 
 #endif

--- a/workbench/src/wb_monitor.h
+++ b/workbench/src/wb_monitor.h
@@ -22,7 +22,7 @@
 #include <glib.h>
 #include "wb_project.h"
 
-#if defined(HAVE_GIO) && GLIB_CHECK_VERSION (2, 46, 0)
+#if defined(HAVE_GIO)
 #define __WB_LIVE_UPDATE 1
 #endif
 

--- a/workbench/src/wb_project.c
+++ b/workbench/src/wb_project.c
@@ -569,7 +569,6 @@ static guint wb_project_dir_rescan_int(WB_PROJECT *prj, WB_PROJECT_DIR *root)
 
 
 /* Add a new file to the project directory and update the sidebar. */
-#ifdef __WB_LIVE_UPDATE
 static void wb_project_dir_add_file_int(WB_PROJECT *prj, WB_PROJECT_DIR *root, const gchar *filepath)
 {
 	gboolean matches;
@@ -634,7 +633,6 @@ static void wb_project_dir_add_file_int(WB_PROJECT *prj, WB_PROJECT_DIR *root, c
 		g_slist_free(scanned);
 	}
 }
-#endif
 
 
 /** Add a new file to the project directory and update the sidebar.
@@ -646,7 +644,6 @@ static void wb_project_dir_add_file_int(WB_PROJECT *prj, WB_PROJECT_DIR *root, c
  * @param filepath The file to add.
  *
  **/
-#ifdef __WB_LIVE_UPDATE
 void wb_project_dir_add_file(WB_PROJECT *prj, WB_PROJECT_DIR *root, const gchar *filepath)
 {
 	wb_project_dir_add_file_int(prj, root, filepath);
@@ -654,11 +651,9 @@ void wb_project_dir_add_file(WB_PROJECT *prj, WB_PROJECT_DIR *root, const gchar 
 		root, NULL);
 
 }
-#endif
 
 
 /* Check if the filepath is equal for the length of the directory path in px_temp */
-#ifdef __WB_LIVE_UPDATE
 static gboolean wb_project_dir_remove_child (gpointer key, gpointer value, gpointer user_data)
 {
 	WB_PROJECT_TEMP_DATA *px_temp;
@@ -680,7 +675,6 @@ static gboolean wb_project_dir_remove_child (gpointer key, gpointer value, gpoin
 	}
 	return FALSE;
 }
-#endif
 
 
 /** Remove a file from the project directory and update the sidebar.
@@ -692,7 +686,6 @@ static gboolean wb_project_dir_remove_child (gpointer key, gpointer value, gpoin
  * @param filepath The file to remove.
  *
  **/
-#ifdef __WB_LIVE_UPDATE
 void wb_project_dir_remove_file(WB_PROJECT *prj, WB_PROJECT_DIR *root, const gchar *filepath)
 {
 	gboolean matches, was_dir;
@@ -768,7 +761,6 @@ void wb_project_dir_remove_file(WB_PROJECT *prj, WB_PROJECT_DIR *root, const gch
 		}
 	}
 }
-#endif
 
 
 /* Stolen and modified version from Geany. The only difference is that Geany
@@ -932,7 +924,6 @@ void wb_project_rescan(WB_PROJECT *prj)
 	}
 
 	/* Create file monitors for directories. */
-#ifdef __WB_LIVE_UPDATE
 	if (workbench_get_enable_live_update(wb_globals.opened_wb) == TRUE)
 	{
 		WB_MONITOR *monitor;
@@ -962,7 +953,6 @@ void wb_project_rescan(WB_PROJECT *prj)
 			}
 		}
 	}
-#endif
 }
 
 

--- a/workbench/src/workbench.c
+++ b/workbench/src/workbench.c
@@ -92,9 +92,7 @@ WORKBENCH *workbench_new(void)
 	new_wb->enable_live_update = TRUE;
 	new_wb->projects = g_ptr_array_new();
 	new_wb->bookmarks = g_ptr_array_new();
-#ifdef __WB_LIVE_UPDATE
 	new_wb->monitor = wb_monitor_new();
-#endif
 
 	return new_wb;
 }
@@ -125,9 +123,7 @@ void workbench_free(WORKBENCH *wb)
 		}
 	}
 
-#ifdef __WB_LIVE_UPDATE
 	wb_monitor_free(wb->monitor);
-#endif
 	g_ptr_array_free (wb->projects, TRUE);
 	g_free(wb);
 }
@@ -920,7 +916,6 @@ static gboolean workbench_references_are_valid(WORKBENCH *wb, WB_PROJECT *prj, W
  * @param file The new file to add to project/directory
  *
  **/
-#ifdef __WB_LIVE_UPDATE
 void workbench_process_add_file_event(WORKBENCH *wb, WB_PROJECT *prj, WB_PROJECT_DIR *dir, const gchar *file)
 {
 	if (workbench_references_are_valid(wb, prj, dir) == FALSE)
@@ -933,7 +928,6 @@ void workbench_process_add_file_event(WORKBENCH *wb, WB_PROJECT *prj, WB_PROJECT
 
 	wb_project_dir_add_file(prj, dir, file);
 }
-#endif
 
 
 /** Process the remove file event.
@@ -948,7 +942,6 @@ void workbench_process_add_file_event(WORKBENCH *wb, WB_PROJECT *prj, WB_PROJECT
  * @param file The file to remove from project/directory
  *
  **/
-#ifdef __WB_LIVE_UPDATE
 void workbench_process_remove_file_event(WORKBENCH *wb, WB_PROJECT *prj, WB_PROJECT_DIR *dir, const gchar *file)
 {
 	if (workbench_references_are_valid(wb, prj, dir) == FALSE)
@@ -961,11 +954,9 @@ void workbench_process_remove_file_event(WORKBENCH *wb, WB_PROJECT *prj, WB_PROJ
 
 	wb_project_dir_remove_file(prj, dir, file);
 }
-#endif
 
 
 /* Foreach callback function for creating file monitors. */
-#ifdef __WB_LIVE_UPDATE
 static void workbench_enable_live_update_foreach_cb(SIDEBAR_CONTEXT *context,
 													gpointer userdata)
 {
@@ -995,7 +986,6 @@ static void workbench_enable_live_update_foreach_cb(SIDEBAR_CONTEXT *context,
 
 	g_free(abs_path);
 }
-#endif
 
 
 /** Enable live update.
@@ -1008,7 +998,6 @@ static void workbench_enable_live_update_foreach_cb(SIDEBAR_CONTEXT *context,
  **/
 void workbench_enable_live_update(WORKBENCH *wb)
 {
-#ifdef __WB_LIVE_UPDATE
 	if (wb != NULL)
 	{
 		sidebar_call_foreach(DATA_ID_DIRECTORY,
@@ -1016,7 +1005,6 @@ void workbench_enable_live_update(WORKBENCH *wb)
 		sidebar_call_foreach(DATA_ID_SUB_DIRECTORY,
 			workbench_enable_live_update_foreach_cb, wb->monitor);
 	}
-#endif
 }
 
 
@@ -1030,10 +1018,8 @@ void workbench_enable_live_update(WORKBENCH *wb)
  **/
 void workbench_disable_live_update(WORKBENCH *wb)
 {
-#ifdef __WB_LIVE_UPDATE
 	if (wb != NULL)
 	{
 		wb_monitor_free(wb->monitor);
 	}
-#endif
 }


### PR DESCRIPTION
This removes the dependency/the requirement for GLib version 2.46.