### PR TITLE
scope: Improved evaluation on-hover

### DIFF
--- a/scope/src/Makefile.am
+++ b/scope/src/Makefile.am
@@ -61,3 +61,17 @@ scope_la_CFLAGS = $(AM_CFLAGS) $(VTE_CFLAGS) \
 	-I$(top_srcdir)/utils/src
 
 include $(top_srcdir)/build/cppcheck.mk
+
+if UNITTESTS
+
+TESTS = unittests
+check_PROGRAMS = unittests
+
+unittests_SOURCES  = tests/unittests.c tests/utils_test.c \
+                     $(scope_la_SOURCES)
+unittests_CPPFLAGS = -DTEST $(scope_la_CPPFLAGS)
+unittests_CFLAGS  = $(GEANY_CFLAGS) -DUNITTESTS $(scope_la_CFLAGS)
+unittests_LDADD    = @GEANY_LIBS@ $(INTLLIBS) @CHECK_LIBS@ \
+                     $(scope_la_LIBADD)
+
+endif

--- a/scope/src/tests/unittests.c
+++ b/scope/src/tests/unittests.c
@@ -1,0 +1,28 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <check.h>
+
+#include <gtk/gtk.h>
+#include "geany.h"
+
+TCase *utils_create_tests(void);
+
+Suite *
+my_suite(void)
+{
+	Suite *s = suite_create("Scope");
+	suite_add_tcase(s, utils_create_tests());
+	return s;
+}
+
+int
+main(void)
+{
+	int nf;
+	Suite *s = my_suite();
+	SRunner *sr = srunner_create(s);
+	srunner_run_all(sr, CK_NORMAL);
+	nf = srunner_ntests_failed(sr);
+	srunner_free(sr);
+	return (nf == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/scope/src/tests/utils_test.c
+++ b/scope/src/tests/utils_test.c
@@ -1,0 +1,73 @@
+#include <check.h>
+#include "../src/common.h"
+#include "../src/utils.h"
+
+typedef struct S_EXPR_TEST_ITEM
+{
+	const gchar *input;
+	guint peek_index;
+	const gchar *expected;
+}EXPR_TEST_ITEM;
+
+EXPR_TEST_ITEM expr_test_items [] =
+{
+	{ " variable ",         sizeof(" var")-1,            "variable"           },
+	{ " (variable) ",       sizeof(" (var")-1,           "variable"           },
+	{ "struct.item",        sizeof("str")-1,             "struct"             },
+	{ "struct.item",        sizeof("str")-1,             "struct"             },
+	{ "struct.item",        sizeof("struct.it")-1,       "struct.item"        },
+	{ "struct->item",       sizeof("str")-1,             "struct"             },
+	{ "struct->item",       sizeof("struct->it")-1,      "struct->item"       },
+	{ "&(struct->item)",    sizeof("&(str")-1,           "struct"             },
+	{ "&(struct->item)",    sizeof("&(struct->it")-1,    "struct->item"       },
+	{ "foobar(item)",       sizeof("foobar(it")-1,       "item"               },
+	{ "sizeof(item)",       sizeof("sizeof(it")-1,       "sizeof(item)"       },
+	{ "array[5]",           sizeof("arr")-1,             "array"              },
+	{ "array[5]",           sizeof("array[")-1,          "array[5]"           },
+	{ "*pointer",           sizeof("*poi")-1,            "pointer"            },
+	{ "*pointer",           0,                           "*pointer"           },
+	{ "&variable",          sizeof("&var")-1,            "variable"           },
+	{ "&variable",          0,                           "&variable"          },
+	{ "foo variable",       sizeof("foo var")-1,         "variable"           },
+	{ "variable foo",       sizeof("var")-1,             "variable"           },
+	{ "int var_a, var_b;",  sizeof("int var")-1,         "var_a"              },
+	{ "int var_a, var_b;",  sizeof("int var_a, va")-1,   "var_b"              },
+	{ "foo(var_a, var_b);", sizeof("foo(var")-1,         "var_a"              },
+	{ "foo(var_a, var_b);", sizeof("foo(var_a, va")-1,   "var_b"              },
+	{ "array[index].item",  sizeof("array[index].i")-1,  "array[index].item"  },
+	{ "array[index]->item", sizeof("array[index]->i")-1, "array[index]->item" },
+	{ NULL,                 0,                         NULL           },
+};
+
+START_TEST(test_parser_for_evaluate)
+{
+	EXPR_TEST_ITEM *test_item;
+	guint index = 0;
+	gchar *expr, *chunk;
+
+	test_item = &(expr_test_items[index]);
+	while (test_item->input != NULL)
+	{
+		chunk = g_strdup(test_item->input);
+		expr = utils_evaluate_expr_from_string (chunk, test_item->peek_index);
+		ck_assert_ptr_ne(expr, NULL);
+		if (g_strcmp0(expr, test_item->expected) != 0)
+		{
+			ck_abort_msg("Index #%lu: Input: '%s', Peek-Ind.: %lu, Result: '%s' != '%s' (expected)",
+				index, test_item->input, test_item->peek_index, expr, test_item->expected);
+		}
+		g_free(chunk);
+		g_free(expr);
+
+		index++;
+		test_item = &(expr_test_items[index]);
+	}
+}
+END_TEST;
+
+TCase *utils_create_tests(void)
+{
+	TCase *tc_utils = tcase_create("utils");
+	tcase_add_test(tc_utils, test_parser_for_evaluate);
+	return tc_utils;
+}

--- a/scope/src/utils.c
+++ b/scope/src/utils.c
@@ -36,6 +36,10 @@
 #ifdef G_OS_UNIX
 #include <fcntl.h>
 
+/* The maximum length of an expression for evaluating the value.
+   (Including the string terminator '\0') */
+#define SCOPE_MAX_EVALUATE_EXPR_LENGTH 256
+
 void show_errno(const char *prefix)
 {
 	show_error(_("%s: %s."), prefix, g_strerror(errno));
@@ -752,4 +756,347 @@ void utils_finalize(void)
 		if (state != DS_INACTIVE)
 			utils_unlock(documents[i]);
 	}
+}
+
+/* checks whether @p c is an ASCII character (e.g. < 0x80) */
+#define IS_ASCII(c) (((unsigned char)(c)) < 0x80)
+
+/* This function is doing the parsing for 'utils_read_evaluate_expr()'.
+   It was mainly separated from it to support easy unit testing. */
+gchar *utils_evaluate_expr_from_string(gchar *chunk, guint peek_index)
+{
+	static const gchar *keep_prefix_list[] =
+		{ "sizeof", NULL };
+	static gchar expr[SCOPE_MAX_EVALUATE_EXPR_LENGTH];
+	static const gchar *wchars = "_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+	static const gchar *wspace = " \t";
+	gint startword, endword, temp_pos, round_brackets;
+	gint pos, left_bracket, cmp;
+	gboolean stop, oper, whitespace, brackets_exist;
+	gchar *expr_copy;
+
+	g_return_val_if_fail(chunk != NULL, NULL);
+
+	startword = peek_index;
+	endword = peek_index;
+	expr[0] = '\0';
+
+	if (chunk[startword] == ' ')
+	{
+		return NULL;
+	}
+
+	/* Find the left boundary of the expression. If the current sign
+	   is a '*' or a '&' then we already are at the left boundary. */
+	round_brackets = 0;
+	if (chunk[startword] != '*' && chunk[startword] != '&')
+	{
+		stop = FALSE;
+		oper = FALSE;
+		whitespace = FALSE;
+		while (startword > 0 && stop == FALSE)
+		{
+			/* the checks for "c < 0" are to allow any Unicode character which should make the code
+			 * a little bit more Unicode safe, anyway, this allows also any Unicode punctuation */
+			if (strchr(wchars, chunk[startword]) || ! IS_ASCII(chunk[startword]))
+			{
+				if (whitespace == TRUE && oper == FALSE)
+				{
+					startword++;
+					stop = TRUE;
+				}
+				else
+				{
+					startword--;
+					oper = FALSE;
+					whitespace = FALSE;
+				}
+			}
+			else
+			{
+				switch (chunk[startword])
+				{
+					case ' ':
+					case '\t':
+						startword--;
+						whitespace = TRUE;
+					break;
+
+					case '(':
+						round_brackets++;
+						startword--;
+					break;
+
+					case ')':
+						round_brackets--;
+						startword--;
+					break;
+
+					case '[':
+					case ']':
+						startword--;
+					break;
+
+					case '.':
+						/* Stop if there are no more signs before the current position,
+						   or if we already have seen an operator, or the sign before
+						   the operator is not a valid variable-name-char or whitespace. */
+						if (startword == 0 || oper == TRUE ||
+							(strchr(wchars, chunk[startword - 1]) == NULL &&
+							 strchr(wspace, chunk[startword - 1]) == NULL &&
+							 chunk[startword - 1] != ']'))
+						{
+							stop = TRUE;
+							break;
+						}
+						oper = TRUE;
+						startword--;
+					break;
+
+					case '>':
+						/* Stop if there are no more signs before the current position,
+						   or if we already have seen an operator, or the sign before
+						   the current sign is not a '-' (we expect a "->" here) */
+						if (startword < 2 || oper == TRUE || chunk[startword - 1] != '-')
+						{
+							stop = TRUE;
+							break;
+						}
+						oper = TRUE;
+						startword -= 2;
+					break;
+
+					case ':':
+						/* Stop if there are no more signs before the current position,
+						   or if we already have seen an operator, or the sign before
+						   the current sign is not a ':' (we expect a "::" here) */
+						if (startword < 2 || oper == TRUE || chunk[startword - 1] != ':')
+						{
+							stop = TRUE;
+							break;
+						}
+						oper = TRUE;
+						startword -= 2;
+					break;
+
+					default:
+						/* Not a valid variable-name-char or whitespace or operator. */
+						stop = TRUE;
+						if (whitespace == TRUE)
+						{
+							startword += 2;
+						}
+					break;
+				}
+			}
+		}
+		if (chunk[startword] == '*' || chunk[startword] == '&')
+		{
+			startword++;
+		}
+	}
+
+	/* Find the right boundary of the expression. */
+	stop = FALSE;
+	while (chunk[endword] != 0 && stop == FALSE)
+	{
+		/* the checks for "c < 0" are to allow any Unicode character which should make the code
+		 * a little bit more Unicode safe, anyway, this allows also any Unicode punctuation */
+		if (strchr(wchars, chunk[endword]) || ! IS_ASCII(chunk[endword]))
+		{
+			endword++;
+		}
+		else
+		{
+			switch (chunk[endword])
+			{
+				case ')':
+					round_brackets--;
+					if (round_brackets < 1)
+					{
+						/* We stop here in any case. 0 would be the normal case.
+						   If the value is below zero something went wrong in the
+						   loop above. Maybe this is just not a valid expression. */
+						stop = TRUE;
+					}
+				break;
+
+				case ']':
+				case '*':
+				case '&':
+					endword++;
+				break;
+
+				case ' ':
+				case '\t':
+					/* We should usually stop here. But we need to continue
+					   if the whitespace is followed by an array index "[...]"! */
+					temp_pos = endword + 1;
+					while (chunk[temp_pos] != 0 &&
+						   (chunk[temp_pos] == ' ' || chunk[temp_pos] == '\t'))
+					{
+						temp_pos++;
+					}
+					if (chunk[temp_pos] == '[' && chunk[temp_pos+1] != ']')
+					{
+						endword = temp_pos + 1;
+					}
+					else
+					{
+						stop = TRUE;
+					}
+				break;
+
+				default:
+					endword--;
+					stop = TRUE;
+				break;
+			}
+		}
+	}
+
+	/* Skip leading whitespace. */
+	while ((chunk[startword] == ' ' || chunk[startword] == '\t') &&
+		   startword < endword)
+	{
+		startword++;
+	}
+
+	/* Skip trailing whitespace. */
+	while (endword > 0 &&
+		   (chunk[endword] == ' ' || chunk[endword] == '\t') &&
+		   startword < endword)
+	{
+		endword--;
+	}
+
+	/* Validate/ensure balanced round brackets. */
+	round_brackets = 0;
+	left_bracket = 0;
+	stop = FALSE;
+	brackets_exist = FALSE;
+	for (pos = startword ; pos <= endword && stop == FALSE ; pos++)
+	{
+		switch (chunk[pos])
+		{
+			case '(':
+				round_brackets++;
+				brackets_exist = TRUE;
+				left_bracket = pos;
+			break;
+
+			case ')':
+				round_brackets--;
+				if (round_brackets == 0)
+				{
+					endword = pos;
+					stop = TRUE;
+				}
+				else if (round_brackets < 0)
+				{
+					endword = pos - 1;
+					stop = TRUE;
+				}
+			break;
+
+			case ' ':
+			case '\t':
+			break;
+
+			default:
+				temp_pos = pos;
+			break;
+		}
+	}
+
+	/* If brackets exist and the left-most sign is not a bracket itself,
+	   then it could be a function name or an operator (sizeof). We
+	   want to exclude the function name but include an operator name. */
+	if (brackets_exist == TRUE && chunk[startword] != '(')
+	{
+		pos = 0;
+		oper = FALSE;
+		while (keep_prefix_list[pos] != NULL)
+		{
+			cmp = strncmp(keep_prefix_list[pos], &(chunk[startword]),
+				strlen(keep_prefix_list[pos]));
+			if (cmp == 0)
+			{
+				/* Match with allowed operator/prefix. Keep it. */
+				oper = TRUE;
+				break;
+			}
+			pos++;
+		}
+
+		/* Did we find a wanted prefix? */
+		if (oper == FALSE)
+		{
+			/* No! Move startword back to position of left-most valid
+			   round bracket. */
+			startword = left_bracket;
+		}
+	}
+
+	/* Skip useless surrounding brackets if present. */
+	if (startword < endword)
+	{
+		guint skipped = 0;
+
+		while (chunk[startword] == '(' && startword < endword)
+		{
+			skipped++;
+			startword++;
+		}
+		while (chunk[endword] == ')' && skipped > 0)
+		{
+			skipped--;
+			endword--;
+		}
+	}
+
+	expr_copy = NULL;
+	if (startword < endword)
+	{
+		if (chunk[endword] != '\0')
+		{
+			chunk[endword+1] = '\0';
+		}
+
+		/* ensure null terminated */
+		g_strlcpy(expr, &(chunk[startword]), sizeof(expr));
+		expr_copy = g_strdup(expr);
+	}
+
+	return expr_copy;
+}
+
+/* Reads the expression for evaluate at the given cursor position and writes
+ * it into the given buffer. The buffer will be NULL terminated in any case,
+ * even when the word is truncated because wordlen is too small.
+ * Position can be -1, then the current position is used. */
+gchar *utils_read_evaluate_expr(GeanyEditor *editor, gint peek_pos)
+{
+	gint line, line_start;
+	gchar *chunk, *expr;
+	ScintillaObject *sci;
+
+	g_return_val_if_fail(editor != NULL, NULL);
+	sci = editor->sci;
+
+	if (peek_pos == -1)
+	{
+		peek_pos = sci_get_current_position(sci);
+	}
+
+	line = sci_get_line_from_position(sci, peek_pos);
+	line_start = sci_get_position_from_line(sci, line);
+	chunk = sci_get_line(sci, line);
+
+	/* Now that we got the content, let's parse it. */
+	expr = utils_evaluate_expr_from_string (chunk, peek_pos - line_start);
+
+	g_free(chunk);
+
+	return expr;
 }

--- a/scope/src/utils.h
+++ b/scope/src/utils.h
@@ -107,5 +107,8 @@ void utils_tree_set_cursor(GtkTreeSelection *selection, GtkTreeIter *iter, gdoub
 void utils_init(void);
 void utils_finalize(void);
 
+gchar *utils_evaluate_expr_from_string(gchar *chunk, guint peek_index);
+gchar *utils_read_evaluate_expr(GeanyEditor *editor, gint pos);
+
 #define UTILS_H 1
 #endif


### PR DESCRIPTION
Scope automatically evaluates an expression if the mouse pointer is hovered over it. But before this change it only evaluated words. E.g. if the mouse was hovered over ```structa->item1``` then scope would have evaluated ```structa``` or ```itemb``` depending on the exact position of the mouse pointer. With this change it will instead evaluate the value of ```structa->item1```.