### PR TITLE
scope: prevent usage of invalid iters (GtkTreeeIter)

### DIFF
--- a/scope/src/break.c
+++ b/scope/src/break.c
@@ -1332,8 +1332,10 @@ static void on_break_apply(const MenuItem *menu_item)
 	if (menu_item || thread_id)
 	{
 		GtkTreeIter iter;
-		gtk_tree_selection_get_selected(selection, NULL, &iter);
-		break_apply(&iter, !menu_item);
+		if (gtk_tree_selection_get_selected(selection, NULL, &iter))
+		{
+			break_apply(&iter, !menu_item);
+		}
 	}
 	else
 		plugin_beep();
@@ -1343,16 +1345,20 @@ static void on_break_run_apply(const MenuItem *menu_item)
 {
 	GtkTreeIter iter;
 
-	gtk_tree_selection_get_selected(selection, NULL, &iter);
-	scp_tree_store_set(store, &iter, BREAK_RUN_APPLY,
-		gtk_check_menu_item_get_active(GTK_CHECK_MENU_ITEM(menu_item->widget)), -1);
+	if (gtk_tree_selection_get_selected(selection, NULL, &iter))
+	{
+		scp_tree_store_set(store, &iter, BREAK_RUN_APPLY,
+			gtk_check_menu_item_get_active(GTK_CHECK_MENU_ITEM(menu_item->widget)), -1);
+	}
 }
 
 static void on_break_delete(G_GNUC_UNUSED const MenuItem *menu_item)
 {
 	GtkTreeIter iter;
-	gtk_tree_selection_get_selected(selection, NULL, &iter);
-	break_delete(&iter);
+	if (gtk_tree_selection_get_selected(selection, NULL, &iter))
+	{
+		break_delete(&iter);
+	}
 }
 
 static void break_seek_selected(gboolean focus)

--- a/scope/src/local.c
+++ b/scope/src/local.c
@@ -152,9 +152,11 @@ static void on_local_watch(G_GNUC_UNUSED const MenuItem *menu_item)
 	GtkTreeIter iter;
 	const char *name;
 
-	gtk_tree_selection_get_selected(selection, NULL, &iter);
-	scp_tree_store_get(store, &iter, LOCAL_NAME, &name, -1);
-	watch_add(name);
+	if (gtk_tree_selection_get_selected(selection, NULL, &iter))
+	{
+		scp_tree_store_get(store, &iter, LOCAL_NAME, &name, -1);
+		watch_add(name);
+	}
 }
 
 static void on_local_inspect(G_GNUC_UNUSED const MenuItem *menu_item)

--- a/scope/src/memory.c
+++ b/scope/src/memory.c
@@ -304,13 +304,15 @@ static void on_memory_copy(G_GNUC_UNUSED const MenuItem *menu_item)
 	const gchar *ascii;
 	gchar *string;
 
-	gtk_tree_selection_get_selected(selection, NULL, &iter);
-	scp_tree_store_get(store, &iter, MEMORY_ADDR, &addr, MEMORY_BYTES, &bytes,
-		MEMORY_ASCII, &ascii, -1);
-	string = g_strdup_printf("%s%s%s", addr, bytes, ascii);
-	gtk_clipboard_set_text(gtk_widget_get_clipboard(menu_item->widget,
-		GDK_SELECTION_CLIPBOARD), string, -1);
-	g_free(string);
+	if (gtk_tree_selection_get_selected(selection, NULL, &iter))
+	{
+		scp_tree_store_get(store, &iter, MEMORY_ADDR, &addr, MEMORY_BYTES, &bytes,
+			MEMORY_ASCII, &ascii, -1);
+		string = g_strdup_printf("%s%s%s", addr, bytes, ascii);
+		gtk_clipboard_set_text(gtk_widget_get_clipboard(menu_item->widget,
+			GDK_SELECTION_CLIPBOARD), string, -1);
+		g_free(string);
+	}
 }
 
 static void on_memory_clear(G_GNUC_UNUSED const MenuItem *menu_item)

