### PR TITLE
vimode: Fix goto_down with line wrapping

### DIFF
--- a/vimode/src/cmds/motion.c
+++ b/vimode/src/cmds/motion.c
@@ -78,7 +78,7 @@ static void goto_down(CmdParams *p, gint num)
 	/* see cmd_goto_up() for explanation */
 	one_above = p->line + num - 1;
 	one_above = one_above < last_line ? one_above : last_line - 1;
-	pos = SSM(p->sci, SCI_POSITIONFROMLINE, one_above, 0);
+	pos = SSM(p->sci, SCI_GETLINEENDPOSITION, one_above, 0);
 	SET_POS_NOX(p->sci, pos, FALSE);
 	SSM(p->sci, SCI_LINEDOWN, 0, 0);
 }


### PR DESCRIPTION
SCI_LINEDOWN goes down only one display line, hence when line wrapping
was enabled and a line wrapped over more than two lines, it was
impossible to go to the next actual line when pressing j.

Note that this still doesn't emulate vim behavior correctly where
caret-x position is saved for actual lines and not display lines. But
this change at least makes j go the next line when wrapping is enabled.

Note that I'm not completely sure whether this change retains all workarounds [mentioned in `cmd_goto_up`](https://github.com/geany/geany-plugins/blob/341cab4e13c122b2b74e6f31a43be9adc653f8af/vimode/src/cmds/motion.c#L51-L54).