### PR TITLE
workbench: added option "Expand on hover"

### DIFF
--- a/workbench/src/dialogs.c
+++ b/workbench/src/dialogs.c
@@ -407,12 +407,13 @@ gboolean dialogs_directory_settings(WB_PROJECT_DIR *directory)
 gboolean dialogs_workbench_settings(WORKBENCH *workbench)
 {
 	gint result;
-	GtkWidget *w_rescan_projects_on_open, *w_enable_live_update;
+	GtkWidget *w_rescan_projects_on_open, *w_enable_live_update, *w_expand_on_hover;
 	GtkWidget *dialog, *content_area;
 	GtkWidget *vbox, *hbox, *table;
 	GtkDialogFlags flags;
 	gboolean changed, rescan_projects_on_open, rescan_projects_on_open_old;
 	gboolean enable_live_update, enable_live_update_old;
+	gboolean expand_on_hover, expand_on_hover_old;
 
 	/* Create the widgets */
 	flags = GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT;
@@ -447,6 +448,14 @@ gboolean dialogs_workbench_settings(WORKBENCH *workbench)
 	enable_live_update_old = workbench_get_enable_live_update(workbench);
 	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(w_enable_live_update), enable_live_update_old);
 
+	w_expand_on_hover = gtk_check_button_new_with_mnemonic(_("_Expand on hover"));
+	ui_table_add_row(GTK_TABLE(table), 2, w_expand_on_hover, NULL);
+	gtk_widget_set_tooltip_text(w_expand_on_hover,
+		_("If the option is activated, then a tree node in the sidebar"
+		  " will be expanded or collapsed by hovering over it with the mouse cursor."));
+	expand_on_hover_old = workbench_get_expand_on_hover(workbench);
+	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(w_expand_on_hover), expand_on_hover_old);
+
 	gtk_box_pack_start(GTK_BOX(vbox), table, FALSE, FALSE, 6);
 
 	hbox = gtk_hbox_new(FALSE, 0);
@@ -471,6 +480,12 @@ gboolean dialogs_workbench_settings(WORKBENCH *workbench)
 		{
 			changed = TRUE;
 			workbench_set_enable_live_update(workbench, enable_live_update);
+		}
+		expand_on_hover = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(w_expand_on_hover));
+		if (expand_on_hover != expand_on_hover_old)
+		{
+			changed = TRUE;
+			workbench_set_expand_on_hover(workbench, expand_on_hover);
 		}
 	}
 

--- a/workbench/src/plugin_main.c
+++ b/workbench/src/plugin_main.c
@@ -130,7 +130,7 @@ void geany_load_module(GeanyPlugin *plugin)
 	/* Set metadata */
 	plugin->info->name = _("Workbench");
 	plugin->info->description = _("Manage and customize multiple projects.");
-	plugin->info->version = "1.04";
+	plugin->info->version = "1.05";
 	plugin->info->author = "LarsGit223";
 
 	/* Set functions */

--- a/workbench/src/sidebar.c
+++ b/workbench/src/sidebar.c
@@ -863,6 +863,9 @@ static void sidebar_update_workbench(GtkTreeIter *iter, gint *position)
 		gint length;
 		gchar text[200];
 
