### PR TITLE
vimode: Separate command and search history

### DIFF
--- a/vimode/src/excmd-prompt.c
+++ b/vimode/src/excmd-prompt.c
@@ -91,10 +91,11 @@ static gboolean on_prompt_key_press_event(GtkWidget *widget, GdkEventKey *event,
 			case GDK_KEY_KP_Enter:
 			case GDK_KEY_ISO_Enter:
 			{
-				guint index;
+				guint i;
 
-				if (g_ptr_array_find_with_equal_func(history, text + 1, g_str_equal, &index))
-					g_ptr_array_remove_index(history, index);
+				for (i = 0; i < history->len; i++)
+					if (g_str_equal(text + 1, history->pdata[i]))
+						g_ptr_array_remove_index(history, i);
 				if (strlen(text) > 1)
 					g_ptr_array_add(history, g_strdup(text + 1));
 				if (history->len > 20) // default vim history size

--- a/vimode/src/excmd-prompt.c
+++ b/vimode/src/excmd-prompt.c
@@ -60,66 +60,71 @@ static void set_prompt_text(const gchar *val)
 
 static gboolean on_prompt_key_press_event(GtkWidget *widget, GdkEventKey *event, gpointer dummy)
 {
-	switch (event->keyval)
+	guint mask = GDK_MODIFIER_MASK & ~(GDK_SHIFT_MASK | GDK_LOCK_MASK);
+
+	if ((event->state & mask) == 0)
 	{
-		case GDK_KEY_Escape:
-			close_prompt();
-			return TRUE;
-
-		case GDK_KEY_Tab:
-			/* avoid leaving the entry */
-			return TRUE;
-
-		case GDK_KEY_Return:
-		case GDK_KEY_KP_Enter:
-		case GDK_KEY_ISO_Enter:
+		switch (event->keyval)
 		{
-			guint index;
-			const gchar *text = gtk_entry_get_text(GTK_ENTRY(entry));
-
-			if (g_ptr_array_find_with_equal_func(history, text + 1, g_str_equal, &index))
-				g_ptr_array_remove_index(history, index);
-			if (strlen(text) > 1)
-				g_ptr_array_add(history, g_strdup(text + 1));
-			if (history->len > 20) // default vim history size
-				g_ptr_array_remove_index(history, 0);
-
-			excmd_perform(ctx, text);
-			close_prompt();
-
-			return TRUE;
-		}
-
-		case GDK_KEY_Up:
-		case GDK_KEY_KP_Up:
-		case GDK_KEY_uparrow:
-		{
-			if (history_pos == -1 && history->len > 0)
-				history_pos = history->len - 1;
-			else if (history_pos > 0)
-				history_pos--;
-
-			if (history_pos != -1)
-				set_prompt_text(history->pdata[history_pos]);
-
-			return TRUE;
-		}
-
-		case GDK_KEY_Down:
-		case GDK_KEY_KP_Down:
-		case GDK_KEY_downarrow:
-		{
-			if (history_pos == -1)
+			case GDK_KEY_Escape:
+				close_prompt();
 				return TRUE;
 
-			if (history_pos + 1 < history->len)
-				history_pos++;
-			else
-				history_pos = -1;
+			case GDK_KEY_Tab:
+				/* avoid leaving the entry */
+				return TRUE;
 
-			set_prompt_text(history_pos == -1 ? "" : history->pdata[history_pos]);
+			case GDK_KEY_Return:
+			case GDK_KEY_KP_Enter:
+			case GDK_KEY_ISO_Enter:
+			{
+				guint index;
+				const gchar *text = gtk_entry_get_text(GTK_ENTRY(entry));
 
-			return TRUE;
+				if (g_ptr_array_find_with_equal_func(history, text + 1, g_str_equal, &index))
+					g_ptr_array_remove_index(history, index);
+				if (strlen(text) > 1)
+					g_ptr_array_add(history, g_strdup(text + 1));
+				if (history->len > 20) // default vim history size
+					g_ptr_array_remove_index(history, 0);
+
+				excmd_perform(ctx, text);
+				close_prompt();
+
+				return TRUE;
+			}
+
+			case GDK_KEY_Up:
+			case GDK_KEY_KP_Up:
+			case GDK_KEY_uparrow:
+			{
+				if (history_pos == -1 && history->len > 0)
+					history_pos = history->len - 1;
+				else if (history_pos > 0)
+					history_pos--;
+
+				if (history_pos != -1)
+					set_prompt_text(history->pdata[history_pos]);
+
+				return TRUE;
+			}
+
+			case GDK_KEY_Down:
+			case GDK_KEY_KP_Down:
+			case GDK_KEY_downarrow:
+			{
+				if (history_pos == -1)
+					return TRUE;
+
+				if (history_pos + 1 < history->len)
+					history_pos++;
+				else
+					history_pos = -1;
+
+				set_prompt_text(history_pos == -1 ? "" : history->pdata[history_pos]);
+
+				return TRUE;
+			}
 		}
 	}
 

--- a/vimode/src/excmd-prompt.c
+++ b/vimode/src/excmd-prompt.c
@@ -60,6 +60,7 @@ static void set_prompt_text(const gchar *val)
 
 static gboolean on_prompt_key_press_event(GtkWidget *widget, GdkEventKey *event, gpointer dummy)
 {
+	const gchar *text = gtk_entry_get_text(GTK_ENTRY(entry));
 	guint printable_mask = GDK_MODIFIER_MASK & ~(GDK_SHIFT_MASK | GDK_LOCK_MASK);
 	guint modif_mask = GDK_MODIFIER_MASK & ~GDK_LOCK_MASK;
 
@@ -80,7 +81,6 @@ static gboolean on_prompt_key_press_event(GtkWidget *widget, GdkEventKey *event,
 			case GDK_KEY_ISO_Enter:
 			{
 				guint index;
-				const gchar *text = gtk_entry_get_text(GTK_ENTRY(entry));
 
 				if (g_ptr_array_find_with_equal_func(history, text + 1, g_str_equal, &index))
 					g_ptr_array_remove_index(history, index);
@@ -126,6 +126,13 @@ static gboolean on_prompt_key_press_event(GtkWidget *widget, GdkEventKey *event,
 
 				return TRUE;
 			}
+
+			case GDK_KEY_Home:
+				gtk_editable_set_position(GTK_EDITABLE(entry), 1);
+				return TRUE;
+			case GDK_KEY_End:
+				gtk_editable_set_position(GTK_EDITABLE(entry), strlen(text));
+				return TRUE;
 		}
 	}
 	else if ((event->state & modif_mask) == GDK_CONTROL_MASK)
@@ -134,6 +141,13 @@ static gboolean on_prompt_key_press_event(GtkWidget *widget, GdkEventKey *event,
 		{
 			case GDK_KEY_c:
 				close_prompt();
+				return TRUE;
+
+			case GDK_KEY_b:
+				gtk_editable_set_position(GTK_EDITABLE(entry), 1);
+				return TRUE;
+			case GDK_KEY_e:
+				gtk_editable_set_position(GTK_EDITABLE(entry), strlen(text));
 				return TRUE;
 		}
 	}

--- a/vimode/src/excmd-prompt.c
+++ b/vimode/src/excmd-prompt.c
@@ -60,9 +60,10 @@ static void set_prompt_text(const gchar *val)
 
 static gboolean on_prompt_key_press_event(GtkWidget *widget, GdkEventKey *event, gpointer dummy)
 {
-	guint mask = GDK_MODIFIER_MASK & ~(GDK_SHIFT_MASK | GDK_LOCK_MASK);
+	guint printable_mask = GDK_MODIFIER_MASK & ~(GDK_SHIFT_MASK | GDK_LOCK_MASK);
+	guint modif_mask = GDK_MODIFIER_MASK & ~GDK_LOCK_MASK;
 
-	if ((event->state & mask) == 0)
+	if ((event->state & printable_mask) == 0)
 	{
 		switch (event->keyval)
 		{
@@ -125,6 +126,15 @@ static gboolean on_prompt_key_press_event(GtkWidget *widget, GdkEventKey *event,
 
 				return TRUE;
 			}
+		}
+	}
+	else if ((event->state & modif_mask) == GDK_CONTROL_MASK)
+	{
+		switch (event->keyval)
+		{
+			case GDK_KEY_c:
+				close_prompt();
+				return TRUE;
 		}
 	}
 

--- a/vimode/src/excmd-prompt.c
+++ b/vimode/src/excmd-prompt.c
@@ -81,6 +81,8 @@ static gboolean on_prompt_key_press_event(GtkWidget *widget, GdkEventKey *event,
 				g_ptr_array_remove_index(history, index);
 			if (strlen(text) > 1)
 				g_ptr_array_add(history, g_strdup(text + 1));
+			if (history->len > 20) // default vim history size
+				g_ptr_array_remove_index(history, 0);
 
 			excmd_perform(ctx, text);
 			close_prompt();


### PR DESCRIPTION
Vi seems to use a separate history for commands (starting with ':')
and searches (starting with '/' or '?'). Let's do the same.