### PR TITLE
geanynumberedbookmarks: fixed deprecated gtk calls for gtk3

### DIFF
--- a/build/geanynumberedbookmarks.m4
+++ b/build/geanynumberedbookmarks.m4
@@ -1,6 +1,8 @@
 AC_DEFUN([GP_CHECK_GEANYNUMBEREDBOOKMARKS],
 [
     GP_ARG_DISABLE([GeanyNumberedBookmarks], [auto])
+    GP_CHECK_UTILSLIB([GeanyNumberedBookmarks])
+
     GP_COMMIT_PLUGIN_STATUS([GeanyNumberedBookmarks])
     AC_CONFIG_FILES([
         geanynumberedbookmarks/Makefile

--- a/geanynumberedbookmarks/src/Makefile.am
+++ b/geanynumberedbookmarks/src/Makefile.am
@@ -5,4 +5,7 @@ geanyplugins_LTLIBRARIES = geanynumberedbookmarks.la
 
 geanynumberedbookmarks_la_SOURCES = geanynumberedbookmarks.c
 geanynumberedbookmarks_la_CPPFLAGS = $(AM_CPPFLAGS) -DG_LOG_DOMAIN=\"GeanyNumberedBookmarks\"
-geanynumberedbookmarks_la_LIBADD = $(COMMONLIBS)
+geanynumberedbookmarks_la_CFLAGS = $(AM_CFLAGS) \
+	-I$(top_srcdir)/utils/src
+geanynumberedbookmarks_la_LIBADD = $(COMMONLIBS) \
+	$(top_builddir)/utils/src/libgeanypluginutils.la

--- a/geanynumberedbookmarks/src/geanynumberedbookmarks.c
+++ b/geanynumberedbookmarks/src/geanynumberedbookmarks.c
@@ -20,6 +20,7 @@
 #include <gdk/gdkkeysyms.h>
 #include <gtk/gtk.h>
 #include <glib/gstdio.h>
+#include <gp_gtkcompat.h>
 
 static const gint base64_char_to_int[]=
 {
@@ -1289,10 +1290,19 @@ will move the bookmark there if it was set on a different line, or create it if 
 	scroll=gtk_scrolled_window_new(NULL,NULL);
 	gtk_scrolled_window_set_policy((GtkScrolledWindow*)scroll,GTK_POLICY_NEVER,
 	                               GTK_POLICY_AUTOMATIC);
+#if GTK_CHECK_VERSION(3, 8, 0)
+	gtk_widget_set_size_request(label, 600, -1);
+	gtk_widget_set_halign(label, GTK_ALIGN_CENTER);
+	gtk_widget_set_valign(label, GTK_ALIGN_CENTER);
+	gtk_widget_set_vexpand(label, TRUE);
+	gtk_container_add(GTK_CONTAINER(scroll),label);
+	gtk_scrolled_window_set_shadow_type((GtkScrolledWindow*)scroll, GTK_SHADOW_IN);
+#else
 	gtk_scrolled_window_add_with_viewport((GtkScrolledWindow*)scroll,label);
+#endif
 
 	gtk_container_add(GTK_CONTAINER(gtk_dialog_get_content_area(GTK_DIALOG(dialog))),scroll);
-	gtk_widget_show(scroll);
+	gtk_widget_show_all(dialog);
 
 	/* set dialog size (leave width default) */
 	gtk_widget_set_size_request(dialog,-1,300);
@@ -1475,7 +1485,11 @@ void plugin_init(GeanyData *data)
 {
 	gint i,k,iResults=0;
 	GdkKeymapKey *gdkkmkResults;
+#if GTK_CHECK_VERSION(3, 22, 0)
+	GdkKeymap *gdkKeyMap=gdk_keymap_get_for_display(gdk_display_get_default());
+#else
 	GdkKeymap *gdkKeyMap=gdk_keymap_get_default();
+#endif
 
 	/* Load settings */
 	LoadSettings();

--- a/utils/src/gp_gtkcompat.h
+++ b/utils/src/gp_gtkcompat.h
@@ -48,8 +48,10 @@ G_BEGIN_DECLS
 #if GTK_CHECK_VERSION(3, 10, 0)
 #undef GTK_STOCK_OPEN
 #undef GTK_STOCK_CANCEL
+#undef GTK_STOCK_OK
 #define GTK_STOCK_OPEN   _("_Open")
 #define GTK_STOCK_CANCEL _("_Cancel")
+#define GTK_STOCK_OK _("_OK")
 #endif
 
 /* Replace calls to gtk_icon_info_free() with call to


### PR DESCRIPTION
This fixes some deprecation warnings in the geanynumberedbookmarks plugin for gtk3. No functional changes.