+		gtk_tree_view_set_hover_expand(GTK_TREE_VIEW(sidebar.file_view),
+			workbench_get_expand_on_hover(wb_globals.opened_wb));
+
 		count = workbench_get_project_count(wb_globals.opened_wb);
 		length = g_snprintf(text, sizeof(text),
 							g_dngettext(GETTEXT_PACKAGE, "%s: %u Project", "%s: %u Projects", count),
@@ -913,6 +916,14 @@ void sidebar_update (SIDEBAR_EVENT event, SIDEBAR_CONTEXT *context)
 			sidebar_reset_tree_store();
 			sidebar_update_workbench(&iter, &position);
 			sidebar_insert_all_projects(&iter, &position);
+
+			if (event == SIDEBAR_CONTEXT_WB_CREATED ||
+				event == SIDEBAR_CONTEXT_WB_OPENED)
+			{
+				gtk_tree_view_set_hover_expand(GTK_TREE_VIEW(sidebar.file_view),
+					workbench_get_expand_on_hover(wb_globals.opened_wb));
+			}
+
 			sidebar_activate();
 		break;
 		case SIDEBAR_CONTEXT_WB_SAVED:

--- a/workbench/src/workbench.c
+++ b/workbench/src/workbench.c
@@ -48,6 +48,7 @@ struct S_WORKBENCH
 	gboolean  modified;
 	gboolean  rescan_projects_on_open;
 	gboolean  enable_live_update;
+	gboolean  expand_on_hover;
 	GPtrArray *projects;
 	GPtrArray *bookmarks;
 	WB_MONITOR *monitor;
@@ -247,6 +248,42 @@ gboolean workbench_get_enable_live_update(WORKBENCH *wb)
 	if (wb != NULL)
 	{
 		return wb->enable_live_update;
+	}
+	return FALSE;
+}
+
+
+/** Set the "Expand on hover" option.
+ *
+ * @param wb    The workbench
+ * @param value The value to set
+ *
+ **/
+void workbench_set_expand_on_hover(WORKBENCH *wb, gboolean value)
+{
+	if (wb != NULL)
+	{
+		if (wb->expand_on_hover != value)
+		{
+			wb->expand_on_hover = value;
+			wb->modified = TRUE;
+		}
+	}
+}
+
+
+/** Get the "Expand on hover" option.
+ *
+ * @param wb The workbench
+ * @return TRUE = expand a tree-node on hovering over it,
+ *         FALSE = don't
+ *
+ **/
+gboolean workbench_get_expand_on_hover(WORKBENCH *wb)
+{
+	if (wb != NULL)
+	{
+		return wb->expand_on_hover;
 	}
 	return FALSE;
 }
@@ -653,6 +690,7 @@ gboolean workbench_save(WORKBENCH *wb, GError **error)
 		g_key_file_set_string(kf, "General", "version", "1.0");
 		g_key_file_set_boolean(kf, "General", "RescanProjectsOnOpen", wb->rescan_projects_on_open);
 		g_key_file_set_boolean(kf, "General", "EnableLiveUpdate", wb->enable_live_update);
+		g_key_file_set_boolean(kf, "General", "ExpandOnHover", wb->expand_on_hover);
 
 		/* Save Workbench bookmarks as string list */
 		boomarks_size = workbench_get_bookmarks_count(wb);
@@ -785,6 +823,16 @@ gboolean workbench_load(WORKBENCH *wb, const gchar *filename, GError **error)
 			/* Not found. Might happen if the workbench was created with an older version of the plugin.
 			   Initialize with TRUE. */
 			wb->enable_live_update = TRUE;
+		}
+		if (g_key_file_has_key (kf, "General", "ExpandOnHover", error))
+		{
+			wb->expand_on_hover = g_key_file_get_boolean(kf, "General", "ExpandOnHover", error);
+		}
+		else
+		{
+			/* Not found. Might happen if the workbench was created with an older version of the plugin.
+			   Initialize with FALSE. */
+			wb->expand_on_hover = FALSE;
 		}
 
 		/* Load Workbench bookmarks from string list */

--- a/workbench/src/workbench.h
+++ b/workbench/src/workbench.h
@@ -43,6 +43,8 @@ void workbench_set_rescan_projects_on_open(WORKBENCH *wb, gboolean value);
 gboolean workbench_get_rescan_projects_on_open(WORKBENCH *wb);
 void workbench_set_enable_live_update(WORKBENCH *wb, gboolean value);
 gboolean workbench_get_enable_live_update(WORKBENCH *wb);
+void workbench_set_expand_on_hover(WORKBENCH *wb, gboolean value);
+gboolean workbench_get_expand_on_hover(WORKBENCH *wb);
 
 WB_PROJECT *workbench_get_project_at_index(WORKBENCH *wb, guint index);
 PROJECT_ENTRY_STATUS workbench_get_project_status_at_index(WORKBENCH *wb, guint index);


### PR DESCRIPTION
The user can now activate the option "Expand on hover". If the option is activated then a tree node in the workbench sidebar will expand or collapse by hovering with the mouse cursor over it.