### PR TITLE
Overview: initialize color variables

### DIFF
--- a/overview/overview/overviewscintilla.c
+++ b/overview/overview/overviewscintilla.c
@@ -796,14 +796,14 @@ overview_scintilla_get_property (GObject      *object,
       break;
     case PROP_OVERLAY_COLOR:
       {
-        OverviewColor color;
+        OverviewColor color = { 0 };
         overview_scintilla_get_overlay_color (self, &color);
         g_value_set_boxed (value, &color);
         break;
       }
     case PROP_OVERLAY_OUTLINE_COLOR:
       {
-        OverviewColor color;
+        OverviewColor color = { 0 };
         overview_scintilla_get_overlay_outline_color (self, &color);
         g_value_set_boxed (value, &color);
         break;


### PR DESCRIPTION
While this might not be necessary technically, cppcheck complained:
overviewscintilla.c:800:53: note: Calling function 'overview_scintilla_get_overlay_color', 2nd argument '&color' value is <Uninit>
        overview_scintilla_get_overlay_color (self, &color);
                                                    ^
overviewscintilla.c:1146:11: note: Uninitialized variable: color