### PR TITLE
autoclose: fixed deprecated gtk call for gtk3

### DIFF
--- a/autoclose/src/autoclose.c
+++ b/autoclose/src/autoclose.c
@@ -1005,7 +1005,11 @@ plugin_autoclose_configure(G_GNUC_UNUSED GeanyPlugin *plugin, GtkDialog *dialog,
 	vbox = gtk_vbox_new(FALSE, 0);
 	scrollbox = gtk_scrolled_window_new(NULL, NULL);
 	gtk_widget_set_size_request(GTK_WIDGET(scrollbox), -1, 400);
+#if GTK_CHECK_VERSION(3, 8, 0)
+	gtk_container_add(GTK_CONTAINER(scrollbox), vbox);
+#else
 	gtk_scrolled_window_add_with_viewport(GTK_SCROLLED_WINDOW(scrollbox), vbox);
+#endif
 	gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(scrollbox),
 		GTK_POLICY_NEVER, GTK_POLICY_AUTOMATIC);
 


### PR DESCRIPTION
This fixes a deprecation warning in the autoclose plugin for gtk3. No functional changes.

A little side note:
I first thought I could use ```gtk_container_add()``` on gtk 2 and 3 because of this deprecation notice in the gtk documentation:

> gtk_scrolled_window_add_with_viewport has been deprecated since version 3.8 and should not be used in newly-written code.
> gtk_container_add() will automatically add a GtkViewport if the child doesn’t implement GtkScrollable.

But the function only works that way under gtk3. A test with gtk2 revealed that the function does not work that way with the result that in this case the scroll bar was missing in the autoclose configuration dialog.