### PR TITLE
'Debugger' plugin port to GTK3 with GTK2 compatibility

### DIFF
--- a/build/debugger.m4
+++ b/build/debugger.m4
@@ -1,10 +1,15 @@
 AC_DEFUN([GP_CHECK_DEBUGGER],
 [
     GP_ARG_DISABLE([Debugger], [auto])
-    GP_CHECK_PLUGIN_GTK2_ONLY([Debugger])
+
+    GP_CHECK_UTILSLIB([Debugger])
+    GP_CHECK_UTILSLIB_VTECOMPAT([Debugger])
+    GP_CHECK_GTK3([vte_package=vte-2.91 vte_version=0.46],
+                  [vte_package=vte vte_version=0.24])
     GP_CHECK_PLUGIN_DEPS([debugger], [VTE],
-                         [vte >= 0.24])
+                         [${vte_package} >= ${vte_version}])
     AC_CHECK_HEADERS([util.h pty.h libutil.h])
+
     GP_COMMIT_PLUGIN_STATUS([Debugger])
     AC_CONFIG_FILES([
         debugger/Makefile

--- a/debugger/src/Makefile.am
+++ b/debugger/src/Makefile.am
@@ -71,9 +71,9 @@ debugger_la_SOURCES = \
 	cell_renderers/cellrenderertoggle.c \
 	cell_renderers/cellrenderertoggle.h
 
-debugger_la_LIBADD = $(COMMONLIBS) $(VTE_LIBS) -lutil
+debugger_la_LIBADD = $(COMMONLIBS) $(VTE_LIBS) -lutil $(top_builddir)/utils/src/libgeanypluginutils.la
 debugger_la_CFLAGS = $(AM_CFLAGS) $(VTE_CFLAGS) -DDBGPLUG_DATA_DIR=\"$(plugindatadir)\" -DPLUGIN_NAME=\"$(plugin)\"
-debugger_la_CPPFLAGS = $(AM_CPPFLAGS) -DG_LOG_DOMAIN=\"Debugger\"
+debugger_la_CPPFLAGS = $(AM_CPPFLAGS) -DG_LOG_DOMAIN=\"Debugger\" -I$(top_srcdir)/utils/src
 
 check_PROGRAMS = gdb_mi_test
 dist_check_SCRIPTS = tests/gdb_mi_test.sh

--- a/debugger/src/btnpanel.c
+++ b/debugger/src/btnpanel.c
@@ -82,9 +82,13 @@ static void on_execute_until(GtkButton *button, gpointer user_data)
  */
 GtkWidget* btnpanel_create(on_toggle cb)
 {
+#if GTK_CHECK_VERSION(3, 0, 0)
+	GtkWidget *vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, CP_BUTTONS_PAD);
+	GtkWidget *hbutton_box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, CP_BUTTONS_PAD);
+#else
 	GtkWidget *vbox = gtk_vbox_new(FALSE, CP_BUTTONS_PAD);
-
 	GtkWidget *hbutton_box = gtk_hbox_new(FALSE, CP_BUTTONS_PAD);
+#endif
 
 	runbtn = create_button("run.gif", _("Run"));
 	g_signal_connect(G_OBJECT(runbtn), "clicked", G_CALLBACK (debug_run), (gpointer)TRUE);
@@ -92,7 +96,12 @@ GtkWidget* btnpanel_create(on_toggle cb)
 	gtk_box_pack_start(GTK_BOX(hbutton_box), runbtn, TRUE, TRUE, 0);
 	gtk_box_pack_start(GTK_BOX(vbox), hbutton_box, FALSE, TRUE, 0);
 	
+#if GTK_CHECK_VERSION(3, 0, 0)
+	hbutton_box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, CP_BUTTONS_PAD);
+	gtk_box_set_homogeneous(GTK_BOX(hbutton_box), TRUE);
+#else
 	hbutton_box = gtk_hbox_new(TRUE, CP_BUTTONS_PAD);
+#endif
 
 	restartbtn = create_button("restart.gif", _("Restart"));
 	g_signal_connect(G_OBJECT(restartbtn), "clicked", G_CALLBACK (debug_restart), (gpointer)TRUE);
@@ -104,7 +113,12 @@ GtkWidget* btnpanel_create(on_toggle cb)
 	gtk_box_pack_start(GTK_BOX(hbutton_box), stopbtn, FALSE, TRUE, 0);
 	gtk_box_pack_start(GTK_BOX(vbox), hbutton_box, FALSE, TRUE, 0);
 
+#if GTK_CHECK_VERSION(3, 0, 0)
+	hbutton_box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, CP_BUTTONS_PAD);
+	gtk_box_set_homogeneous(GTK_BOX(hbutton_box), TRUE);
+#else
 	hbutton_box = gtk_hbox_new(TRUE, CP_BUTTONS_PAD);
