### PR TITLE
UpdateChecker: Use new service URL

### DIFF
--- a/updatechecker/src/updatechecker.c
+++ b/updatechecker/src/updatechecker.c
@@ -47,7 +47,7 @@ enum {
     UPDATECHECK_STARTUP
 };
 
-#define UPDATE_CHECK_URL "https://geany.org/service/version.php"
+#define UPDATE_CHECK_URL "https://geany.org/service/version/"
 
 static GtkWidget *main_menu_item = NULL;
 static void update_check_result_cb(SoupSession *session,


### PR DESCRIPTION
The old URL is kept running only to support old versions.