### PR TITLE
Scope: fix Automake conditional when building for Windows

### DIFF
--- a/build/scope.m4
+++ b/build/scope.m4
@@ -2,22 +2,17 @@ AC_DEFUN([GP_CHECK_SCOPE],
 [
     GP_ARG_DISABLE([Scope], [auto])
 
-    case "$host_os" in
-        cygwin* | mingw* | win32*)
-            PTY_LIBS=""
-            ;;
+    AS_CASE([$host_os],
+            [cygwin* | mingw* | win32*],
+            [PTY_LIBS=""],
 
-        *)
+            [GP_CHECK_GTK3([vte_package=vte-2.91], [vte_package="vte >= 0.17"])
+             GP_CHECK_PLUGIN_DEPS([scope], [VTE], [$vte_package])
+             GP_CHECK_UTILSLIB_VTECOMPAT([Scope])
 
-            GP_CHECK_GTK3([vte_package=vte-2.91], [vte_package="vte >= 0.17"])
-            GP_CHECK_PLUGIN_DEPS([scope], [VTE], [$vte_package])
+             AC_CHECK_HEADERS([util.h pty.h libutil.h])
+             PTY_LIBS="-lutil"])
 
-            AC_CHECK_HEADERS([util.h pty.h libutil.h])
-            PTY_LIBS="-lutil"
-            ;;
-    esac
-
-    AM_CONDITIONAL([SCOPE_USE_VTE291], [test "$enable_scope" != no && test "$vte_package" = vte-2.91])
     AC_SUBST(PTY_LIBS)
 
     GP_COMMIT_PLUGIN_STATUS([Scope])

--- a/build/scope.m4
+++ b/build/scope.m4
@@ -11,13 +11,13 @@ AC_DEFUN([GP_CHECK_SCOPE],
 
             GP_CHECK_GTK3([vte_package=vte-2.91], [vte_package="vte >= 0.17"])
             GP_CHECK_PLUGIN_DEPS([scope], [VTE], [$vte_package])
-            AM_CONDITIONAL([GP_VTE291_USED], [test "$enable_scope" != no && test "$vte_package" = vte-2.91])
 
             AC_CHECK_HEADERS([util.h pty.h libutil.h])
             PTY_LIBS="-lutil"
             ;;
     esac
 
+    AM_CONDITIONAL([GP_VTE291_USED], [test "$enable_scope" != no && test "$vte_package" = vte-2.91])
     AC_SUBST(PTY_LIBS)
 
     GP_COMMIT_PLUGIN_STATUS([Scope])

--- a/build/scope.m4
+++ b/build/scope.m4
@@ -17,7 +17,7 @@ AC_DEFUN([GP_CHECK_SCOPE],
             ;;
     esac
 
-    AM_CONDITIONAL([GP_VTE291_USED], [test "$enable_scope" != no && test "$vte_package" = vte-2.91])
+    AM_CONDITIONAL([SCOPE_USE_VTE291], [test "$enable_scope" != no && test "$vte_package" = vte-2.91])
     AC_SUBST(PTY_LIBS)
 
     GP_COMMIT_PLUGIN_STATUS([Scope])

--- a/build/utils.m4
+++ b/build/utils.m4
@@ -7,6 +7,22 @@ AC_DEFUN([_GP_UTILSLIB_ARG],
               [enable_utilslib=auto])
 ])
 
+dnl GP_CHECK_UTILSLIB_VTECOMPAT(PluginName)
+AC_DEFUN([GP_CHECK_UTILSLIB_VTECOMPAT],
+[
+    AS_IF([test "$m4_tolower(AS_TR_SH(enable_$1))" != no],
+          [GP_CHECK_GTK3([utilslib_vte_package=vte-2.91],
+                         [utilslib_vte_package=vte])
+           PKG_CHECK_MODULES([UTILSLIB], [$utilslib_vte_package],
+                             [utilslib_have_vte=yes],
+                             [utilslib_have_vte=no])
+           AS_IF([test "$utilslib_have_vte" != yes || test "$enable_utilslib" = no],
+                 [AS_IF([test "$m4_tolower(AS_TR_SH(enable_$1))" = yes],
+                        [AC_MSG_ERROR([Plugin $1 depends on utilslib VTE support which is not available])],
+                        [m4_tolower(AS_TR_SH(enable_$1))=no])],
+                 [enable_utilslib=yes])])
+])
+
 dnl GP_CHECK_UTILSLIB(PluginName)
 dnl Check for utils library
 AC_DEFUN([GP_CHECK_UTILSLIB],
@@ -30,5 +46,7 @@ AC_DEFUN([GP_COMMIT_UTILSLIB_STATUS],
            ])],
           [enable_utilslib=no])
     AM_CONDITIONAL([ENABLE_UTILSLIB], [test "$enable_utilslib" = "yes"])
+    AM_CONDITIONAL([ENABLE_UTILSLIB_VTECOMPAT], [test "$enable_utilslib" = yes && test "$utilslib_have_vte" = yes])
     GP_STATUS_FEATURE_ADD([Utility library], [$enable_utilslib])
+    GP_STATUS_FEATURE_ADD([Utility library VTE support], [${utilslib_have_vte-no}])
 ])

--- a/utils/src/Makefile.am
+++ b/utils/src/Makefile.am
@@ -6,7 +6,7 @@ libgeanypluginutils_la_SOURCES = \
 	filelist.h \
 	filelist.c
 
-if SCOPE_USE_VTE291
+if ENABLE_UTILSLIB_VTECOMPAT
 libgeanypluginutils_la_SOURCES += \
 	gp_vtecompat.h \
 	gp_vtecompat.c
@@ -14,8 +14,7 @@ endif
 
 libgeanypluginutils_la_CPPFLAGS = $(AM_CPPFLAGS) \
 	-DG_LOG_DOMAIN=\"Utils\"
-libgeanypluginutils_la_CFLAGS = $(AM_CFLAGS) $(VTE_CFLAGS)
-libgeanypluginutils_la_LIBADD = $(COMMONLIBS) $(VTE_LIBS)
+libgeanypluginutils_la_CFLAGS = $(AM_CFLAGS) $(UTILSLIB_CFLAGS)
+libgeanypluginutils_la_LIBADD = $(COMMONLIBS) $(UTILSLIB_LIBS)
 libgeanypluginutils_la_LDFLAGS = -no-undefined $(GP_LDFLAGS)
 include $(top_srcdir)/build/cppcheck.mk
-

--- a/utils/src/Makefile.am
+++ b/utils/src/Makefile.am
@@ -6,7 +6,7 @@ libgeanypluginutils_la_SOURCES = \
 	filelist.h \
 	filelist.c
 
-if GP_VTE291_USED
+if SCOPE_USE_VTE291
 libgeanypluginutils_la_SOURCES += \
 	gp_vtecompat.h \
 	gp_vtecompat.c


### PR DESCRIPTION
It is not valid to place `AM_CONDITIONAL`s inside a shell condition, because Automake has to known its value in all cases.  Automake is smart enough to detect it if used in a AutoShell conditional (like `AS_IF`/`AS_CASE`/...), but can't work any magic inside a pure shell conditional (if/case/...). So, move the `AM_CONDITIONAL` outside the conditional, as the value is already conditional anyway.

This PR also cleans up the conditional a little bit by giving it a plugin-specific name, and removing irrelevant test fro the condition (whether or not the plugin is enabled has little to no relevance here, and the plugin won't be built anyway).