### PR TITLE
projectorganizer : add shortcut to focus sidebar project tab

### DIFF
--- a/projectorganizer/src/prjorg-menu.c
+++ b/projectorganizer/src/prjorg-menu.c
@@ -42,6 +42,7 @@ enum
 	KB_FIND_IN_PROJECT,
 	KB_FIND_FILE,
 	KB_FIND_TAG,
+	KB_FOCUS_TAB,
 	KB_COUNT
 };
 
@@ -225,6 +226,9 @@ static gboolean kb_callback(guint key_id)
 		case KB_FIND_TAG:
 			on_find_tag(NULL, NULL);
 			return TRUE;
+		case KB_FOCUS_TAB:
+			prjorg_sidebar_focus();
+			return TRUE;
 	}
 	return FALSE;
 }
@@ -379,6 +383,9 @@ void prjorg_menu_init(void)
 	s_sep_item = gtk_separator_menu_item_new();
 	gtk_widget_show(s_sep_item);
 	gtk_container_add(GTK_CONTAINER(geany->main_widgets->project_menu), s_sep_item);
+
+	keybindings_set_item(key_group, KB_FOCUS_TAB, NULL,
+		0, 0, "focus_tab", _("Focus project tab"), NULL);
 
 	image = gtk_image_new_from_stock(GTK_STOCK_FIND, GTK_ICON_SIZE_MENU);
 	gtk_widget_show(image);

--- a/projectorganizer/src/prjorg-sidebar.c
+++ b/projectorganizer/src/prjorg-sidebar.c
@@ -63,6 +63,7 @@ static GtkWidget *s_file_view_vbox = NULL;
 static GtkWidget *s_file_view = NULL;
 static GtkTreeStore *s_file_store = NULL;
 static gboolean s_follow_editor = TRUE;
+static gint sidebar_page_number = 0;
 
 static struct
 {
@@ -1724,7 +1725,7 @@ void prjorg_sidebar_init(void)
 	gtk_box_pack_start(GTK_BOX(s_file_view_vbox), scrollwin, TRUE, TRUE, 0);
 
 	gtk_widget_show_all(s_file_view_vbox);
-	gtk_notebook_append_page(GTK_NOTEBOOK(geany->main_widgets->sidebar_notebook),
+	sidebar_page_number = gtk_notebook_append_page(GTK_NOTEBOOK(geany->main_widgets->sidebar_notebook),
 				 s_file_view_vbox, gtk_label_new(_("Project")));
 }
 
@@ -1732,6 +1733,11 @@ void prjorg_sidebar_init(void)
 void prjorg_sidebar_activate(gboolean activate)
 {
 	gtk_widget_set_sensitive(s_file_view_vbox, activate);
+}
+
+void prjorg_sidebar_focus(void)
+{
+	gtk_notebook_set_current_page(GTK_NOTEBOOK(geany->main_widgets->sidebar_notebook), sidebar_page_number);
 }
 
 

--- a/projectorganizer/src/prjorg-sidebar.h
+++ b/projectorganizer/src/prjorg-sidebar.h
@@ -23,6 +23,7 @@
 void prjorg_sidebar_init(void);
 void prjorg_sidebar_cleanup(void);
 void prjorg_sidebar_activate(gboolean activate);
+void prjorg_sidebar_focus(void);
 
 void prjorg_sidebar_find_file_in_active(void);
 void prjorg_sidebar_find_tag_in_active(void);


### PR DESCRIPTION
So one can easily switch between tabs with keyboard.

This is my first contribution here, I hope I've done everything correctly...
Thanks