### PR TITLE
updatechecker: remove duplicate config_file string allocation

### DIFF
--- a/updatechecker/src/updatechecker.c
+++ b/updatechecker/src/updatechecker.c
@@ -245,10 +245,6 @@ on_configure_response(G_GNUC_UNUSED GtkDialog *dialog, gint response,
         gchar *data;
         gchar *config_dir = g_path_get_dirname(config_file);
 
-        config_file = g_strconcat(geany->app->configdir,
-            G_DIR_SEPARATOR_S, "plugins", G_DIR_SEPARATOR_S,
-            "updatechecker", G_DIR_SEPARATOR_S, "general.conf", NULL);
-
         /* Crabbing options that has been set */
         check_on_startup =
             gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(config_widgets.run_on_startup));


### PR DESCRIPTION
I think that this might be a small memory leak:

The string `config_file` is allocated in `init_configuration()` when the plugin is loaded, and then again in the callback function `on_configure_response()`.

From what I can tell it's not being freed every time the callback is called.