### PR TITLE
Devhelp: Fix embedded library's use of glib-genmarshal

### DIFF
--- a/devhelp/devhelp/Makefile.am
+++ b/devhelp/devhelp/Makefile.am
@@ -77,8 +77,7 @@ libdevhelp_2_la_LDFLAGS = \
 	-no-undefined
 
 dh-marshal.h: dh-marshal.list
-	$(AM_V_GEN) $(GLIB_GENMARSHAL) $< --header --prefix=_dh_marshal dh-marshal.list > $@
+	$(AM_V_GEN)$(GLIB_GENMARSHAL) --prefix=_dh_marshal --header --output=$@ dh-marshal.list
 
 dh-marshal.c: dh-marshal.list
-	$(AM_V_GEN) echo "#include \"dh-marshal.h\"" > $@ && \
-	$(GLIB_GENMARSHAL) $< --body --prefix=_dh_marshal dh-marshal.list >> $@
+	$(AM_V_GEN)$(GLIB_GENMARSHAL) --prefix=_dh_marshal --body --output=$@ dh-marshal.list


### PR DESCRIPTION
This was [changed upstream](https://github.com/GNOME/devhelp/commit/94f3661dbc3d0a228a78ff4a4d38b076b7a221b8) some unknown time ago.

I didn't really test this properly, hoping Travis CI will do it for me :)

See comments in #864