### PR TITLE
scope: fixed "Modify" menu item being active without selection

### DIFF
--- a/scope/src/local.c
+++ b/scope/src/local.c
@@ -179,7 +179,7 @@ static void on_local_mr_mode(const MenuItem *menu_item)
 
 #define DS_FRESHABLE (DS_DEBUG | DS_EXTRA_2)
 #define DS_COPYABLE (DS_BASICS | DS_EXTRA_1)
-#define DS_MODIFYABLE (DS_DEBUG | DS_EXTRA_2)
+#define DS_MODIFYABLE (DS_DEBUG | DS_EXTRA_1)
 #define DS_WATCHABLE (DS_BASICS | DS_EXTRA_1)
 #define DS_INSPECTABLE (DS_NOT_BUSY | DS_EXTRA_1)
 #define DS_REPARSABLE (DS_BASICS | DS_EXTRA_1)


### PR DESCRIPTION
The context menu item "Modify" is now only set to sensitive=TRUE if a local variable is selected. This prevents a crash that happened if "Modify" was selected without having a local variable selected. Fixes #825.