+#endif
 
 	stepoverbtn = create_button("step_over.gif", _("Step over"));
 	g_signal_connect(G_OBJECT(stepoverbtn), "clicked", G_CALLBACK (debug_step_over), (gpointer)TRUE);
@@ -116,7 +130,12 @@ GtkWidget* btnpanel_create(on_toggle cb)
 	gtk_box_pack_start(GTK_BOX(hbutton_box), stepinbtn, FALSE, TRUE, 0);
 	gtk_box_pack_start(GTK_BOX(vbox), hbutton_box, FALSE, TRUE, 0);
 
+#if GTK_CHECK_VERSION(3, 0, 0)
+	hbutton_box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, CP_BUTTONS_PAD);
+	gtk_box_set_homogeneous(GTK_BOX(hbutton_box), TRUE);
+#else
 	hbutton_box = gtk_hbox_new(TRUE, CP_BUTTONS_PAD);
+#endif
 
 	stepoutbtn = create_button("step_out.gif", _("Step out"));
 	g_signal_connect(G_OBJECT(stepoutbtn), "clicked", G_CALLBACK (debug_step_out), (gpointer)TRUE);
@@ -128,7 +147,11 @@ GtkWidget* btnpanel_create(on_toggle cb)
 	gtk_box_pack_start(GTK_BOX(hbutton_box), runcursorbtn, FALSE, TRUE, 0);
 	gtk_box_pack_start(GTK_BOX(vbox), hbutton_box, FALSE, TRUE, 0);
 
+#if GTK_CHECK_VERSION(3, 0, 0)
+	optbtn = create_stock_button("preferences-system", _("Settings"));
+#else
 	optbtn = create_stock_button(GTK_STOCK_PREFERENCES, _("Settings"));
+#endif
 	g_signal_connect(G_OBJECT(optbtn), "clicked", G_CALLBACK (on_settings), NULL);
 	gtk_box_pack_end(GTK_BOX(vbox), optbtn, FALSE, FALSE, 0);
 

--- a/debugger/src/cell_renderers/cellrendererbreakicon.c
+++ b/debugger/src/cell_renderers/cellrendererbreakicon.c
@@ -40,6 +40,27 @@ enum {
   PROP_HITSCOUNT
 };
 
+struct _CellRendererBreakIcon
+{
+  GtkCellRenderer parent;
+
+  guint enabled;
+  const gchar* condition;
+  guint hitscount;
+
+  GdkPixbuf *pixbuf_enabled;
+  GdkPixbuf *pixbuf_disabled;
+  GdkPixbuf *pixbuf_conditional;
+  GdkPixbuf *pixbuf_file;
+};
+
+struct _CellRendererBreakIconClass
+{
+  GtkCellRendererClass parent_class;
+
+  void (*clicked)(CellRendererBreakIcon *cell_renderer_toggle, const gchar *path);
+};
+
 static gpointer parent_class;
 static guint clicked_signal;
 
