### PR TITLE
treebrowser: fixed deprecated gtk calls for gtk3

### DIFF
--- a/build/treebrowser.m4
+++ b/build/treebrowser.m4
@@ -1,6 +1,8 @@
 AC_DEFUN([GP_CHECK_TREEBROWSER],
 [
     GP_ARG_DISABLE([Treebrowser], [auto])
+    GP_CHECK_UTILSLIB([Treebrowser])
+
     if [[ "$enable_treebrowser" != no ]]; then
         AC_CHECK_FUNC([creat],
             [enable_treebrowser=yes],

--- a/treebrowser/src/Makefile.am
+++ b/treebrowser/src/Makefile.am
@@ -5,8 +5,10 @@ geanyplugins_LTLIBRARIES = treebrowser.la
 
 treebrowser_la_SOURCES = treebrowser.c
 treebrowser_la_CPPFLAGS = $(AM_CPPFLAGS) -DG_LOG_DOMAIN=\"TreeBrowser\"
-treebrowser_la_CFLAGS = $(AM_CFLAGS) $(GIO_CFLAGS)
-treebrowser_la_LIBADD = $(COMMONLIBS) $(GIO_LIBS)
+treebrowser_la_CFLAGS = $(AM_CFLAGS) $(GIO_CFLAGS) \
+	-I$(top_srcdir)/utils/src
+treebrowser_la_LIBADD = $(COMMONLIBS) $(GIO_LIBS) \
+	$(top_builddir)/utils/src/libgeanypluginutils.la
 
 AM_CPPCHECKFLAGS = --suppress='deallocDealloc:$(srcdir)/treebrowser.c'
 AM_CPPCHECKFLAGS += --suppress='doubleFree:$(srcdir)/treebrowser.c'


### PR DESCRIPTION
Apart from fixing a load of deprecation warnings on gtk3 this also fixes two gtk3 related problems in the treebrowser plugin:
- lines in the Treeview had a red color - now they are black like under gtk2
- the text field turned red if the path entered wasn't a valid directory - this did not work under gtk3 before but now it works

The gtk2 behavior is unchanged and there are also no functional changes.

If this get's merged PR #279 would become needless and could be closed un-merged.