### PR TITLE
treebrowser: use xdg-open for external open command

### DIFF
--- a/treebrowser/src/treebrowser.c
+++ b/treebrowser/src/treebrowser.c
@@ -55,7 +55,7 @@ static gboolean 			flag_on_expand_refresh 		= FALSE;
  * ------------------ */
 
 #ifndef G_OS_WIN32
-# define CONFIG_OPEN_EXTERNAL_CMD_DEFAULT "nautilus '%d'"
+# define CONFIG_OPEN_EXTERNAL_CMD_DEFAULT "xdg-open '%d'"
 # define CONFIG_OPEN_TERMINAL_DEFAULT "xterm"
 #else
 # define CONFIG_OPEN_EXTERNAL_CMD_DEFAULT "explorer '%d'"


### PR DESCRIPTION
Using generic xdg-open that will open associated file manager is better than hard-coded nautilus that works only for Gnome/Unity.