### PR TITLE
NEWS: removed 'Fix misplaced '#define SCOPE_MAX_EVALUATE_EXPR_LENGTH (PR #885)'

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -47,7 +47,6 @@ Geany Plugins 1.36 (not yet released)
     
     Scope:
     * Improve evaluation on-hover (PR #823)
-    * Fix misplaced '#define SCOPE_MAX_EVALUATE_EXPR_LENGTH' (PR #885)
 
     Tableconvert: 
     * Fix deprecated GTK call for GTK+3 (PR #859)


### PR DESCRIPTION
This issue was only a temporary problem during 1.36 development. The issue that was fixed did not exist in 1.35 so this bugfix shouldn't be mentioned in NEWS.