### PR TITLE
workbench: auto-save project on change

### DIFF
--- a/workbench/README
+++ b/workbench/README
@@ -62,12 +62,6 @@ These are the available items:
   adding a project you need to save the workbench settings by selecting
   "Workbench / Save" in the menubar.
 
-**Save project**
-  Selecting this item will save the Workbench related project settings in
-  the Geany project file. It is only available if you right clicked inside
-  of a project. It will only save the settings of the project that you
-  clicked on.
-
 **Remove project**
   Remove the project from the Workbench. It is only available if you
   right clicked inside of a project.  After removing a project you need

--- a/workbench/src/plugin_main.c
+++ b/workbench/src/plugin_main.c
@@ -117,7 +117,7 @@ void geany_load_module(GeanyPlugin *plugin)
 	/* Set metadata */
 	plugin->info->name = _("Workbench");
 	plugin->info->description = _("Manage and customize multiple projects.");
-	plugin->info->version = "1.07";
+	plugin->info->version = "1.08";
 	plugin->info->author = "LarsGit223";
 
 	/* Set functions */


### PR DESCRIPTION
This removes the item _"Save project"_ from the popup menu and automatically saves a project if something is changed (e.g. directory added/removed).

This also fixes some situations in which saving of the workbench file was missing (e.g. a change in the workbench bookmarks). See #841.