### PR TITLE
projectorganizer: Make showing empty directories in the sidebar configurable

### DIFF
--- a/projectorganizer/src/prjorg-project.c
+++ b/projectorganizer/src/prjorg-project.c
@@ -37,6 +37,7 @@ typedef struct
 	GtkWidget *header_patterns;
 	GtkWidget *ignored_dirs_patterns;
 	GtkWidget *ignored_file_patterns;
+	GtkWidget *show_empty_dirs;
 	GtkWidget *generate_tag_prefs;
 } PropertyDialogElements;
 
@@ -118,7 +119,7 @@ static GSList *get_file_list(const gchar *utf8_path, GSList *patterns,
 						ignored_file_patterns, visited_paths);
 				if (lst)
 					list = g_slist_concat(list, lst);
-				else
+				else if (prj_org->show_empty_dirs)
 					list = g_slist_prepend(list, g_build_path(G_DIR_SEPARATOR_S, utf8_filename, PROJORG_DIR_ENTRY, NULL));
 			}
 		}
@@ -332,7 +333,8 @@ static void update_project(
 	gchar **header_patterns,
 	gchar **ignored_dirs_patterns,
 	gchar **ignored_file_patterns,
-	PrjOrgTagPrefs generate_tag_prefs)
+	PrjOrgTagPrefs generate_tag_prefs,
+	gboolean show_empty_dirs)
 {
 	if (prj_org->source_patterns)
 		g_strfreev(prj_org->source_patterns);
@@ -351,6 +353,7 @@ static void update_project(
 	prj_org->ignored_file_patterns = g_strdupv(ignored_file_patterns);
 
 	prj_org->generate_tag_prefs = generate_tag_prefs;
+	prj_org->show_empty_dirs = show_empty_dirs;
 
 	prjorg_project_rescan();
 }
@@ -373,6 +376,7 @@ void prjorg_project_save(GKeyFile * key_file)
 	g_key_file_set_string_list(key_file, "prjorg", "ignored_file_patterns",
 		(const gchar**) prj_org->ignored_file_patterns, g_strv_length(prj_org->ignored_file_patterns));
 	g_key_file_set_integer(key_file, "prjorg", "generate_tag_prefs", prj_org->generate_tag_prefs);
+	g_key_file_set_boolean(key_file, "prjorg", "show_empty_dirs", prj_org->show_empty_dirs);
 
 	array = g_ptr_array_new();
 	lst = prj_org->roots->next;
@@ -469,6 +473,7 @@ void prjorg_project_open(GKeyFile * key_file)
 {
 	gchar **source_patterns, **header_patterns, **ignored_dirs_patterns, **ignored_file_patterns, **external_dirs, **dir_ptr, *last_name;
 	gint generate_tag_prefs;
+	gboolean show_empty_dirs;
 	GSList *elem = NULL, *ext_list = NULL;
 	gchar *utf8_base_path;
 
@@ -482,6 +487,7 @@ void prjorg_project_open(GKeyFile * key_file)
 	prj_org->ignored_dirs_patterns = NULL;
 	prj_org->ignored_file_patterns = NULL;
 	prj_org->generate_tag_prefs = PrjOrgTagAuto;
+	prj_org->show_empty_dirs = TRUE;
 
 	source_patterns = g_key_file_get_string_list(key_file, "prjorg", "source_patterns", NULL, NULL);
 	if (!source_patterns)
@@ -496,6 +502,7 @@ void prjorg_project_open(GKeyFile * key_file)
 	if (!ignored_file_patterns)
 		ignored_file_patterns = g_strsplit("*.o *.obj *.a *.lib *.so *.dll *.lo *.la *.class *.jar *.pyc *.mo *.gmo", " ", -1);
 	generate_tag_prefs = utils_get_setting_integer(key_file, "prjorg", "generate_tag_prefs", PrjOrgTagAuto);
+	show_empty_dirs = utils_get_setting_boolean(key_file, "prjorg", "show_empty_dirs", TRUE);
 
 	external_dirs = g_key_file_get_string_list(key_file, "prjorg", "external_dirs", NULL, NULL);
 	foreach_strv (dir_ptr, external_dirs)
@@ -520,7 +527,8 @@ void prjorg_project_open(GKeyFile * key_file)
 		header_patterns,
 		ignored_dirs_patterns,
 		ignored_file_patterns,
-		generate_tag_prefs);
+		generate_tag_prefs,
+		show_empty_dirs);
 
 	g_strfreev(source_patterns);
 	g_strfreev(header_patterns);
@@ -559,7 +567,8 @@ void prjorg_project_read_properties_tab(void)
 
 	update_project(
 		source_patterns, header_patterns, ignored_dirs_patterns, ignored_file_patterns,
-		gtk_combo_box_get_active(GTK_COMBO_BOX(e->generate_tag_prefs)));
+		gtk_combo_box_get_active(GTK_COMBO_BOX(e->generate_tag_prefs)),
+		gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(e->show_empty_dirs)));
 
 	g_strfreev(source_patterns);
 	g_strfreev(header_patterns);
@@ -580,8 +589,8 @@ GtkWidget *prjorg_project_add_properties_tab(GtkWidget *notebook)
 	vbox = gtk_vbox_new(FALSE, 0);
 
 	table = gtk_table_new(5, 2, FALSE);
