### PR TITLE
workbench: added option to enable or disable tree lines

### DIFF
--- a/workbench/README
+++ b/workbench/README
@@ -155,6 +155,14 @@ The following settings exist for a workbench:
   which has been created with an older version of the workbench plugin
   then the option will be added with value "activated".
 
+**Expand on hover**
+  If the option is activated, then a tree node in the sidebar
+  will be expanded or collapsed by hovering over it with the mouse cursor.
+
+**Enable tree lines**
+  If the option is activated, lines will be drawn between the nodes in
+  the sidebar tree.
+
 Live update
 -----------
 From version 1.03 on the workbench plugin supports an automatic live update

--- a/workbench/src/dialogs.c
+++ b/workbench/src/dialogs.c
@@ -465,7 +465,7 @@ gboolean dialogs_workbench_settings(WORKBENCH *workbench)
 {
 	gint result;
 	GtkWidget *w_rescan_projects_on_open, *w_enable_live_update, *w_expand_on_hover;
-	GtkWidget *dialog, *content_area;
+	GtkWidget *dialog, *content_area, *w_enable_tree_lines;
 	GtkWidget *vbox, *hbox;
 #if GTK_CHECK_VERSION(3, 4, 0)
 	GtkWidget *grid;
@@ -476,6 +476,7 @@ gboolean dialogs_workbench_settings(WORKBENCH *workbench)
 	gboolean changed, rescan_projects_on_open, rescan_projects_on_open_old;
 	gboolean enable_live_update, enable_live_update_old;
 	gboolean expand_on_hover, expand_on_hover_old;
+	gboolean enable_tree_lines, enable_tree_lines_old;
 
 	/* Create the widgets */
 	flags = GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT;
@@ -548,6 +549,22 @@ gboolean dialogs_workbench_settings(WORKBENCH *workbench)
 	expand_on_hover_old = workbench_get_expand_on_hover(workbench);
 	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(w_expand_on_hover), expand_on_hover_old);
 
+	w_enable_tree_lines = gtk_check_button_new_with_mnemonic(_("_Enable tree lines"));
+#if GTK_CHECK_VERSION(3, 4, 0)
+	gtk_grid_attach (GTK_GRID(grid), w_enable_tree_lines, 0, 3, 1, 1);
+	gtk_widget_set_halign (w_enable_tree_lines, GTK_ALIGN_CENTER);
+	gtk_widget_set_hexpand (w_enable_tree_lines, TRUE);
+	gtk_widget_set_valign (w_enable_tree_lines, GTK_ALIGN_CENTER);
+	gtk_widget_set_vexpand (w_enable_tree_lines, TRUE);
+#else
+	ui_table_add_row(GTK_TABLE(table), 3, w_enable_tree_lines, NULL);
+#endif
+	gtk_widget_set_tooltip_text(w_enable_tree_lines,
+		_("If the option is activated, lines will be drawn between "
+		  "the nodes in the sidebar tree."));
+	enable_tree_lines_old = workbench_get_enable_tree_lines(workbench);
+	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(w_enable_tree_lines), enable_tree_lines_old);
+
 #if GTK_CHECK_VERSION(3, 4, 0)
 	gtk_box_pack_start(GTK_BOX(vbox), grid, FALSE, FALSE, 6);
 #else
@@ -582,6 +599,12 @@ gboolean dialogs_workbench_settings(WORKBENCH *workbench)
 		{
 			changed = TRUE;
 			workbench_set_expand_on_hover(workbench, expand_on_hover);
+		}
+		enable_tree_lines = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(w_enable_tree_lines));
+		if (enable_tree_lines != enable_tree_lines_old)
+		{
+			changed = TRUE;
+			workbench_set_enable_tree_lines(workbench, enable_tree_lines);
 		}
 	}
 

--- a/workbench/src/plugin_main.c
+++ b/workbench/src/plugin_main.c
@@ -130,7 +130,7 @@ void geany_load_module(GeanyPlugin *plugin)
 	/* Set metadata */
 	plugin->info->name = _("Workbench");
 	plugin->info->description = _("Manage and customize multiple projects.");
-	plugin->info->version = "1.06";
+	plugin->info->version = "1.07";
 	plugin->info->author = "LarsGit223";
 
 	/* Set functions */

--- a/workbench/src/sidebar.c
+++ b/workbench/src/sidebar.c
@@ -867,6 +867,9 @@ static void sidebar_update_workbench(GtkTreeIter *iter, gint *position)
 		gtk_tree_view_set_hover_expand(GTK_TREE_VIEW(sidebar.file_view),
 			workbench_get_expand_on_hover(wb_globals.opened_wb));
 
