### PR TITLE
workbench: added option to let git decide which files to display

### DIFF
--- a/build/workbench.m4
+++ b/build/workbench.m4
@@ -3,6 +3,9 @@ AC_DEFUN([GP_CHECK_WORKBENCH],
     GP_ARG_DISABLE([Workbench], [auto])
     GP_CHECK_UTILSLIB([Workbench])
 
+    GP_CHECK_PLUGIN_DEPS([Workbench], [WORKBENCH],
+                         [libgit2 >= 0.21])
+
     GP_COMMIT_PLUGIN_STATUS([Workbench])
     AC_CONFIG_FILES([
         workbench/Makefile

--- a/utils/src/filelist.h
+++ b/utils/src/filelist.h
@@ -28,12 +28,17 @@ typedef enum
 	FILELIST_FLAG_ADD_DIRS = 1,
 }FILELIST_FLAG;
 
+GSList *filelist_get_precompiled_patterns(gchar **patterns);
+gboolean filelist_patterns_match(GSList *patterns, const gchar *str);
 GSList *gp_filelist_scan_directory(guint *files, guint *folders, const gchar *searchdir, gchar **file_patterns,
 		gchar **ignored_dirs_patterns, gchar **ignored_file_patterns);
 GSList *gp_filelist_scan_directory_full(guint *files, guint *folders, const gchar *searchdir, gchar **file_patterns,
 		gchar **ignored_dirs_patterns, gchar **ignored_file_patterns, guint flags);
 gboolean gp_filelist_filepath_matches_patterns(const gchar *filepath, gchar **file_patterns,
 		gchar **ignored_dirs_patterns, gchar **ignored_file_patterns);
+GSList *gp_filelist_scan_directory_callback(const gchar *searchdir,
+	void (*callback)(const gchar *path, gboolean *add, gboolean *enter, void *userdata),
+	void *userdata);
 
 G_END_DECLS
 

--- a/workbench/README
+++ b/workbench/README
@@ -93,8 +93,12 @@ These are the available items:
 **Directory settings**
   Select this item to change the directory settings. It is only available
   if you right clicked inside of a project directory. In the directory
-  settings you can set a filter which controls the files and sub-directories
-  that will be displayed or not.
+  settings you can set filters which control the files and sub-directories
+  that will be displayed or not. You can choose between a filter mechanism
+  controlled by the workbench plugin or controlled by git. In the later case
+  the .gitignore settings decide which files are displayed and which not.
+  This option is only available if the directory is/contains a git
+  repository.
 
 **Fold/unfold directory**
   Fold or unfold the items belonging to the directory. It is only available

--- a/workbench/src/Makefile.am
+++ b/workbench/src/Makefile.am
@@ -30,9 +30,10 @@ workbench_la_SOURCES = \
 
 workbench_la_CPPFLAGS = $(AM_CPPFLAGS) \
 	-DG_LOG_DOMAIN=\"Workbench\"
-workbench_la_CFLAGS = $(AM_CFLAGS) \
+workbench_la_CFLAGS = $(AM_CFLAGS) $(WORKBENCH_CFLAGS) \
 	-I$(top_srcdir)/utils/src
 workbench_la_LIBADD = $(COMMONLIBS) \
+	$(WORKBENCH_LIBS) \
 	$(top_builddir)/utils/src/libgeanypluginutils.la
 include $(top_srcdir)/build/cppcheck.mk
 

--- a/workbench/src/dialogs.h
+++ b/workbench/src/dialogs.h
@@ -25,7 +25,7 @@ gchar *dialogs_create_new_workbench(void);
 gchar *dialogs_open_workbench(void);
 gchar *dialogs_add_project(void);
 gchar *dialogs_add_directory(WB_PROJECT *project);
-gboolean dialogs_directory_settings(WB_PROJECT_DIR *directory);
+gboolean dialogs_directory_settings(WB_PROJECT *project, WB_PROJECT_DIR *directory);
 gboolean dialogs_workbench_settings(WORKBENCH *workbench);
 
 #endif

--- a/workbench/src/plugin_main.c
+++ b/workbench/src/plugin_main.c
@@ -25,6 +25,7 @@
 
 #include <sys/time.h>
 #include <string.h>
+#include <git2.h>
 
 #include <wb_globals.h>
 
@@ -33,6 +34,13 @@
 #include "popup_menu.h"
 #include "idle_queue.h"
 #include "tm_control.h"
+
+
+#if ! defined (LIBGIT2_SOVERSION) || LIBGIT2_SOVERSION < 22
+# define git_libgit2_init     git_threads_init
+# define git_libgit2_shutdown git_threads_shutdown
+#endif
+
 
 GeanyPlugin *geany_plugin;
 GeanyData *geany_data;
@@ -80,6 +88,9 @@ static gboolean plugin_workbench_init(GeanyPlugin *plugin, G_GNUC_UNUSED gpointe
 	menu_set_context(MENU_CONTEXT_WB_CLOSED);
 	sidebar_show_intro_message(_("Create or open a workbench\nusing the workbench menu."), FALSE);
 
+	/* Init libgit2. */
+	git_libgit2_init();
+
 	return TRUE;
 }
 
@@ -90,6 +101,9 @@ static void plugin_workbench_cleanup(G_GNUC_UNUSED GeanyPlugin *plugin, G_GNUC_U
 	menu_cleanup();
 	sidebar_cleanup();
 	wb_tm_control_cleanup();
+
+	/* Shutdown/cleanup libgit2. */
+	git_libgit2_shutdown();
 }
 
 
@@ -117,7 +131,7 @@ void geany_load_module(GeanyPlugin *plugin)
 	/* Set metadata */
 	plugin->info->name = _("Workbench");
 	plugin->info->description = _("Manage and customize multiple projects.");
-	plugin->info->version = "1.08";
+	plugin->info->version = "1.09";
 	plugin->info->author = "LarsGit223";
 
 	/* Set functions */

--- a/workbench/src/popup_menu.c
+++ b/workbench/src/popup_menu.c
@@ -432,7 +432,7 @@ static void popup_menu_on_directory_settings(G_GNUC_UNUSED GtkMenuItem * menuite
 	if (sidebar_file_view_get_selected_context(&context)
 		&& context.project != NULL && context.directory != NULL)
 	{
-		if (dialogs_directory_settings(context.directory))
+		if (dialogs_directory_settings(context.project, context.directory))
 		{
 			wb_project_set_modified(context.project, TRUE);
 			wb_project_dir_rescan(context.project, context.directory);

--- a/workbench/src/utils.c
+++ b/workbench/src/utils.c
@@ -292,3 +292,16 @@ void close_all_files_in_list(GPtrArray *list)
 		}
 	}
 }
+
+
+gboolean is_git_repository(gchar *path)
+{
+	gboolean is_git_repo;
+	gchar *git_path;
+
+	git_path = g_build_filename(path, ".git", NULL);
+	is_git_repo = g_file_test(git_path, G_FILE_TEST_IS_DIR);
+	g_free(git_path);
+
+	return is_git_repo;
+}

--- a/workbench/src/utils.h
+++ b/workbench/src/utils.h
@@ -28,5 +28,6 @@ gchar *get_combined_path(const gchar *base, const gchar *relative);
 gchar *get_any_relative_path (const gchar *base, const gchar *target);
 void open_all_files_in_list(GPtrArray *list);
 void close_all_files_in_list(GPtrArray *list);
+gboolean is_git_repository(gchar *path);
 
 #endif

--- a/workbench/src/wb_project.h
+++ b/workbench/src/wb_project.h
@@ -24,6 +24,13 @@
 typedef struct S_WB_PROJECT WB_PROJECT;
 typedef struct S_WB_PROJECT_DIR WB_PROJECT_DIR;
 
+typedef enum
+{
+	WB_PROJECT_SCAN_MODE_INVALID,
+	WB_PROJECT_SCAN_MODE_WORKBENCH,
+	WB_PROJECT_SCAN_MODE_GIT,
+}WB_PROJECT_SCAN_MODE;
+
 WB_PROJECT *wb_project_new(const gchar *filename);
 void wb_project_free(WB_PROJECT *prj);
 
@@ -51,6 +58,8 @@ gchar **wb_project_dir_get_ignored_dirs_patterns (WB_PROJECT_DIR *directory);
 gboolean wb_project_dir_set_ignored_dirs_patterns (WB_PROJECT_DIR *directory, gchar **new);
 gchar **wb_project_dir_get_ignored_file_patterns (WB_PROJECT_DIR *directory);
 gboolean wb_project_dir_set_ignored_file_patterns (WB_PROJECT_DIR *directory, gchar **new);
+WB_PROJECT_SCAN_MODE wb_project_dir_get_scan_mode (WB_PROJECT_DIR *directory);
+gboolean wb_project_dir_set_scan_mode (WB_PROJECT *project, WB_PROJECT_DIR *directory, WB_PROJECT_SCAN_MODE mode);
 guint wb_project_dir_rescan(WB_PROJECT *prj, WB_PROJECT_DIR *root);
 gchar *wb_project_dir_get_info (WB_PROJECT_DIR *dir);
 gboolean wb_project_dir_file_is_included(WB_PROJECT_DIR *dir, const gchar *filename);


### PR DESCRIPTION
In the directory settings it is now possible to choose between a workbench or a git file filter. The later is new and lets git decide which files to display depending on the contents of the ```.gitignore``` file.

This also adds a new function to the utils-lib called ```gp_filelist_scan_directory_callback()```.

See this example screenshot:
![DirectorySettingsWithGitOption](https://user-images.githubusercontent.com/9009011/60295870-106e1400-9925-11e9-9764-576a812ef0ec.png)
