### PR TITLE
Issue737 treebrowser follow doc fix

### DIFF
--- a/treebrowser/src/treebrowser.c
+++ b/treebrowser/src/treebrowser.c
@@ -149,6 +149,7 @@ static void 	treebrowser_rename_current(void);
 static void 	on_menu_create_new_object(GtkMenuItem *menuitem, const gchar *type);
 static void 	load_settings(void);
 static gboolean save_settings(void);
+static void 	treebrowser_track_current_cb(void);
 
 
 /* ------------------
@@ -158,6 +159,7 @@ static gboolean save_settings(void);
 PluginCallback plugin_callbacks[] =
 {
 	{ "project-open", (GCallback) &project_open_cb, TRUE, NULL },
+	{ "document-activate", (GCallback) &treebrowser_track_current_cb, TRUE, NULL },
 	{ NULL, NULL, FALSE, NULL }
 };
 
@@ -2125,9 +2127,6 @@ plugin_init(GeanyData *data)
 		0, 0, "rename_refresh", _("Refresh"), NULL);
 	keybindings_set_item(key_group, KB_TRACK_CURRENT, kb_activate,
 		0, 0, "track_current", _("Track Current"), NULL);
-
-	plugin_signal_connect(geany_plugin, NULL, "document-activate", TRUE,
-		(GCallback)&treebrowser_track_current_cb, NULL);
 }
 
 void

--- a/treebrowser/src/treebrowser.c
+++ b/treebrowser/src/treebrowser.c
@@ -795,7 +795,7 @@ static gboolean
 treebrowser_expand_to_path(gchar* root, gchar* find)
 {
 	guint i = 0;
-	gboolean founded = FALSE, global_founded = FALSE;
+	gboolean found = FALSE, global_found = FALSE;
 	gchar *new = NULL;
 	gchar **root_segments = NULL, **find_segments = NULL;
 	guint find_segments_n = 0;
@@ -805,26 +805,25 @@ treebrowser_expand_to_path(gchar* root, gchar* find)
 
 	find_segments_n = g_strv_length(find_segments)-1;
 
-
 	for (i = 1; i<=find_segments_n; i++)
 	{
 		new = g_strconcat(new ? new : "", G_DIR_SEPARATOR_S, find_segments[i], NULL);
 
-		if (founded)
+		if (found)
 		{
 			if (treebrowser_search(new, NULL))
-				global_founded = TRUE;
+				global_found = TRUE;
 		}
 		else
 			if (utils_str_equal(root, new) == TRUE)
-				founded = TRUE;
+				found = TRUE;
 	}
 
 	g_free(new);
 	g_strfreev(root_segments);
 	g_strfreev(find_segments);
 
-	return global_founded;
+	return global_found;
 }
 
 static gboolean
@@ -846,7 +845,7 @@ treebrowser_track_current(void)
 		if (! treebrowser_search(path_current, NULL))
 		{
 			/*
-			 * Else we have to chroting to the document`s nearles path
+			 * Else we have to chrooting to the document`s nearles path
 			 */
 
 			froot = path_is_in_dir(addressbar_last_address, g_path_get_dirname(path_current));

--- a/treebrowser/src/treebrowser.c
+++ b/treebrowser/src/treebrowser.c
@@ -434,7 +434,7 @@ treebrowser_chroot(const gchar *dir)
 {
 	gchar *directory;
 
-	if (g_str_has_suffix(dir, G_DIR_SEPARATOR_S))
+	if (g_str_has_suffix(dir, G_DIR_SEPARATOR_S) && !utils_str_equal(dir, G_DIR_SEPARATOR_S))
 		directory = g_strndup(dir, strlen(dir)-1);
 	else
 		directory = g_strdup(dir);
@@ -800,7 +800,7 @@ treebrowser_expand_to_path(gchar* root, gchar* find)
 
 	find_segments_n = g_strv_length(find_segments)-1;
 
-	for (i = 1; i<=find_segments_n; i++)
+	for (i = 0; i<=find_segments_n; i++)
 	{
 		new_root = g_build_filename(new ? new : G_DIR_SEPARATOR_S, find_segments[i], NULL);
 		SETPTR(new, new_root);


### PR DESCRIPTION
This fixes following the current document path.
As mentioned in #737 this was broken on Windows but actually it was broken on non-Windows as well if the start directory (Geany's default open directory or the project base directory) has no common parts with the current document's file path.

For Windows, there was an additional hack necessary: ignoring the drive letter completely in all checks.
This made it working for the moment but obviously breaks a lot of the plugin's functionality if files on another drive than the current are handled.
This should be fixed properly but since the fact that I don't use the plugin and my available time is limited, I won't do myself.