### PR TITLE
scope: corrected height of "Environment" GtkTextView

### DIFF
--- a/scope/data/scope_gtk3.glade
+++ b/scope/data/scope_gtk3.glade
@@ -2535,6 +2535,7 @@
                 <property name="can_focus">True</property>
                 <child>
                   <object class="GtkVBox" id="program_page_vbox">
+                    <property name="height_request">350</property>
                     <property name="visible">True</property>
                     <property name="border_width">6</property>
                     <property name="orientation">vertical</property>


### PR DESCRIPTION
The height of the text view was fixed by setting a height size request for the surrounding GtkVBox. Fixes #829.