--- a/scope/src/menu.c
+++ b/scope/src/menu.c
@@ -203,9 +203,11 @@ void menu_mode_display(GtkTreeSelection *selection, const MenuItem *menu_item, g
 	GtkTreeIter iter;
 	gint mode;
 
-	gtk_tree_selection_get_selected(selection, &model, &iter);
-	gtk_tree_model_get(model, &iter, column, &mode, -1);
-	menu_item_set_active(menu_item + mode + 1, TRUE);
+	if (gtk_tree_selection_get_selected(selection, &model, &iter))
+	{
+		gtk_tree_model_get(model, &iter, column, &mode, -1);
+		menu_item_set_active(menu_item + mode + 1, TRUE);
+	}
 }
 
 static void menu_mode_update_iter(ScpTreeStore *store, GtkTreeIter *iter, gint new_mode,
@@ -235,18 +237,20 @@ void menu_mode_update(GtkTreeSelection *selection, gint new_mode, gboolean hbit)
 	GtkTreeIter iter;
 	const char *name;
 
-	scp_tree_selection_get_selected(selection, &store, &iter);
-	scp_tree_store_get(store, &iter, COLUMN_NAME, &name, -1);
-	menu_mode_update_iter(store, &iter, new_mode, hbit);
-	parse_mode_update(name, hbit ? MODE_HBIT : MODE_MEMBER, new_mode);
-
-	if (hbit)
+	if (scp_tree_selection_get_selected(selection, &store, &iter))
 	{
-		char *reverse = parse_mode_reentry(name);
+		scp_tree_store_get(store, &iter, COLUMN_NAME, &name, -1);
+		menu_mode_update_iter(store, &iter, new_mode, hbit);
+		parse_mode_update(name, hbit ? MODE_HBIT : MODE_MEMBER, new_mode);
 
-		if (store_find(store, &iter, COLUMN_NAME, reverse))
-			menu_mode_update_iter(store, &iter, new_mode, TRUE);
-		g_free(reverse);
+		if (hbit)
+		{
+			char *reverse = parse_mode_reentry(name);
+
+			if (store_find(store, &iter, COLUMN_NAME, reverse))
+				menu_mode_update_iter(store, &iter, new_mode, TRUE);
+			g_free(reverse);
+		}
 	}
 }
 
@@ -306,18 +310,20 @@ void menu_copy(GtkTreeSelection *selection, const MenuItem *menu_item)
 	const char *value;
 	GString *string;
 
-	scp_tree_selection_get_selected(selection, &store, &iter);
-	scp_tree_store_get(store, &iter, COLUMN_NAME, &name, COLUMN_DISPLAY, &display,
-		COLUMN_VALUE, &value, -1);
-	string = g_string_new(name);
+	if (scp_tree_selection_get_selected(selection, &store, &iter))
+	{
+		scp_tree_store_get(store, &iter, COLUMN_NAME, &name, COLUMN_DISPLAY, &display,
+			COLUMN_VALUE, &value, -1);
+		string = g_string_new(name);
 
-	if (value)
-		g_string_append_printf(string, " = %s", display);
+		if (value)
+			g_string_append_printf(string, " = %s", display);
 
-	gtk_clipboard_set_text(gtk_widget_get_clipboard(menu_item->widget,
-		GDK_SELECTION_CLIPBOARD), string->str, string->len);
+		gtk_clipboard_set_text(gtk_widget_get_clipboard(menu_item->widget,
+			GDK_SELECTION_CLIPBOARD), string->str, string->len);
 
-	g_string_free(string, TRUE);
+		g_string_free(string, TRUE);
+	}
 }
 
 static GtkWidget *modify_dialog;
@@ -373,11 +379,13 @@ void menu_modify(GtkTreeSelection *selection, const MenuItem *menu_item)
 	const char *value;
 	gint hb_mode;
 
