### PR TITLE
scope: small code cleanup. See #794.

### DIFF
--- a/scope/src/conterm.c
+++ b/scope/src/conterm.c
@@ -184,7 +184,7 @@ static void console_output(int fd, const char *text, gint length)
 	if (fd != last_fd)
 	{
 		setaf[3] = fd_colors[fd];
-		vte_terminal_feed(debug_console, setaf, sizeof setaf);
+		vte_terminal_feed(debug_console, setaf, sizeof(setaf));
 		last_fd = fd;
 	}
 
@@ -260,7 +260,7 @@ void context_output(int fd, const char *text, gint length)
 	}
 
 	gtk_text_buffer_place_cursor(context, &end);
-      gtk_text_view_scroll_mark_onscreen(debug_context, gtk_text_buffer_get_insert(context));
+	gtk_text_view_scroll_mark_onscreen(debug_context, gtk_text_buffer_get_insert(context));
 }
 
 void context_output_nl(int fd, const char *text, gint length)
@@ -327,8 +327,8 @@ static void on_console_copy(G_GNUC_UNUSED const MenuItem *menu_item)
 	else
 #endif
 	{
-     		g_signal_emit_by_name(debug_context, "copy-clipboard");
-     	}
+		g_signal_emit_by_name(debug_context, "copy-clipboard");
+	}
 }
 
 static void on_console_select_all(G_GNUC_UNUSED const MenuItem *menu_item)

--- a/scope/src/memory.c
+++ b/scope/src/memory.c
@@ -390,8 +390,7 @@ void memory_init(void)
 	g_signal_connect(tree, "key-press-event", G_CALLBACK(on_memory_key_press),
 		(gpointer) menu_item_find(memory_menu_items, "memory_read"));
 
-	pointer_size = sizeof(void *) > sizeof &memory_init ? sizeof(void *) :
-		sizeof &memory_init;
+	pointer_size = MAX(sizeof(void *), sizeof(&memory_init));
 	addr_format = g_strdup_printf("%%0%u" G_GINT64_MODIFIER "x  ", pointer_size * 2);
 	memory_configure();
 

--- a/scope/src/utils.c
+++ b/scope/src/utils.c
@@ -99,7 +99,7 @@ gboolean utils_check_path(const gchar *pathname, gboolean file, int mode)
 
 		if (stat(path, &buf) == 0)
 		{
-			if (!S_ISDIR(buf.st_mode) == file)
+			if ((!S_ISDIR(buf.st_mode)) == file)
 				result = access(path, mode) == 0;
 			else
 				errno = file ? EISDIR : ENOTDIR;
@@ -324,7 +324,7 @@ gboolean utils_source_filetype(GeanyFiletype *ft)
 
 		guint i;
 
-		for (i = 0; i < sizeof ft_id / sizeof ft_id[0]; i++)
+		for (i = 0; i < sizeof(ft_id) / sizeof(ft_id[0]); i++)
 			if (ft_id[i] == ft->id)
 				return TRUE;
 	}


### PR DESCRIPTION
Fixed ```sizeof``` without parentheses, spaces instead of tab and a compiler warning.