### PR TITLE
workbench: save settings immediately

### DIFF
--- a/workbench/README
+++ b/workbench/README
@@ -35,12 +35,10 @@ menu:
   As explained above, creates a new Workbench.
 **Item "Open"**
   Open a Workbench.
-**Item "Save"**
-  Save the opened Workbench. This "only" saves any changes
-  in the Workbench file. It does not save any changes of the projects
-  belonging to the Workbench.
 **Item "Settings"**
-  Open the Workbench settings dialog.
+  Open the Workbench settings dialog. After the settings have been
+  confirmed with "OK" they will be written back to the workbench file
+  (if any value was changed).
 **Item "Close"**
   Closes the opened Workbench.
 

--- a/workbench/src/plugin_main.c
+++ b/workbench/src/plugin_main.c
@@ -130,7 +130,7 @@ void geany_load_module(GeanyPlugin *plugin)
 	/* Set metadata */
 	plugin->info->name = _("Workbench");
 	plugin->info->description = _("Manage and customize multiple projects.");
-	plugin->info->version = "1.05";
+	plugin->info->version = "1.06";
 	plugin->info->author = "LarsGit223";
 
 	/* Set functions */


### PR DESCRIPTION
After confirming changed settings with _"OK"_ they will now immediately be written back to the workbench file. Therefore the menu item _"Workbench / Save"_ became useless and has been removed. Closes #841.