### PR TITLE
debugger/bptree.c:fix compiler warning

### DIFF
--- a/debugger/src/bptree.c
+++ b/debugger/src/bptree.c
@@ -370,9 +370,9 @@ static void on_hitscount_changed(GtkCellRendererText *renderer, gchar *path, gch
 		LINE, &line,
         -1);
         
-    if (oldcount != count)
-    	breaks_set_hits_count(file, line, count);
-	
+	if (oldcount != count)
+		breaks_set_hits_count(file, line, count);
+
 	gtk_tree_path_free(tree_path);
 	g_free(file);
 }                                                        


### PR DESCRIPTION
I noticed this warning on buster and slack current, both using gcc8.

This fixes the warning (caused by mixed tabs/spaces indentation):

```
bptree.c: In function ‘on_hitscount_changed’:
bptree.c:373:5: warning: this ‘if’ clause does not guard...
[-Wmisleading-indentation]
     if (oldcount != count)
     ^~
bptree.c:376:2: note: ...this statement, but the latter is misleadingly
indented as if it were guarded by the ‘if’
  gtk_tree_path_free(tree_path);
  ^~~~~~~~~~~~~~~~~~
```