### PR TITLE
git-changebar: fix compatibility with libgit2 0.28 API

### DIFF
--- a/git-changebar/src/gcb-plugin.c
+++ b/git-changebar/src/gcb-plugin.c
@@ -45,6 +45,10 @@
                     new_buffer, new_len, new_as_path, options, \
                     file_cb, hunk_cb, line_cb, payload)
 #endif
+#if ! defined (LIBGIT2_SOVERSION) || LIBGIT2_SOVERSION < 28
+# define git_buf_dispose  git_buf_free
+# define git_error_last   giterr_last
+#endif
 
 
 GeanyPlugin      *geany_plugin;
@@ -238,7 +242,7 @@ static void
 clear_cached_blob_contents (void)
 {
   if (G_blob_contents.ptr) {
-    git_buf_free (&G_blob_contents);
+    git_buf_dispose (&G_blob_contents);
     buf_zero (&G_blob_contents);
   }
   G_blob_contents_tag = 0;
@@ -293,7 +297,7 @@ free_job (gpointer data)
   
   /* unlikely, but if we still have the buffer, free it */
   if (job->buf.ptr) {
-    git_buf_free (&job->buf);
+    git_buf_dispose (&job->buf);
   }
   g_free (job->path);
   g_slice_free1 (sizeof *job, job);
@@ -463,7 +467,7 @@ worker_thread (gpointer data)
       
       if (relpath) {
         if (! repo_get_file_blob_contents (repo, relpath, &job->buf, 0)) {
-          git_buf_free (&job->buf);
+          git_buf_dispose (&job->buf);
           buf_zero (&job->buf);
         }
         
@@ -1481,7 +1485,7 @@ plugin_init (GeanyData *data)
   G_queue             = NULL;
   
   if (git_libgit2_init () < 0) {
-    const git_error *err = giterr_last ();
+    const git_error *err = git_error_last ();
     g_warning ("Failed to initialize libgit2: %s", err ? err->message : "?");
     return;
   }


### PR DESCRIPTION
Namely rename the deprecated git_buf_free to git_buf_dispose and change
giterr calls to git_error.