### PR TITLE
Improved the color-calltip macros

### DIFF
--- a/addons/README
+++ b/addons/README
@@ -103,10 +103,14 @@ a menu item in the Tools menu.
 *Show colorized calltip on hovering over a color value*
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 This extension will show a calltip if the mouse is hovered over a color
-value like #fff or #ffffff. The calltip background color represents the
-color value over which the mouse is hovered. The preferences option "Show
-a calltip when hovering over a color value" is used to enable or disable
-the extension.
+value like #fff, #ffffff, 0xfff, or 0xffffff. The calltip background color
+represents the color value over which the mouse is hovered. The preferences
+option "Show a calltip when hovering over a color value" is used to enable
+or disable the extension.
+
+The calltip can be customized at compile-time by specifying the value of
+the `COLOR_TIP_TEMPLATE` macro (i.e. `-DCOLOR_TIP_TEMPLATE='STRING'`) or
+by specifying `-DLARGE_COLOR_TIP=1` (large) or `-DLARGE_COLOR_TIP=2` (larger).
 
 *Open Color Chooser on double clicking on a color value*
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/addons/src/ao_colortip.c
+++ b/addons/src/ao_colortip.c
@@ -32,15 +32,6 @@ typedef struct _AoColorTipPrivate			AoColorTipPrivate;
 #define AO_COLORTIP_GET_PRIVATE(obj)		(G_TYPE_INSTANCE_GET_PRIVATE((obj),\
 			AO_COLORTIP_TYPE, AoColorTipPrivate))
 
-// This is helpful for making the color-tip larger on 4K screens or for people with less acute vision 
-#if (!(defined(COLOR_TIP_TEMPLATE) || defined(LARGE_COLOR_TIP)))
-#   define COLOR_TIP_TEMPLATE   "    "
-#elif (!defined(COLOR_TIP_TEMPLATE) && defined(LARGE_COLOR_TIP) && LARGE_COLOR_TIP == 1)
-#   define COLOR_TIP_TEMPLATE   "        \n        "
-#elif (!defined(COLOR_TIP_TEMPLATE) && defined(LARGE_COLOR_TIP) && LARGE_COLOR_TIP == 2)
-#   define COLOR_TIP_TEMPLATE   "        \n        \n        "
-#endif
-
 struct _AoColorTip
 {
 	GObject parent;

--- a/addons/src/ao_colortip.c
+++ b/addons/src/ao_colortip.c
@@ -33,7 +33,6 @@ typedef struct _AoColorTipPrivate			AoColorTipPrivate;
 			AO_COLORTIP_TYPE, AoColorTipPrivate))
 
 // This is helpful for making the color-tip larger on 4K screens or for people with less acute vision 
-// This is helpful for making the color-tip larger on 4K screens or for people with less acute vision 
 #if (!(defined(COLOR_TIP_TEMPLATE) || defined(LARGE_COLOR_TIP)))
 #   define COLOR_TIP_TEMPLATE   "    "
 #elif (!defined(COLOR_TIP_TEMPLATE) && defined(LARGE_COLOR_TIP) && LARGE_COLOR_TIP == 1)

--- a/addons/src/ao_colortip.c
+++ b/addons/src/ao_colortip.c
@@ -33,10 +33,13 @@ typedef struct _AoColorTipPrivate			AoColorTipPrivate;
 			AO_COLORTIP_TYPE, AoColorTipPrivate))
 
 // This is helpful for making the color-tip larger on 4K screens or for people with less acute vision 
+// This is helpful for making the color-tip larger on 4K screens or for people with less acute vision 
 #if (!(defined(COLOR_TIP_TEMPLATE) || defined(LARGE_COLOR_TIP)))
 #   define COLOR_TIP_TEMPLATE   "    "
-#else
+#elif (!defined(COLOR_TIP_TEMPLATE) && defined(LARGE_COLOR_TIP) && LARGE_COLOR_TIP == 1)
 #   define COLOR_TIP_TEMPLATE   "        \n        "
+#elif (!defined(COLOR_TIP_TEMPLATE) && defined(LARGE_COLOR_TIP) && LARGE_COLOR_TIP == 2)
+#   define COLOR_TIP_TEMPLATE   "        \n        \n        "
 #endif
 
 struct _AoColorTip

--- a/addons/src/ao_colortip.h
+++ b/addons/src/ao_colortip.h
@@ -46,4 +46,15 @@ void		ao_color_tip_editor_notify	(AoColorTip *colortip, GeanyEditor *editor, SCN
 
 G_END_DECLS
 
+
+// This is helpful for making the color-tip larger on 4K screens or for people with less acute vision 
+#if (!(defined(COLOR_TIP_TEMPLATE) || defined(LARGE_COLOR_TIP)))
+#   define COLOR_TIP_TEMPLATE   "    "
+#elif (!defined(COLOR_TIP_TEMPLATE) && defined(LARGE_COLOR_TIP) && LARGE_COLOR_TIP == 1)
+#   define COLOR_TIP_TEMPLATE   "        \n        "
+#elif (!defined(COLOR_TIP_TEMPLATE) && defined(LARGE_COLOR_TIP) && LARGE_COLOR_TIP == 2)
+#   define COLOR_TIP_TEMPLATE   "        \n        \n        "
+#endif
+
+
 #endif /* __AO_COLORTIP_H__ */


### PR DESCRIPTION
I improved the color-calltip macros and described its use in the "README" file.

Someday, I hope to add adjustable settings for this that are accessible in the autogen.sh file.