### PR TITLE
treebrowser: removed needless Gtk version checks

### DIFF
--- a/treebrowser/src/treebrowser.c
+++ b/treebrowser/src/treebrowser.c
@@ -138,11 +138,7 @@ PLUGIN_SET_TRANSLATABLE_INFO(
 static GList*
 _gtk_cell_layout_get_cells(GtkTreeViewColumn *column)
 {
-#if GTK_CHECK_VERSION(2, 12, 0)
 	return gtk_cell_layout_get_cells(GTK_CELL_LAYOUT(column));
-#else
-	return gtk_tree_view_column_get_cell_renderers(column);
-#endif
 }
 
 
@@ -206,7 +202,6 @@ utils_pixbuf_from_stock(const gchar *stock_id)
 static GdkPixbuf *
 utils_pixbuf_from_path(gchar *path)
 {
-#if GTK_CHECK_VERSION(2, 14, 0)
 	GIcon 		*icon;
 	GdkPixbuf 	*ret = NULL;
 	GtkIconInfo *info;
@@ -237,11 +232,6 @@ utils_pixbuf_from_path(gchar *path)
 		gtk_icon_info_free(info);
 	}
 	return ret;
-#else
-	return utils_pixbuf_from_stock(g_file_test(path, G_FILE_TEST_IS_DIR)
-									? GTK_STOCK_DIRECTORY
-									: GTK_STOCK_FILE);
-#endif
 }
 
 
@@ -1706,15 +1696,11 @@ create_view_and_model(void)
 
 	ui_widget_modify_font_from_string(view, geany->interface_prefs->tagbar_font);
 
-#if GTK_CHECK_VERSION(2, 10, 0)
 	g_object_set(view, "has-tooltip", TRUE, "tooltip-column", TREEBROWSER_COLUMN_URI, NULL);
-#endif
 
 	gtk_tree_selection_set_mode(gtk_tree_view_get_selection(GTK_TREE_VIEW(view)), GTK_SELECTION_SINGLE);
 
-#if GTK_CHECK_VERSION(2, 10, 0)
 	gtk_tree_view_set_enable_tree_lines(GTK_TREE_VIEW(view), CONFIG_SHOW_TREE_LINES);
-#endif
 
 	treestore = gtk_tree_store_new(TREEBROWSER_COLUMNC, GDK_TYPE_PIXBUF, G_TYPE_STRING, G_TYPE_STRING, G_TYPE_INT);
 
@@ -1783,11 +1769,8 @@ create_sidebar(void)
 
 	gtk_widget_set_tooltip_text(filter,
 		_("Filter (*.c;*.h;*.cpp), and if you want temporary filter using the '!' reverse try for example this '!;*.c;*.h;*.cpp'"));
-	if (gtk_check_version(2, 15, 2) == NULL)
-	{
-		ui_entry_add_clear_icon(GTK_ENTRY(filter));
-		g_signal_connect(filter, "icon-release", G_CALLBACK(on_filter_clear), NULL);
-	}
+	ui_entry_add_clear_icon(GTK_ENTRY(filter));
+	g_signal_connect(filter, "icon-release", G_CALLBACK(on_filter_clear), NULL);
 
 	gtk_widget_set_tooltip_text(addressbar,
 		_("Addressbar for example '/projects/my-project'"));
@@ -1936,9 +1919,7 @@ on_configure_response(GtkDialog *dialog, gint response, gpointer user_data)
 
 	if (save_settings() == TRUE)
 	{
-#if GTK_CHECK_VERSION(2, 10, 0)
 		gtk_tree_view_set_enable_tree_lines(GTK_TREE_VIEW(treeview), CONFIG_SHOW_TREE_LINES);
-#endif
 		treebrowser_chroot(addressbar_last_address);
 		if (CONFIG_SHOW_BOOKMARKS)
 			treebrowser_load_bookmarks();
@@ -2052,9 +2033,7 @@ plugin_configure(GtkDialog *dialog)
 	configure_widgets.SHOW_TREE_LINES = gtk_check_button_new_with_label(_("Show tree lines"));
 	gtk_button_set_focus_on_click(GTK_BUTTON(configure_widgets.SHOW_TREE_LINES), FALSE);
 	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(configure_widgets.SHOW_TREE_LINES), CONFIG_SHOW_TREE_LINES);
-#if GTK_CHECK_VERSION(2, 10, 0)
 	gtk_box_pack_start(GTK_BOX(vbox), configure_widgets.SHOW_TREE_LINES, FALSE, FALSE, 0);
-#endif
 
 	configure_widgets.SHOW_BOOKMARKS = gtk_check_button_new_with_label(_("Show bookmarks"));
 	gtk_button_set_focus_on_click(GTK_BUTTON(configure_widgets.SHOW_BOOKMARKS), FALSE);


### PR DESCRIPTION
Geany depends on Gtk version 2.24 so all version checks for a lower version than 2.24 are needless.