### PR TITLE
scope: removed unnecessary includes of 'vte/vte.h'

### DIFF
--- a/scope/src/prefs.c
+++ b/scope/src/prefs.c
@@ -26,10 +26,6 @@
 
 #include "common.h"
 
-#ifdef G_OS_UNIX
-#include <vte/vte.h>
-#endif
-
 gchar *pref_gdb_executable;
 gboolean pref_gdb_async_mode;
 #ifndef G_OS_UNIX

--- a/scope/src/scope.c
+++ b/scope/src/scope.c
@@ -25,8 +25,6 @@
 
 #include "common.h"
 
-#include <vte/vte.h>
-
 #include <gp_gtkcompat.h>
 
 GeanyPlugin *geany_plugin;


### PR DESCRIPTION
As discussed in PR #787.