-	scp_tree_selection_get_selected(selection, &store, &iter);
-	scp_tree_store_get(store, &iter, COLUMN_NAME, &name, COLUMN_VALUE, &value, COLUMN_HB_MODE,
-		&hb_mode, -1);
-	menu_evaluate_modify(name, value, _("Modify"), hb_mode, menu_item ? MR_MODIFY : MR_MODSTR,
-		"07");
+	if (scp_tree_selection_get_selected(selection, &store, &iter))
+	{
+		scp_tree_store_get(store, &iter, COLUMN_NAME, &name, COLUMN_VALUE, &value, COLUMN_HB_MODE,
+			&hb_mode, -1);
+		menu_evaluate_modify(name, value, _("Modify"), hb_mode, menu_item ? MR_MODIFY : MR_MODSTR,
+			"07");
+	}
 }
 
 void menu_inspect(GtkTreeSelection *selection)
@@ -386,9 +394,11 @@ void menu_inspect(GtkTreeSelection *selection)
 	GtkTreeIter iter;
 	const char *name;
 
-	scp_tree_selection_get_selected(selection, &store, &iter);
-	scp_tree_store_get(store, &iter, COLUMN_NAME, &name, -1);
-	inspect_add(name);
+	if (scp_tree_selection_get_selected(selection, &store, &iter))
+	{
+		scp_tree_store_get(store, &iter, COLUMN_NAME, &name, -1);
+		inspect_add(name);
+	}
 }
 
 void on_menu_display_booleans(const MenuItem *menu_item)

--- a/scope/src/register.c
+++ b/scope/src/register.c
@@ -459,16 +459,20 @@ static void on_register_format_update(const MenuItem *menu_item)
 	gint format = GPOINTER_TO_INT(menu_item->gdata);
 	gint id;
 
-	gtk_tree_selection_get_selected(selection, NULL, &iter);
-	scp_tree_store_get(store, &iter, REGISTER_ID, &id, -1);
-
-	if (debug_state() & DS_DEBUG)
+	if (gtk_tree_selection_get_selected(selection, NULL, &iter))
 	{
-		debug_send_format(N, "02%d%c%s%s-data-list-register-values %c %d", format,
-			FRAME_ARGS, register_formats[format], id);
+		scp_tree_store_get(store, &iter, REGISTER_ID, &id, -1);
+
+		if (debug_state() & DS_DEBUG)
+		{
+			debug_send_format(N, "02%d%c%s%s-data-list-register-values %c %d", format,
+				FRAME_ARGS, register_formats[format], id);
+		}
+		else
+		{
+			scp_tree_store_set(store, &iter, REGISTER_FORMAT, format, -1);
+		}
 	}
-	else
-		scp_tree_store_set(store, &iter, REGISTER_FORMAT, format, -1);
 }
 
 static void on_register_query(G_GNUC_UNUSED const MenuItem *menu_item)

--- a/scope/src/stack.c
+++ b/scope/src/stack.c
@@ -165,10 +165,12 @@ void on_stack_follow(GArray *nodes)
 gboolean stack_entry(void)
 {
 	GtkTreeIter iter;
-	gboolean entry;
+	gboolean entry = NULL;
 
-	gtk_tree_selection_get_selected(selection, NULL, &iter);
-	scp_tree_store_get(store, &iter, STACK_ENTRY, &entry, -1);
+	if (gtk_tree_selection_get_selected(selection, NULL, &iter))
+	{
+		scp_tree_store_get(store, &iter, STACK_ENTRY, &entry, -1);
+	}
 	return entry;
 }
 
@@ -268,18 +270,22 @@ static void on_stack_show_entry(const MenuItem *menu_item)
 	GtkTreeIter iter;
 
 	view_dirty(VIEW_LOCALS);
-	gtk_tree_selection_get_selected(selection, NULL, &iter);
-	scp_tree_store_get(store, &iter, STACK_FUNC, &ed.func, -1);
-	parse_mode_update(ed.func, MODE_ENTRY, ed.entry);
-	store_foreach(store, (GFunc) stack_iter_show_entry, &ed);
-
-	if (ed.count == 1)
+	if (gtk_tree_selection_get_selected(selection, NULL, &iter))
 	{
-		debug_send_format(T, "04%s-stack-list-arguments 1 %s %s", thread_id, frame_id,
-			frame_id);
+		scp_tree_store_get(store, &iter, STACK_FUNC, &ed.func, -1);
+		parse_mode_update(ed.func, MODE_ENTRY, ed.entry);
+		store_foreach(store, (GFunc) stack_iter_show_entry, &ed);
+
+		if (ed.count == 1)
+		{
+			debug_send_format(T, "04%s-stack-list-arguments 1 %s %s", thread_id, frame_id,
+				frame_id);
+		}
+		else
+		{
+			debug_send_format(T, "04%s-stack-list-arguments 1", thread_id);
+		}
 	}