+		gtk_tree_view_set_enable_tree_lines(GTK_TREE_VIEW(sidebar.file_view),
+			workbench_get_enable_tree_lines(wb_globals.opened_wb));
+
 		count = workbench_get_project_count(wb_globals.opened_wb);
 		length = g_snprintf(text, sizeof(text),
 							g_dngettext(GETTEXT_PACKAGE, "%s: %u Project", "%s: %u Projects", count),

--- a/workbench/src/workbench.c
+++ b/workbench/src/workbench.c
@@ -49,6 +49,7 @@ struct S_WORKBENCH
 	gboolean  rescan_projects_on_open;
 	gboolean  enable_live_update;
 	gboolean  expand_on_hover;
+	gboolean  enable_tree_lines;
 	GPtrArray *projects;
 	GPtrArray *bookmarks;
 	WB_MONITOR *monitor;
@@ -284,6 +285,42 @@ gboolean workbench_get_expand_on_hover(WORKBENCH *wb)
 	if (wb != NULL)
 	{
 		return wb->expand_on_hover;
+	}
+	return FALSE;
+}
+
+
+/** Set the "Enable Tree Lines" option.
+ *
+ * @param wb    The workbench
+ * @param value The value to set
+ *
+ **/
+void workbench_set_enable_tree_lines(WORKBENCH *wb, gboolean value)
+{
+	if (wb != NULL)
+	{
+		if (wb->enable_tree_lines != value)
+		{
+			wb->enable_tree_lines = value;
+			wb->modified = TRUE;
+		}
+	}
+}
+
+
+/** Get the "Enable Tree Lines" option.
+ *
+ * @param wb The workbench
+ * @return TRUE = show tree lines,
+ *         FALSE = don't
+ *
+ **/
+gboolean workbench_get_enable_tree_lines(WORKBENCH *wb)
+{
+	if (wb != NULL)
+	{
+		return wb->enable_tree_lines;
 	}
 	return FALSE;
 }
@@ -691,6 +728,7 @@ gboolean workbench_save(WORKBENCH *wb, GError **error)
 		g_key_file_set_boolean(kf, "General", "RescanProjectsOnOpen", wb->rescan_projects_on_open);
 		g_key_file_set_boolean(kf, "General", "EnableLiveUpdate", wb->enable_live_update);
 		g_key_file_set_boolean(kf, "General", "ExpandOnHover", wb->expand_on_hover);
+		g_key_file_set_boolean(kf, "General", "EnableTreeLines", wb->enable_tree_lines);
 
 		/* Save Workbench bookmarks as string list */
 		boomarks_size = workbench_get_bookmarks_count(wb);
@@ -833,6 +871,16 @@ gboolean workbench_load(WORKBENCH *wb, const gchar *filename, GError **error)
 			/* Not found. Might happen if the workbench was created with an older version of the plugin.
 			   Initialize with FALSE. */
 			wb->expand_on_hover = FALSE;
+		}
+		if (g_key_file_has_key (kf, "General", "EnableTreeLines", error))
+		{
+			wb->enable_tree_lines = g_key_file_get_boolean(kf, "General", "EnableTreeLines", error);
+		}
+		else
+		{
+			/* Not found. Might happen if the workbench was created with an older version of the plugin.
+			   Initialize with FALSE. */
+			wb->enable_tree_lines = FALSE;
 		}
 
 		/* Load Workbench bookmarks from string list */

--- a/workbench/src/workbench.h
+++ b/workbench/src/workbench.h
@@ -45,6 +45,8 @@ void workbench_set_enable_live_update(WORKBENCH *wb, gboolean value);
 gboolean workbench_get_enable_live_update(WORKBENCH *wb);
 void workbench_set_expand_on_hover(WORKBENCH *wb, gboolean value);
 gboolean workbench_get_expand_on_hover(WORKBENCH *wb);
+void workbench_set_enable_tree_lines(WORKBENCH *wb, gboolean value);
+gboolean workbench_get_enable_tree_lines(WORKBENCH *wb);
 
 WB_PROJECT *workbench_get_project_at_index(WORKBENCH *wb, guint index);
 PROJECT_ENTRY_STATUS workbench_get_project_status_at_index(WORKBENCH *wb, guint index);


### PR DESCRIPTION
This PR adds a simple config option to disable or enable tree lines in the workbench's sidebar tree.

(This also adds the missing description for the option _"Expand on hover"_ to the README file)