### PR TITLE
Added additional color format to ao_colortip.c in "Addons"

### DIFF
--- a/addons/src/ao_colortip.c
+++ b/addons/src/ao_colortip.c
@@ -71,6 +71,14 @@ static gint contains_color_value(gchar *string, gint position, gint maxdist)
 	guint length;
 
 	start = strchr(string, '#');
+	if (!start)
+	{
+		start = strstr(string, "0x");
+		if (start)
+		{
+			start += 1; 
+		}
+	}
 	if (start == NULL)
 	{
 		return color;


### PR DESCRIPTION
Added code needed to show hexadecimal numbers as colors. This is useful for any computer languages and/or syntax that represents numbers in the format `0x123456` (such as the colorscheme themes in Geany).