-	gtk_table_set_row_spacings(GTK_TABLE(table), 5);
-	gtk_table_set_col_spacings(GTK_TABLE(table), 10);
+	gtk_table_set_row_spacings(GTK_TABLE(table), 6);
+	gtk_table_set_col_spacings(GTK_TABLE(table), 12);
 
 	label = gtk_label_new(_("Source patterns:"));
 	gtk_misc_set_alignment(GTK_MISC(label), 0, 0);
@@ -631,6 +640,35 @@ GtkWidget *prjorg_project_add_properties_tab(GtkWidget *notebook)
 	gtk_entry_set_text(GTK_ENTRY(e->ignored_dirs_patterns), str);
 	g_free(str);
 
+	gtk_box_pack_start(GTK_BOX(vbox), table, FALSE, FALSE, 6);
+
+	hbox1 = gtk_hbox_new(FALSE, 0);
+	label = gtk_label_new(_("The patterns above affect only sidebar and indexing and are not used in the Find in Files\n"
+	"dialog. You can further restrict the files belonging to the project by setting the\n"
+	"File Patterns under the Project tab (these are also used for the Find in Files dialog)."));
+	gtk_box_pack_start(GTK_BOX(hbox1), label, FALSE, FALSE, 12);
+	gtk_box_pack_start(GTK_BOX(vbox), hbox1, FALSE, FALSE, 0);
+
+	hbox1 = gtk_hbox_new(FALSE, 0);
+	label = gtk_label_new(NULL);
+	gtk_label_set_markup(GTK_LABEL(label), _("<b>Various</b>"));
+	gtk_box_pack_start(GTK_BOX(hbox1), label, FALSE, FALSE, 0);
+	gtk_box_pack_start(GTK_BOX(vbox), hbox1, FALSE, FALSE, 12);
+
+	hbox1 = gtk_hbox_new(FALSE, 0);
+	e->show_empty_dirs = gtk_check_button_new_with_label(_("Show empty directories in sidebar"));
+	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(e->show_empty_dirs), prj_org->show_empty_dirs);
+	gtk_widget_set_tooltip_text(e->show_empty_dirs,
+		_("Whether to show empty directories in the sidebar or not. Showing empty "
+		  "directories is useful when using file operations from the context menu, "
+		  "e.g. to create a new file in the directory."));
+	gtk_box_pack_start(GTK_BOX(hbox1), e->show_empty_dirs, FALSE, FALSE, 12);
+	gtk_box_pack_start(GTK_BOX(vbox), hbox1, FALSE, FALSE, 0);
+
+	table = gtk_table_new(1, 2, FALSE);
+	gtk_table_set_row_spacings(GTK_TABLE(table), 6);
+	gtk_table_set_col_spacings(GTK_TABLE(table), 12);
+
 	label = gtk_label_new(_("Index all project files:"));
 	gtk_misc_set_alignment(GTK_MISC(label), 0, 0);
 	e->generate_tag_prefs = gtk_combo_box_text_new();
@@ -638,19 +676,15 @@ GtkWidget *prjorg_project_add_properties_tab(GtkWidget *notebook)
 	gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(e->generate_tag_prefs), _("Yes"));
 	gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(e->generate_tag_prefs), _("No"));
 	gtk_combo_box_set_active(GTK_COMBO_BOX(e->generate_tag_prefs), prj_org->generate_tag_prefs);
-	ui_table_add_row(GTK_TABLE(table), 4, label, e->generate_tag_prefs, NULL);
 	gtk_widget_set_tooltip_text(e->generate_tag_prefs,
 		_("Generate symbol list for all project files instead of only for the currently opened files. "
 		  "Might be slow for big projects."));
 
-	gtk_box_pack_start(GTK_BOX(vbox), table, FALSE, FALSE, 6);
+	ui_table_add_row(GTK_TABLE(table), 1, label, e->generate_tag_prefs, NULL);
 
 	hbox1 = gtk_hbox_new(FALSE, 0);
-	label = gtk_label_new(_("Note: the patterns above affect only the sidebar and are not used in the Find in Files\n"
-	"dialog. You can further restrict the files belonging to the project by setting the\n"
-	"File Patterns under the Project tab (these are also used for the Find in Files dialog)."));
-	gtk_box_pack_start(GTK_BOX(hbox1), label, FALSE, FALSE, 0);
-	gtk_box_pack_start(GTK_BOX(vbox), hbox1, FALSE, FALSE, 6);
+	gtk_box_pack_start(GTK_BOX(hbox1), table, FALSE, FALSE, 12);
+	gtk_box_pack_start(GTK_BOX(vbox), hbox1, FALSE, FALSE, 0);
 
 	label = gtk_label_new("Project Organizer");
 

--- a/projectorganizer/src/prjorg-project.h
+++ b/projectorganizer/src/prjorg-project.h
@@ -38,6 +38,7 @@ typedef struct
 	gchar **header_patterns;
 	gchar **ignored_dirs_patterns;
 	gchar **ignored_file_patterns;
+	gboolean show_empty_dirs;
 	PrjOrgTagPrefs generate_tag_prefs;
 
 	GSList *roots;  /* list of PrjOrgRoot; the project root is always the first followed by external dirs roots */


### PR DESCRIPTION
When file operations were added to project organizer, the plugin started
showing empty directories in the sidebar because they are useful e.g.
for creating new files inside them. This may be unwanted e.g. in projects
with many directories which are irrelevant to the code.

This patch makes this configurable on a per-project basis.

Fixes #881