-	else
-		debug_send_format(T, "04%s-stack-list-arguments 1", thread_id);
 }
 
 #define DS_VIEWABLE (DS_ACTIVE | DS_EXTRA_2)

--- a/scope/src/store/scptreestore.c
+++ b/scope/src/store/scptreestore.c
@@ -527,16 +527,19 @@ static void validate_store(ScpTreeStore *store)
 static gboolean scp_insert_element(ScpTreeStore *store, GtkTreeIter *iter, AElem *elem,
 	gint position, GtkTreeIter *parent_iter)
 {
-	ScpTreeStorePrivate *priv = store->priv;
-	AElem *parent = parent_iter ? ITER_ELEM(parent_iter) : priv->root;
-	GPtrArray *array = parent->children;
+	ScpTreeStorePrivate *priv;
+	AElem *parent;
+	GPtrArray *array;
 	GtkTreePath *path;
 
 	g_return_val_if_fail(SCP_IS_TREE_STORE(store), FALSE);
 	g_return_val_if_fail(iter != NULL, FALSE);
+	priv = store->priv;
 	g_return_val_if_fail(priv->sublevels == TRUE || parent_iter == NULL, FALSE);
 	g_return_val_if_fail(VALID_ITER_OR_NULL(parent_iter, store), FALSE);
 
+	parent = parent_iter ? ITER_ELEM(parent_iter) : priv->root;
+	array = parent->children;
 	if (array)
 	{
 		if (position == -1)
@@ -624,12 +627,13 @@ void scp_tree_store_insert_with_values(ScpTreeStore *store, GtkTreeIter *iter,
 void scp_tree_store_get_valist(ScpTreeStore *store, GtkTreeIter *iter, va_list ap)
 {
 	ScpTreeStorePrivate *priv = store->priv;
-	AElem *elem = ITER_ELEM(iter);
+	AElem *elem;
 	gint column;
 
 	g_return_if_fail(SCP_IS_TREE_STORE(store));
 	g_return_if_fail(VALID_ITER(iter, store));
 
+	elem = ITER_ELEM(iter);
 	while ((column = va_arg(ap, int)) != -1)
 	{
 		gpointer dest;
@@ -896,12 +900,13 @@ gboolean scp_tree_store_get_iter(ScpTreeStore *store, GtkTreeIter *iter, GtkTree
 
 GtkTreePath *scp_tree_store_get_path(VALIDATE_ONLY ScpTreeStore *store, GtkTreeIter *iter)
 {
-	AElem *elem = ITER_ELEM(iter);
+	AElem *elem;
 	GtkTreePath *path;
 
 	g_return_val_if_fail(VALID_ITER(iter, store), NULL);
 	path = gtk_tree_path_new();
 
+	elem = ITER_ELEM(iter);
 	if (elem->parent)
 	{
 		gtk_tree_path_append_index(path, ITER_INDEX(iter));

--- a/scope/src/thread.c
+++ b/scope/src/thread.c
@@ -775,14 +775,16 @@ static void on_thread_interrupt(G_GNUC_UNUSED const MenuItem *menu_item)
 	GtkTreeIter iter;
 	HANDLE hid;
 
-	gtk_tree_selection_get_selected(selection, NULL, &iter);
-	hid = iter_to_handle(&iter);
-
-	if (hid)
+	if (gtk_tree_selection_get_selected(selection, NULL, &iter))
 	{
-		if (!DebugBreakProcess(hid))
-			show_errno("DebugBreakProcess");
-		CloseHandle(hid);
+		hid = iter_to_handle(&iter);
+
+		if (hid)
+		{
+			if (!DebugBreakProcess(hid))
+				show_errno("DebugBreakProcess");
+			CloseHandle(hid);
+		}
 	}
 }
 


### PR DESCRIPTION
This fixes the crash described in #824 (and two more potential crashes).