### PR TITLE
Extending markdown preview

### DIFF
--- a/markdown/README
+++ b/markdown/README
@@ -24,6 +24,9 @@ Features
 * Allows simple customization of fonts and colours and complete control
   with custom template files.
 
+* New: .html and .svg files are previewd real-time in the Webkit as they
+  would apear in a web-browser. Templates are not applied here.
+
 Usage
 -----
 

--- a/markdown/src/plugin.c
+++ b/markdown/src/plugin.c
@@ -43,7 +43,7 @@ PLUGIN_SET_TRANSLATABLE_INFO(LOCALEDIR, GETTEXT_PACKAGE,
 #  define MARKDOWN_HELP_FILE MARKDOWN_DOC_DIR "/html/help.html"
 #endif
 
-#define MARKDOWN_PREVIEW_LABEL _("Markdown Preview")
+#define MARKDOWN_PREVIEW_LABEL _("Markdown")
 
 /* Global data */
 static MarkdownViewer *g_viewer = NULL;
@@ -166,12 +166,24 @@ update_markdown_viewer(MarkdownViewer *viewer)
 {
   GeanyDocument *doc = document_get_current();
 
-  if (DOC_VALID(doc) && g_strcmp0(doc->file_type->name, "Markdown") == 0) {
+  if (DOC_VALID(doc) && g_strcmp0(doc->file_type->name, "Markdown") == 0)
+  {
     gchar *text;
     text = (gchar*) scintilla_send_message(doc->editor->sci, SCI_GETCHARACTERPOINTER, 0, 0);
     markdown_viewer_set_markdown(viewer, text, doc->encoding);
     gtk_widget_set_sensitive(g_export_html, TRUE);
-  } else {
+  }
+  else  if (DOC_VALID(doc) && doc->file_name)
+  { if( strrchr(doc->file_name,'.') && ( (g_strcmp0(strrchr(doc->file_name,'.'), ".svg")==0) || (g_strcmp0(strrchr(doc->file_name,'.'  ), ".html")==0) ) )
+	  {
+		gchar *text;
+		text = (gchar*) scintilla_send_message(doc->editor->sci, SCI_GETCHARACTERPOINTER, 0, 0);
+		markdown_viewer_set_markdown(viewer, text, doc->encoding);
+		gtk_widget_set_sensitive(g_export_html, FALSE);
+	  }
+  }
+  else
+  {
     markdown_viewer_set_markdown(viewer,
       _("The current document does not have a Markdown filetype."), "UTF-8");
     gtk_widget_set_sensitive(g_export_html, FALSE);

--- a/markdown/src/viewer.c
+++ b/markdown/src/viewer.c
@@ -337,6 +337,12 @@ markdown_viewer_get_html(MarkdownViewer *self)
     update_internal_text(self, "");
   }
 
+  if((self->priv->text->len > 1) && (self->priv->text->str[0]=='<') ) 
+  {
+	  html = g_malloc(strlen(self->priv->text->str) + 1); 
+	  strcpy(html, self->priv->text->str); html[strlen(self->priv->text->str)]='\0';
+  }
+  else
   {
 #ifndef FULL_PRICE  /* this version using Discount markdown library
                      * is faster but may invoke endless discussions
@@ -383,7 +389,8 @@ markdown_viewer_update_view(MarkdownViewer *self)
      * substituting the file's basename for `index.html`. */
     if (DOC_VALID(doc) && doc->real_path != NULL) {
       gchar *base_dir = g_path_get_dirname(doc->real_path);
-      base_path = g_build_filename(base_dir, "index.html", NULL);
+      //base_path = g_build_filename(base_dir, "index.html", NULL);
+      base_path = g_build_filename(doc->real_path, NULL);
       g_free(base_dir);
     }
     /* Otherwise assume use a file `index.html` in the current working directory. */
@@ -417,7 +424,7 @@ markdown_viewer_update_view(MarkdownViewer *self)
     }
 
 #ifdef MARKDOWN_WEBKIT2
-    webkit_web_view_load_html(WEBKIT_WEB_VIEW(self), html, base_uri);
+    webkit_web_view_load_html(WEBKIT_WEB_VIEW(self), html, base_uri,self->priv->enc, base_uri);
 #else
     webkit_web_view_load_string(WEBKIT_WEB_VIEW(self), html, "text/html",
       self->priv->enc, base_uri);

--- a/markdown/src/viewer.c
+++ b/markdown/src/viewer.c
@@ -424,7 +424,7 @@ markdown_viewer_update_view(MarkdownViewer *self)
     }
 
 #ifdef MARKDOWN_WEBKIT2
-    webkit_web_view_load_html(WEBKIT_WEB_VIEW(self), html, base_uri,self->priv->enc, base_uri);
+    webkit_web_view_load_html(WEBKIT_WEB_VIEW(self), html, base_uri);
 #else
     webkit_web_view_load_string(WEBKIT_WEB_VIEW(self), html, "text/html",
       self->priv->enc, base_uri);

--- a/treebrowser/src/treebrowser.c
+++ b/treebrowser/src/treebrowser.c
@@ -122,7 +122,7 @@ PLUGIN_VERSION_CHECK(224)
 PLUGIN_SET_TRANSLATABLE_INFO(
 	LOCALEDIR,
 	GETTEXT_PACKAGE,
-	_("TreeBrowser"),
+	_("FileTreeBrowser"),// affects the alphabetical sorting in sidebar, puts TreeBrowser just after "Documents"
 	_("This plugin adds a tree browser to Geany, allowing the user to "
 	  "browse files using a tree view of the directory being browsed."),
 	"1.32" ,


### PR DESCRIPTION
With only few lines of code modification, I am now using the Mardown geany plugin as a svg image viewer (adding any other file that a Webkit supports is possible too, I only added .svg and .html).  This is really handy for me;  I can now write my code, run them and plot the outpouts without leaving geany IDE :-).   Any interest in merging these with the upsteram branch?  

A side note: I have also changed the (internal) name of  Tree Browser, the previous one kept appearing after Scope plugin tabs which was not ideal

