### PR TITLE
Don't rely on a pkg-config output formatting detail

### DIFF
--- a/build/gtk.m4
+++ b/build/gtk.m4
@@ -4,13 +4,14 @@ dnl GP_GTK_VERSION_MAJOR (e.g. "2");  and defines the GP_GTK3 AM conditional
 AC_DEFUN([GP_CHECK_GTK_VERSION],
 [
     AC_REQUIRE([AC_PROG_AWK])
+    AC_REQUIRE([AC_PROG_SED])
     AC_REQUIRE([PKG_PROG_PKG_CONFIG])
 
     GP_GEANY_PKG_CONFIG_PATH_PUSH
 
     _gtk_req=$(${PKG_CONFIG} --print-requires geany | ${AWK} '/^gtk\+-/{print}')
-    GP_GTK_PACKAGE=$(echo ${_gtk_req} | ${AWK} '{print $[]1}')
-    GP_GTK_VERSION=$(echo ${_gtk_req} | ${AWK} '{print $[]3}')
+    GP_GTK_PACKAGE=$(echo ${_gtk_req} | ${SED} 's/ *[[><=]].*$//')
+    GP_GTK_VERSION=$(echo ${_gtk_req} | ${SED} 's/^.*[[><=]] *//')
     GP_GTK_VERSION_MAJOR=$(echo ${GP_GTK_VERSION} | cut -d. -f1)
     AC_SUBST([GP_GTK_PACKAGE])
     AC_SUBST([GP_GTK_VERSION])


### PR DESCRIPTION
Do not require pkg-config to emit spaces around elements in its `--print-requires` output.

This should fix Geany GTK version check on OpenBSD 6.4.

---
@andy5995 could you check this and see if it helps?  Once configured, you should get something like that (obviously with GTK2 version of it if you've got a GTK2 build):
```shell
$ grep ^GP_GTK_ config.log 
GP_GTK_PACKAGE='gtk+-3.0'
GP_GTK_VERSION='3.0'
GP_GTK_VERSION_MAJOR='3'
```