### PR TITLE
projectorganizer: fixed too short title underline in README

### DIFF
--- a/projectorganizer/README
+++ b/projectorganizer/README
@@ -173,7 +173,7 @@ The following search properties are configurable:
   name only (excluding path); when checked, the search is performed in the full path
 
 Find symbol dialog
-----------------
+------------------
 
 The Find symbol dialog can be invoked either from the Project menu or from the
 sidebar's context menu. Searches are performed within the "Search inside" directory.


### PR DESCRIPTION
This fixes an ugly error message on the geany-plugins website, see https://plugins.geany.org/projectorganizer.html.