### PR TITLE
scope: removed invalid signal 'project-before-save' and callback function

### DIFF
--- a/scope/src/scope.c
+++ b/scope/src/scope.c
@@ -351,12 +351,6 @@ static void on_settings_save(G_GNUC_UNUSED GObject *obj, G_GNUC_UNUSED GKeyFile 
 	schedule_settings_saved(TRUE);
 }
 
-static void on_project_before_save(G_GNUC_UNUSED GObject *obj, G_GNUC_UNUSED GKeyFile *keyfile,
-	G_GNUC_UNUSED gpointer gdata)
-{
-	schedule_settings_saved(FALSE);
-}
-
 static gboolean on_editor_notify(G_GNUC_UNUSED GObject *obj, GeanyEditor *editor,
 	SCNotification *nt, G_GNUC_UNUSED gpointer gdata)
 {
@@ -438,7 +432,6 @@ static const ScopeCallback scope_callbacks[] =
 	{ "document-filetype-set",    G_CALLBACK(on_document_filetype_set) },
 	{ "document-activate",        G_CALLBACK(on_document_activate) },
 	{ "document-save",            G_CALLBACK(on_document_activate) },
-	{ "project-before-save",      G_CALLBACK(on_project_before_save) },
 	{ "project-open",             G_CALLBACK(on_project_open) },
 	{ "project-close",            G_CALLBACK(on_project_close) },
 	{ "geany-startup-complete",   G_CALLBACK(on_geany_startup_complete) },


### PR DESCRIPTION
This prevents a debug message like 

> "signal 'project-before-save' is invalid for instance '0xd7da10' of type 'GeanyObject'"

 being generated on loading the scope plugin.