@@ -136,14 +157,23 @@ static void cell_renderer_break_icon_set_property (GObject *object, guint param_
 /*
  * get size of a cell
  */
+#if GTK_CHECK_VERSION(3, 0, 0)
+static void cell_renderer_break_icon_get_size(GtkCellRenderer *cell, GtkWidget *widget, const GdkRectangle *cell_area, 
+	gint *x_offset, gint *y_offset, gint *width, gint *height)
+#else
 static void cell_renderer_break_icon_get_size(GtkCellRenderer *cell, GtkWidget *widget, GdkRectangle *cell_area, 
 	gint *x_offset, gint *y_offset, gint *width, gint *height)
+#endif
 {
 	CellRendererBreakIcon *cellbreakpoint = (CellRendererBreakIcon *) cell;
 	gint pixbuf_width  = 0;
 	gint pixbuf_height = 0;
 	gint calc_width;
 	gint calc_height;
+	gint xpad;
+	gint ypad;
+	gfloat xalign;
+	gfloat yalign;
 	
 	if (cellbreakpoint->pixbuf_enabled)
 	{
@@ -166,21 +196,24 @@ static void cell_renderer_break_icon_get_size(GtkCellRenderer *cell, GtkWidget *
 		pixbuf_height = MAX (pixbuf_height, gdk_pixbuf_get_height (cellbreakpoint->pixbuf_file));
 	}
 	
-	calc_width  = (gint) cell->xpad * 2 + pixbuf_width;
-	calc_height = (gint) cell->ypad * 2 + pixbuf_height;
+	gtk_cell_renderer_get_padding(cell, &xpad, &ypad);
+	calc_width  = xpad * 2 + pixbuf_width;
+	calc_height = ypad * 2 + pixbuf_height;
+
+	gtk_cell_renderer_get_alignment(cell, &xalign, &yalign);
 	
 	if (cell_area && pixbuf_width > 0 && pixbuf_height > 0)
 	{
 		if (x_offset)
 		{
 			*x_offset = (((gtk_widget_get_direction (widget) == GTK_TEXT_DIR_RTL) ?
-				(1.0 - cell->xalign) : cell->xalign) * 
+				(1.0 - xalign) : xalign) * 
 				(cell_area->width - calc_width));
 			*x_offset = MAX (*x_offset, 0);
 		}
 		if (y_offset)
 		{
-			*y_offset = (cell->yalign * (cell_area->height - calc_height));
+			*y_offset = (yalign * (cell_area->height - calc_height));
 			*y_offset = MAX (*y_offset, 0);
 		}
 	}
@@ -200,8 +233,13 @@ static void cell_renderer_break_icon_get_size(GtkCellRenderer *cell, GtkWidget *
 /*
  * render a cell
  */
+#if GTK_CHECK_VERSION(3, 0, 0)
+static void cell_renderer_break_icon_render(GtkCellRenderer *cell, cairo_t *cr, GtkWidget *widget,
+	const GdkRectangle *background_area, const GdkRectangle *cell_area, GtkCellRendererState flags)
+#else
 static void cell_renderer_break_icon_render(GtkCellRenderer *cell, GdkDrawable *window, GtkWidget *widget,
 	GdkRectangle *background_area, GdkRectangle *cell_area, GdkRectangle *expose_area, GtkCellRendererState flags)
+#endif
 {
 	CellRendererBreakIcon *cellbreakpoint = (CellRendererBreakIcon*) cell;
 	
@@ -209,7 +247,15 @@ static void cell_renderer_break_icon_render(GtkCellRenderer *cell, GdkDrawable *
 	
 	GdkRectangle pix_rect;
 	GdkRectangle draw_rect;
+
+	gint xpad;
+	gint ypad;
+
+	gboolean is_expander;
+
+#if !GTK_CHECK_VERSION(3, 0, 0)
 	cairo_t *cr;
+#endif
 	
 	cell_renderer_break_icon_get_size (cell, widget, cell_area,
 		&pix_rect.x,
@@ -217,16 +263,23 @@ static void cell_renderer_break_icon_render(GtkCellRenderer *cell, GdkDrawable *
 		&pix_rect.width,
 		&pix_rect.height);
 	
-	pix_rect.x += cell_area->x + cell->xpad;
-	pix_rect.y += cell_area->y + cell->ypad;
-	pix_rect.width  -= cell->xpad * 2;
-	pix_rect.height -= cell->ypad * 2;
-	
+	gtk_cell_renderer_get_padding(cell, &xpad, &ypad);
+	pix_rect.x += cell_area->x + xpad;
+	pix_rect.y += cell_area->y + ypad;
+	pix_rect.width  -= xpad * 2;
+	pix_rect.height -= ypad * 2;
+
+#if GTK_CHECK_VERSION(3, 0, 0)
+	if (!gdk_rectangle_intersect (cell_area, &pix_rect, &draw_rect))
+#else
 	if (!gdk_rectangle_intersect (cell_area, &pix_rect, &draw_rect) ||
 		!gdk_rectangle_intersect (expose_area, &draw_rect, &draw_rect))
+#endif
 		return;
+
+	g_object_get(cell, "is-expander", &is_expander, NULL);
 	
-	if (cell->is_expander)
+	if (is_expander)
 	{
 		pixbuf = cellbreakpoint->pixbuf_file;
 	}
@@ -246,20 +299,29 @@ static void cell_renderer_break_icon_render(GtkCellRenderer *cell, GdkDrawable *
 	if (!pixbuf)
 		return;
 	
+#if !GTK_CHECK_VERSION(3, 0, 0)
 	cr = gdk_cairo_create (window);
+#endif
 	
 	gdk_cairo_set_source_pixbuf (cr, pixbuf, pix_rect.x, pix_rect.y);
 	gdk_cairo_rectangle (cr, &draw_rect);
 	cairo_fill (cr);
 	
+#if !GTK_CHECK_VERSION(3, 0, 0)
 	cairo_destroy (cr);
+#endif
 }
 
 /*
  * activate callback
  */
+#if GTK_CHECK_VERSION(3, 0, 0)
+static gint cell_renderer_break_icon_activate(GtkCellRenderer *cell, GdkEvent *event, GtkWidget *widget, const gchar *path,
+	const GdkRectangle *background_area, const GdkRectangle *cell_area, GtkCellRendererState flags)
+#else
 static gint cell_renderer_break_icon_activate(GtkCellRenderer *cell, GdkEvent *event, GtkWidget *widget, const gchar *path,
 	GdkRectangle *background_area, GdkRectangle *cell_area, GtkCellRendererState  flags)
+#endif
 {
 	if (!event ||
 		(
@@ -284,7 +346,7 @@ static void cell_renderer_break_icon_init (CellRendererBreakIcon *cell)
 	cell->condition = NULL;
 	cell->hitscount = 0;
 	
-	cell_renderer->mode = GTK_CELL_RENDERER_MODE_ACTIVATABLE;
+	g_object_set(cell_renderer, "mode", GTK_CELL_RENDERER_MODE_ACTIVATABLE, NULL);
 
 	cell->pixbuf_enabled = cell->pixbuf_disabled = cell->pixbuf_conditional = cell->pixbuf_file = 0;
 }

--- a/debugger/src/cell_renderers/cellrendererbreakicon.h
+++ b/debugger/src/cell_renderers/cellrendererbreakicon.h
@@ -36,27 +36,6 @@ G_BEGIN_DECLS
 typedef struct _CellRendererBreakIcon CellRendererBreakIcon;
 typedef struct _CellRendererBreakIconClass CellRendererBreakIconClass;
 
-struct _CellRendererBreakIcon
-{
-  GtkCellRenderer parent;
-
-  guint GSEAL (enabled);
-  const gchar* GSEAL(condition);
-  guint GSEAL (hitscount);
-
-  GdkPixbuf *GSEAL (pixbuf_enabled);
-  GdkPixbuf *GSEAL (pixbuf_disabled);
-  GdkPixbuf *GSEAL (pixbuf_conditional);
-  GdkPixbuf *GSEAL (pixbuf_file);
-};
-
-struct _CellRendererBreakIconClass
-{
-  GtkCellRendererClass parent_class;
-
-  void (*clicked)(CellRendererBreakIcon *cell_renderer_toggle, const gchar *path);
-};
-
 GType					cell_renderer_break_icon_get_type(void);
 GtkCellRenderer*		cell_renderer_break_icon_new (void);
 

--- a/debugger/src/cell_renderers/cellrendererframeicon.h
+++ b/debugger/src/cell_renderers/cellrendererframeicon.h
@@ -36,23 +36,6 @@ G_BEGIN_DECLS
 typedef struct _CellRendererFrameIcon CellRendererFrameIcon;
 typedef struct _CellRendererFrameIconClass CellRendererFrameIconClass;
 
-struct _CellRendererFrameIcon
-{
-  GtkCellRenderer parent;
-
-  guint GSEAL (active_frame);
-
-  GdkPixbuf *GSEAL (pixbuf_active);
-  GdkPixbuf *GSEAL (pixbuf_highlighted);
-};
-
-struct _CellRendererFrameIconClass
-{
-  GtkCellRendererClass parent_class;
-
-  void (*clicked)(CellRendererFrameIcon *cell_renderer_toggle, const gchar *path);
-};
-
 GType					cell_renderer_frame_icon_get_type(void);
 GtkCellRenderer*		cell_renderer_frame_icon_new (void);
 

--- a/debugger/src/cell_renderers/cellrenderertoggle.c
+++ b/debugger/src/cell_renderers/cellrenderertoggle.c
@@ -29,11 +29,26 @@
 
 #include "cellrenderertoggle.h"
 
+struct _CellRendererToggle
+{
+  GtkCellRendererToggle parent;
+};
+
+struct _CellRendererToggleClass
+{
+  GtkCellRendererToggleClass parent_class;
+};
+
 /*
  * handles an activation and sends a toggle signal is its cell renderer has been clicked
  */
+#if GTK_CHECK_VERSION(3, 0, 0)
+static gint cell_renderer_toggle_activate(GtkCellRenderer *cell, GdkEvent *event, GtkWidget *widget, const gchar *path,
+	const GdkRectangle *background_area, const GdkRectangle *cell_area, GtkCellRendererState  flags)
+#else
 static gint cell_renderer_toggle_activate(GtkCellRenderer *cell, GdkEvent *event, GtkWidget *widget, const gchar *path,
 	GdkRectangle *background_area, GdkRectangle *cell_area, GtkCellRendererState  flags)
+#endif
 {
 	if (!event ||
 		(
@@ -53,7 +68,7 @@ static gint cell_renderer_toggle_activate(GtkCellRenderer *cell, GdkEvent *event
 static void cell_renderer_toggle_init (CellRendererToggle *cell)
 {
 	GtkCellRenderer *cell_renderer = (GtkCellRenderer*)cell;
-	cell_renderer->mode = GTK_CELL_RENDERER_MODE_ACTIVATABLE;
+	g_object_set(cell_renderer, "mode", GTK_CELL_RENDERER_MODE_ACTIVATABLE, NULL);
 }
 
 /*

--- a/debugger/src/cell_renderers/cellrenderertoggle.h
+++ b/debugger/src/cell_renderers/cellrenderertoggle.h
@@ -36,16 +36,6 @@ G_BEGIN_DECLS
 typedef struct _CellRendererToggle CellRendererToggle;
 typedef struct _CellRendererToggleClass CellRendererToggleClass;
 
-struct _CellRendererToggle
-{
-  GtkCellRendererToggle parent;
-};
-
-struct _CellRendererToggleClass
-{
-  GtkCellRendererToggleClass parent_class;
-};
-
 GType					cell_renderer_toggle_get_type(void);
 GtkCellRenderer*		cell_renderer_toggle_new (void);
 

--- a/debugger/src/dconfig.c
+++ b/debugger/src/dconfig.c
@@ -67,8 +67,8 @@ static GKeyFile *keyfile_project = NULL;
 static gboolean debug_config_loading = FALSE;
 
 /* saving thread staff */
-static GMutex *change_config_mutex;
-static GCond *cond;
+static GMutex change_config_mutex;
+static GCond cond;
 static GThread *saving_thread;
 
 /* flags that indicate that part of a config has been changed and
@@ -269,8 +269,8 @@ static void save_to_keyfile(GKeyFile *keyfile)
  */
 static gpointer saving_thread_func(gpointer data)
 {
-	GTimeVal interval;
-	g_mutex_lock(change_config_mutex);
+	gint64 interval;
+	g_mutex_lock(&change_config_mutex);
 	do
 	{
 		if (
@@ -308,11 +308,10 @@ static gpointer saving_thread_func(gpointer data)
 			debug_config_changed = FALSE;
 		}
 
-		g_get_current_time(&interval);
-		g_time_val_add(&interval, SAVING_INTERVAL);
+		interval = g_get_monotonic_time() + SAVING_INTERVAL;
 	}
-	while (!g_cond_timed_wait(cond, change_config_mutex, &interval));
-	g_mutex_unlock(change_config_mutex);
+	while (!g_cond_wait_until(&cond, &change_config_mutex, interval));
+	g_mutex_unlock(&change_config_mutex);
 	
 	return NULL;
 }
@@ -324,9 +323,9 @@ void config_set_debug_changed(void)
 {
 	if (!debug_config_loading)
 	{
-		g_mutex_lock(change_config_mutex);
+		g_mutex_lock(&change_config_mutex);
 		debug_config_changed = TRUE;
-		g_mutex_unlock(change_config_mutex);
+		g_mutex_unlock(&change_config_mutex);
 	}
 }
 
@@ -337,7 +336,7 @@ void config_set_panel(int config_part, gpointer config_value, ...)
 {
 	va_list ap;
 	
-	g_mutex_lock(change_config_mutex);
+	g_mutex_lock(&change_config_mutex);
 	
 	va_start(ap, config_value);
 	
@@ -395,7 +394,7 @@ void config_set_panel(int config_part, gpointer config_value, ...)
 	va_end(ap);
 	
 	panel_config_changed = TRUE;
-	g_mutex_unlock(change_config_mutex);
+	g_mutex_unlock(&change_config_mutex);
 }
 
 /*
@@ -458,9 +457,9 @@ void config_init(void)
 		g_free(data);
 	}
 
-	change_config_mutex = g_mutex_new();
-	cond = g_cond_new();
-	saving_thread = g_thread_create(saving_thread_func, NULL, TRUE, NULL);
+	g_mutex_init(&change_config_mutex);
+	g_cond_init(&cond);
+	saving_thread = g_thread_new(NULL, saving_thread_func, NULL);
 }	
 
 /*
@@ -468,11 +467,11 @@ void config_init(void)
  */
 void config_destroy(void)
 {
-	g_cond_signal(cond);
+	g_cond_signal(&cond);
 	g_thread_join(saving_thread);
 	
-	g_mutex_free(change_config_mutex);
-	g_cond_free(cond);
+	g_mutex_clear(&change_config_mutex);
+	g_cond_clear(&cond);
 
 	g_free(plugin_config_path);
 	
@@ -642,9 +641,9 @@ static void on_configure_response(GtkDialog* dialog, gint response, gpointer use
 	{
 		g_key_file_set_boolean(keyfile_plugin, "saving_settings", "save_to_project", newvalue);
 
-		g_mutex_lock(change_config_mutex);
+		g_mutex_lock(&change_config_mutex);
 		panel_config_changed = TRUE;
-		g_mutex_unlock(change_config_mutex);
+		g_mutex_unlock(&change_config_mutex);
 
 		if (geany_data->app->project)
 		{
@@ -668,8 +667,13 @@ static void on_configure_response(GtkDialog* dialog, gint response, gpointer use
  */
 GtkWidget *config_plugin_configure(GtkDialog *dialog)
 {
+#if GTK_CHECK_VERSION(3, 0, 0)
+	GtkWidget *vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 6);
+	GtkWidget *_hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 6);
+#else
 	GtkWidget *vbox = gtk_vbox_new(FALSE, 6);
 	GtkWidget *_hbox = gtk_hbox_new(FALSE, 6);
+#endif
 	
 	save_to_project_btn = gtk_check_button_new_with_label(_("Save debug session data to a project"));
 	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(save_to_project_btn), config_get_save_to_project());

--- a/debugger/src/dpaned.c
+++ b/debugger/src/dpaned.c
@@ -40,7 +40,7 @@ extern GeanyData		*geany_data;
 #include "stree.h"
 #include "dconfig.h"
 
-#define NOTEBOOK_GROUP 438948394
+#define NOTEBOOK_GROUP "notebook-438948394"
 #define HPANED_BORDER_WIDTH 4
 
 #define CONNECT_PAGE_SIGNALS(X) \
@@ -287,8 +287,8 @@ void dpaned_init(void)
 	/* setup notebooks */
 	gtk_notebook_set_scrollable(GTK_NOTEBOOK(debug_notebook_left), TRUE);
 	gtk_notebook_set_scrollable(GTK_NOTEBOOK(debug_notebook_right), TRUE);
-	gtk_notebook_set_group_id(GTK_NOTEBOOK(debug_notebook_left), NOTEBOOK_GROUP);
-	gtk_notebook_set_group_id (GTK_NOTEBOOK(debug_notebook_right), NOTEBOOK_GROUP);
+	gtk_notebook_set_group_name(GTK_NOTEBOOK(debug_notebook_left), NOTEBOOK_GROUP);
+	gtk_notebook_set_group_name(GTK_NOTEBOOK(debug_notebook_right), NOTEBOOK_GROUP);
 	gtk_notebook_set_tab_pos(GTK_NOTEBOOK(debug_notebook_left), GTK_POS_TOP);
 	gtk_notebook_set_tab_pos(GTK_NOTEBOOK(debug_notebook_right), GTK_POS_TOP);
 	

--- a/debugger/src/gui.c
+++ b/debugger/src/gui.c
@@ -52,7 +52,11 @@ GtkWidget* create_button(const gchar *icon, const gchar *tooltip)
 GtkWidget* create_stock_button(const gchar *stockid, const gchar *tooltip)
 {
 	GtkWidget *btn = gtk_button_new();
+#if GTK_CHECK_VERSION(3, 0, 0)
+	GtkWidget *image = gtk_image_new_from_icon_name(stockid, GTK_ICON_SIZE_MENU);
+#else
 	GtkWidget *image = gtk_image_new_from_stock (stockid, GTK_ICON_SIZE_MENU);
+#endif
 	gtk_widget_show(image);
 	gtk_button_set_image(GTK_BUTTON(btn), image);
 

--- a/debugger/src/plugin.c
+++ b/debugger/src/plugin.c
@@ -97,7 +97,11 @@ void plugin_init(GeanyData *data)
 	pixbufs_init();
 
 	/* main box */
+#if GTK_CHECK_VERSION(3, 0, 0)
+	hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 7);
+#else
 	hbox = gtk_hbox_new(FALSE, 7);
+#endif
 	gtk_container_set_border_width(GTK_CONTAINER(hbox), 6);
 
 	/* add target page */

--- a/debugger/src/stree.c
+++ b/debugger/src/stree.c
@@ -197,7 +197,7 @@ static void on_render_line(GtkTreeViewColumn *tree_column, GtkCellRenderer *cell
 		g_object_set(cell, "text", "", NULL);
 	else
 	{
-		GValue value = {0};
+		GValue value = G_VALUE_INIT;
 
 		g_value_init(&value, G_TYPE_INT);
 		g_value_set_int (&value, f->line);

--- a/debugger/src/tpage.c
+++ b/debugger/src/tpage.c
@@ -33,6 +33,7 @@
 	#include "config.h"
 #endif
 #include "geanyplugin.h"
+#include <gp_gtkcompat.h>
 
 extern GeanyData		*geany_data;
 
@@ -161,23 +162,41 @@ void tpage_pack_widgets(gboolean tabbed)
 	{
 		GtkWidget *hbox, *rbox, *lbox;
 
+#if GTK_CHECK_VERSION(3, 0, 0)
+		root = gtk_box_new(GTK_ORIENTATION_VERTICAL, SPACING);
+#else
 		root = gtk_vbox_new(FALSE, SPACING);
+#endif
 		gtk_container_set_border_width(GTK_CONTAINER(root), ROOT_BORDER_WIDTH);
 	
 		/* filename */
+#if GTK_CHECK_VERSION(3, 0, 0)
+		hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, SPACING);
+#else
 		hbox = gtk_hbox_new(FALSE, SPACING);
+#endif
 		gtk_box_pack_start(GTK_BOX(root), hbox, FALSE, FALSE, 0);
 		gtk_box_pack_start(GTK_BOX(hbox), target_label, FALSE, FALSE, 0);
 		gtk_box_pack_start(GTK_BOX(hbox), target_name, TRUE, TRUE, 0);
 		gtk_box_pack_start(GTK_BOX(hbox), target_button_browse, FALSE, FALSE, 0);
 		
 		/* lower hbox */
+#if GTK_CHECK_VERSION(3, 0, 0)
+		hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, SPACING);
+		gtk_box_set_homogeneous(GTK_BOX(hbox), TRUE);
+#else
 		hbox = gtk_hbox_new(TRUE, SPACING);
+#endif
 		gtk_box_pack_start(GTK_BOX(root), hbox, TRUE, TRUE, 0);
 
 		/* lower left and right vboxes */
+#if GTK_CHECK_VERSION(3, 0, 0)
+		lbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, SPACING);
+		rbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, SPACING);
+#else
 		lbox = gtk_vbox_new(FALSE, SPACING);
 		rbox = gtk_vbox_new(FALSE, SPACING);
+#endif
 		gtk_box_pack_start(GTK_BOX(hbox), lbox, TRUE, TRUE, 0);
 		gtk_box_pack_start(GTK_BOX(hbox), rbox, TRUE, TRUE, 0);
 
@@ -187,7 +206,11 @@ void tpage_pack_widgets(gboolean tabbed)
 		/* arguments */
 		gtk_box_pack_start(GTK_BOX(rbox), args_frame, TRUE, TRUE, 0);
 		/* debugger type */
+#if GTK_CHECK_VERSION(3, 0, 0)
+		hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, SPACING);
+#else
 		hbox = gtk_hbox_new(FALSE, SPACING);
+#endif
 		gtk_box_pack_start(GTK_BOX(hbox), debugger_label, FALSE, FALSE, 0);
 		gtk_box_pack_start(GTK_BOX(hbox), debugger_cmb, TRUE, TRUE, 0);
 		gtk_box_pack_start(GTK_BOX(rbox), hbox, FALSE, FALSE, 0);
@@ -196,11 +219,21 @@ void tpage_pack_widgets(gboolean tabbed)
 	{
 		GtkWidget *lbox, *rbox, *hbox;
 
+#if GTK_CHECK_VERSION(3, 0, 0)
+		root = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, SPACING);
+		gtk_box_set_homogeneous(GTK_BOX(root), TRUE);
+#else
 		root = gtk_hbox_new(TRUE, SPACING);
+#endif
 		gtk_container_set_border_width(GTK_CONTAINER(root), ROOT_BORDER_WIDTH);
 
+#if GTK_CHECK_VERSION(3, 0, 0)
+		lbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, SPACING);
+		rbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, SPACING);
+#else
 		lbox = gtk_vbox_new(FALSE, SPACING);
 		rbox = gtk_vbox_new(FALSE, SPACING);
+#endif
 		gtk_box_pack_start(GTK_BOX(root), lbox, TRUE, TRUE, 0);
 		gtk_box_pack_start(GTK_BOX(root), rbox, TRUE, TRUE, 0);
 
@@ -208,7 +241,11 @@ void tpage_pack_widgets(gboolean tabbed)
 		gtk_box_pack_start(GTK_BOX(lbox), env_frame, TRUE, TRUE, 0);
 
 		/* target */
+#if GTK_CHECK_VERSION(3, 0, 0)
+		hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, SPACING);
+#else
 		hbox = gtk_hbox_new(FALSE, SPACING);
+#endif
 		gtk_box_pack_start(GTK_BOX(hbox), target_label, FALSE, FALSE, 0);
 		gtk_box_pack_start(GTK_BOX(hbox), target_name, TRUE, TRUE, 0);
 		gtk_box_pack_start(GTK_BOX(hbox), target_button_browse, FALSE, FALSE, 0);
@@ -216,7 +253,11 @@ void tpage_pack_widgets(gboolean tabbed)
 		/* arguments */
 		gtk_box_pack_start(GTK_BOX(rbox), args_frame, TRUE, TRUE, 0);
 		/* debugger type */
+#if GTK_CHECK_VERSION(3, 0, 0)
+		hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, SPACING);
+#else
 		hbox = gtk_hbox_new(FALSE, SPACING);
+#endif
 		gtk_box_pack_start(GTK_BOX(hbox), debugger_label, FALSE, FALSE, 0);
 		gtk_box_pack_start(GTK_BOX(hbox), debugger_cmb, TRUE, TRUE, 0);
 		gtk_box_pack_start(GTK_BOX(rbox), hbox, FALSE, FALSE, 0);
@@ -233,7 +274,11 @@ void tpage_pack_widgets(gboolean tabbed)
 		gtk_container_remove(GTK_CONTAINER(tab_target), oldroot);
 	}
 
+#if GTK_CHECK_VERSION(3, 0, 0)
+	gtk_box_pack_start(GTK_BOX(tab_target), root, TRUE, TRUE, 0);
+#else
 	gtk_container_add(GTK_CONTAINER(tab_target), root);
+#endif
 	gtk_widget_show_all(tab_target);
 }
 
@@ -250,27 +295,32 @@ static void tpage_create_widgets(void)
 	/* target */
 	target_label = gtk_label_new(_("Target:"));
 	target_name = gtk_entry_new ();
+#if GTK_CHECK_VERSION(3, 0, 0)
+	gtk_editable_set_editable(GTK_EDITABLE(target_name), FALSE);
+	target_button_browse = create_stock_button("document-open", _("Browse"));
+#else
 	gtk_entry_set_editable(GTK_ENTRY(target_name), FALSE);
 	target_button_browse = create_stock_button(GTK_STOCK_OPEN, _("Browse"));
+#endif
 	gtk_widget_set_size_request(target_button_browse, BROWSE_BUTTON_WIDTH, 0);
 	g_signal_connect(G_OBJECT(target_button_browse), "clicked", G_CALLBACK (on_target_browse_clicked), NULL);
 
 	/* debugger */
 	debugger_label = gtk_label_new(_("Debugger:")); 
-	debugger_cmb = gtk_combo_box_new_text();
+	debugger_cmb = gtk_combo_box_text_new();
 	modules = debug_get_modules();
 	for (iter = modules; iter; iter = iter->next)
 	{
-		gtk_combo_box_append_text(GTK_COMBO_BOX(debugger_cmb), (gchar*)iter->data);
+		gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(debugger_cmb), (gchar*)iter->data);
 	}
 	g_list_free(modules);
 	gtk_combo_box_set_active(GTK_COMBO_BOX(debugger_cmb), 0);
 
 	/* arguments */
 	args_frame = gtk_frame_new(_("Command Line Arguments"));
-	hbox = gtk_hbox_new(FALSE, 0);
-	gtk_container_set_border_width(GTK_CONTAINER(hbox), 5);
-	args_textview = gtk_text_view_new ();
+	hbox = gtk_scrolled_window_new(NULL, NULL);
+	gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(hbox), GTK_POLICY_AUTOMATIC, GTK_POLICY_AUTOMATIC);
+	args_textview = gtk_text_view_new();
 	gtk_text_view_set_wrap_mode(GTK_TEXT_VIEW(args_textview), GTK_WRAP_CHAR);
 	buffer = gtk_text_view_get_buffer(GTK_TEXT_VIEW(args_textview));
 	g_signal_connect(G_OBJECT(buffer), "changed", G_CALLBACK (on_arguments_changed), NULL);
@@ -279,8 +329,8 @@ static void tpage_create_widgets(void)
 
 	/* environment */
 	env_frame = gtk_frame_new(_("Environment Variables"));
-	hbox = gtk_hbox_new(FALSE, 0);
-	gtk_container_set_border_width(GTK_CONTAINER(hbox), 5);
+	hbox = gtk_scrolled_window_new(NULL, NULL);
+	gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(hbox), GTK_POLICY_AUTOMATIC, GTK_POLICY_AUTOMATIC);
 	tree = envtree_init();
 	gtk_container_add(GTK_CONTAINER(hbox), tree);
 	gtk_container_add(GTK_CONTAINER(env_frame), hbox);
@@ -366,7 +416,7 @@ int tpage_get_debug_module_index(void)
  */
 gchar* tpage_get_debugger(void)
 {
-	return gtk_combo_box_get_active_text(GTK_COMBO_BOX(debugger_cmb));
+	return gtk_combo_box_text_get_active_text(GTK_COMBO_BOX_TEXT(debugger_cmb));
 }
 
 /*
@@ -404,7 +454,11 @@ GList* tpage_get_environment(void)
  */
 void tpage_init(void)
 {
+#if GTK_CHECK_VERSION(3, 0, 0)
+	tab_target = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
+#else
 	tab_target = gtk_vbox_new(FALSE, 0);
+#endif
 	tpage_create_widgets();
 }
 


### PR DESCRIPTION
This pull request is heavily based on #645 from which it borrows the majority of the changes.
The main improvement is that this one doesn't break compatibility with GTK2 (there are macros which select the correct code path accordingly).
I also removed some cosmetic-only changes to maintain the differences as small as possible and provided a corrected code for console font selection (which was just commented out in the original pull request).

This was successfully tested on Centos 7.5 with stock development packages.