### PR TITLE
projectorganizer: don't use stock icons

### DIFF
--- a/projectorganizer/src/prjorg-menu.c
+++ b/projectorganizer/src/prjorg-menu.c
@@ -373,7 +373,6 @@ static void on_open_selected_file(GtkMenuItem *menuitem, gpointer user_data)
 
 void prjorg_menu_init(void)
 {
-	GtkWidget *image;
 	GeanyKeyGroup *key_group = plugin_set_key_group(geany_plugin, "ProjectOrganizer", KB_COUNT, kb_callback);
 
 	s_sep_item = gtk_separator_menu_item_new();

--- a/projectorganizer/src/prjorg-menu.c
+++ b/projectorganizer/src/prjorg-menu.c
@@ -380,31 +380,19 @@ void prjorg_menu_init(void)
 	gtk_widget_show(s_sep_item);
 	gtk_container_add(GTK_CONTAINER(geany->main_widgets->project_menu), s_sep_item);
 
-	image = gtk_image_new_from_stock(GTK_STOCK_FIND, GTK_ICON_SIZE_MENU);
-	gtk_widget_show(image);
-	s_fif_item = gtk_image_menu_item_new_with_mnemonic(_("Find in Project Files..."));
-	gtk_image_menu_item_set_image(GTK_IMAGE_MENU_ITEM(s_fif_item), image);
-	gtk_widget_show(s_fif_item);
+	s_fif_item = menu_item_new("edit-find", _("Find in Project Files..."));
 	gtk_container_add(GTK_CONTAINER(geany->main_widgets->project_menu), s_fif_item);
 	g_signal_connect((gpointer) s_fif_item, "activate", G_CALLBACK(on_find_in_project), NULL);
 	keybindings_set_item(key_group, KB_FIND_IN_PROJECT, NULL,
 		0, 0, "find_in_project", _("Find in project files"), s_fif_item);
 
-	image = gtk_image_new_from_stock(GTK_STOCK_FIND, GTK_ICON_SIZE_MENU);
-	gtk_widget_show(image);
-	s_ff_item = gtk_image_menu_item_new_with_mnemonic(_("Find Project File..."));
-	gtk_image_menu_item_set_image(GTK_IMAGE_MENU_ITEM(s_ff_item), image);
-	gtk_widget_show(s_ff_item);
+	s_ff_item = menu_item_new("edit-find", _("Find Project File..."));
 	gtk_container_add(GTK_CONTAINER(geany->main_widgets->project_menu), s_ff_item);
 	g_signal_connect((gpointer) s_ff_item, "activate", G_CALLBACK(on_find_file), NULL);
 	keybindings_set_item(key_group, KB_FIND_FILE, NULL,
 		0, 0, "find_file", _("Find project file"), s_ff_item);
 
-	image = gtk_image_new_from_stock(GTK_STOCK_FIND, GTK_ICON_SIZE_MENU);
-	gtk_widget_show(image);
-	s_ft_item = gtk_image_menu_item_new_with_mnemonic(_("Find Project Symbol..."));
-	gtk_image_menu_item_set_image(GTK_IMAGE_MENU_ITEM(s_ft_item), image);
-	gtk_widget_show(s_ft_item);
+	s_ft_item = menu_item_new("edit-find", _("Find Project Symbol..."));
 	gtk_container_add(GTK_CONTAINER(geany->main_widgets->project_menu), s_ft_item);
 	g_signal_connect((gpointer) s_ft_item, "activate", G_CALLBACK(on_find_tag), NULL);
 	keybindings_set_item(key_group, KB_FIND_TAG, NULL,

--- a/projectorganizer/src/prjorg-sidebar.c
+++ b/projectorganizer/src/prjorg-sidebar.c
@@ -1537,14 +1537,14 @@ void prjorg_sidebar_init(void)
 	item = GTK_WIDGET(gtk_separator_tool_item_new());
 	gtk_container_add(GTK_CONTAINER(s_toolbar), item);
 
-	image = gtk_image_new_from_icon_name("list-add", GTK_ICON_SIZE_SMALL_TOOLBAR);
+	image = gtk_image_new_from_icon_name("go-down", GTK_ICON_SIZE_SMALL_TOOLBAR);
 	item = GTK_WIDGET(gtk_tool_button_new(image, NULL));
 	gtk_widget_set_tooltip_text(item, _("Expand all"));
 	g_signal_connect(item, "clicked", G_CALLBACK(on_expand_all), NULL);
 	gtk_container_add(GTK_CONTAINER(s_toolbar), item);
 	s_project_toolbar.expand = item;
 
-	image = gtk_image_new_from_icon_name("list-remove", GTK_ICON_SIZE_SMALL_TOOLBAR);
+	image = gtk_image_new_from_icon_name("go-up", GTK_ICON_SIZE_SMALL_TOOLBAR);
 	item = GTK_WIDGET(gtk_tool_button_new(image, NULL));
 	gtk_widget_set_tooltip_text(item, _("Collapse to project root"));
 	g_signal_connect(item, "clicked", G_CALLBACK(on_collapse_all), NULL);
@@ -1610,7 +1610,7 @@ void prjorg_sidebar_init(void)
 
 	s_popup_menu.widget = gtk_menu_new();
 
-	item = menu_item_new("list-add", _("Expand All"));
+	item = menu_item_new("go-down", _("Expand All"));
 	gtk_container_add(GTK_CONTAINER(s_popup_menu.widget), item);
 	g_signal_connect((gpointer) item, "activate", G_CALLBACK(expand_all), NULL);
 	s_popup_menu.expand = item;
@@ -1653,12 +1653,12 @@ void prjorg_sidebar_init(void)
 	g_signal_connect((gpointer) item, "activate", G_CALLBACK(on_create_dir), NULL);
 	s_popup_menu.create_dir = item;
 
-	item = menu_item_new(NULL, _("Rename..."));
+	item = menu_item_new("document-save-as", _("Rename..."));
 	gtk_container_add(GTK_CONTAINER(s_popup_menu.widget), item);
 	g_signal_connect((gpointer) item, "activate", G_CALLBACK(on_rename), NULL);
 	s_popup_menu.rename = item;
 
-	item = menu_item_new("list-remove", _("Delete"));
+	item = menu_item_new("edit-delete", _("Delete"));
 	gtk_container_add(GTK_CONTAINER(s_popup_menu.widget), item);
 	g_signal_connect((gpointer) item, "activate", G_CALLBACK(on_delete), NULL);
 	s_popup_menu.delete = item;

--- a/projectorganizer/src/prjorg-sidebar.c
+++ b/projectorganizer/src/prjorg-sidebar.c
@@ -1610,38 +1610,22 @@ void prjorg_sidebar_init(void)
 
 	s_popup_menu.widget = gtk_menu_new();
 
-	image = gtk_image_new_from_icon_name("list-add", GTK_ICON_SIZE_MENU);
-	gtk_widget_show(image);
-	item = gtk_image_menu_item_new_with_mnemonic(_("Expand All"));
-	gtk_image_menu_item_set_image(GTK_IMAGE_MENU_ITEM(item), image);
-	gtk_widget_show(item);
+	item = menu_item_new("list-add", _("Expand All"));
 	gtk_container_add(GTK_CONTAINER(s_popup_menu.widget), item);
 	g_signal_connect((gpointer) item, "activate", G_CALLBACK(expand_all), NULL);
 	s_popup_menu.expand = item;
 
-	image = gtk_image_new_from_stock(GTK_STOCK_FIND, GTK_ICON_SIZE_MENU);
-	gtk_widget_show(image);
-	item = gtk_image_menu_item_new_with_mnemonic(_("Find in Files..."));
-	gtk_image_menu_item_set_image(GTK_IMAGE_MENU_ITEM(item), image);
-	gtk_widget_show(item);
+	item = menu_item_new("edit-find", _("Find in Files..."));
 	gtk_container_add(GTK_CONTAINER(s_popup_menu.widget), item);
 	g_signal_connect((gpointer) item, "activate", G_CALLBACK(on_find_in_files), NULL);
 	s_popup_menu.find_in_directory = item;
 
-	image = gtk_image_new_from_stock(GTK_STOCK_FIND, GTK_ICON_SIZE_MENU);
-	gtk_widget_show(image);
-	item = gtk_image_menu_item_new_with_mnemonic(_("Find File..."));
-	gtk_image_menu_item_set_image(GTK_IMAGE_MENU_ITEM(item), image);
-	gtk_widget_show(item);
+	item = menu_item_new("edit-find", _("Find File..."));
 	gtk_container_add(GTK_CONTAINER(s_popup_menu.widget), item);
 	g_signal_connect((gpointer) item, "activate", G_CALLBACK(on_find_file), NULL);
 	s_popup_menu.find_file = item;
 
-	image = gtk_image_new_from_stock(GTK_STOCK_FIND, GTK_ICON_SIZE_MENU);
-	gtk_widget_show(image);
-	item = gtk_image_menu_item_new_with_mnemonic(_("Find Symbol..."));
-	gtk_image_menu_item_set_image(GTK_IMAGE_MENU_ITEM(item), image);
-	gtk_widget_show(item);
+	item = menu_item_new("edit-find", _("Find Symbol..."));
 	gtk_container_add(GTK_CONTAINER(s_popup_menu.widget), item);
 	g_signal_connect((gpointer) item, "activate", G_CALLBACK(on_find_tag), NULL);
 	s_popup_menu.find_tag = item;
@@ -1650,11 +1634,7 @@ void prjorg_sidebar_init(void)
 	gtk_widget_show(item);
 	gtk_container_add(GTK_CONTAINER(s_popup_menu.widget), item);
 
-	image = gtk_image_new_from_stock(GTK_STOCK_REMOVE, GTK_ICON_SIZE_MENU);
-	gtk_widget_show(image);
-	item = gtk_image_menu_item_new_with_mnemonic(_("Remove External Directory"));
-	gtk_image_menu_item_set_image(GTK_IMAGE_MENU_ITEM(item), image);
-	gtk_widget_show(item);
+	item = menu_item_new("list-remove", _("Remove External Directory"));
 	gtk_container_add(GTK_CONTAINER(s_popup_menu.widget), item);
 	g_signal_connect((gpointer) item, "activate", G_CALLBACK(on_remove_external_dir), NULL);
 	s_popup_menu.remove_external_dir = item;
@@ -1663,38 +1643,22 @@ void prjorg_sidebar_init(void)
 	gtk_widget_show(item);
 	gtk_container_add(GTK_CONTAINER(s_popup_menu.widget), item);
 
-	image = gtk_image_new_from_stock(GTK_STOCK_FILE, GTK_ICON_SIZE_MENU);
-	gtk_widget_show(image);
-	item = gtk_image_menu_item_new_with_mnemonic(_("New File..."));
-	gtk_image_menu_item_set_image(GTK_IMAGE_MENU_ITEM(item), image);
-	gtk_widget_show(item);
+	item = menu_item_new("document-new", _("New File..."));
 	gtk_container_add(GTK_CONTAINER(s_popup_menu.widget), item);
 	g_signal_connect((gpointer) item, "activate", G_CALLBACK(on_create_file), NULL);
 	s_popup_menu.create_file = item;
 
-	image = gtk_image_new_from_stock(GTK_STOCK_DIRECTORY, GTK_ICON_SIZE_MENU);
-	gtk_widget_show(image);
-	item = gtk_image_menu_item_new_with_mnemonic(_("New Directory..."));
-	gtk_image_menu_item_set_image(GTK_IMAGE_MENU_ITEM(item), image);
-	gtk_widget_show(item);
+	item = menu_item_new("folder-new", _("New Directory..."));
 	gtk_container_add(GTK_CONTAINER(s_popup_menu.widget), item);
 	g_signal_connect((gpointer) item, "activate", G_CALLBACK(on_create_dir), NULL);
 	s_popup_menu.create_dir = item;
 
-	image = gtk_image_new_from_stock(GTK_STOCK_EDIT, GTK_ICON_SIZE_MENU);
-	gtk_widget_show(image);
-	item = gtk_image_menu_item_new_with_mnemonic(_("Rename..."));
-	gtk_image_menu_item_set_image(GTK_IMAGE_MENU_ITEM(item), image);
-	gtk_widget_show(item);
+	item = menu_item_new(NULL, _("Rename..."));
 	gtk_container_add(GTK_CONTAINER(s_popup_menu.widget), item);
 	g_signal_connect((gpointer) item, "activate", G_CALLBACK(on_rename), NULL);
 	s_popup_menu.rename = item;
 
-	image = gtk_image_new_from_stock(GTK_STOCK_REMOVE, GTK_ICON_SIZE_MENU);
-	gtk_widget_show(image);
-	item = gtk_image_menu_item_new_with_mnemonic(_("Delete"));
-	gtk_image_menu_item_set_image(GTK_IMAGE_MENU_ITEM(item), image);
-	gtk_widget_show(item);
+	item = menu_item_new("list-remove", _("Delete"));
 	gtk_container_add(GTK_CONTAINER(s_popup_menu.widget), item);
 	g_signal_connect((gpointer) item, "activate", G_CALLBACK(on_delete), NULL);
 	s_popup_menu.delete = item;
@@ -1703,10 +1667,7 @@ void prjorg_sidebar_init(void)
 	gtk_widget_show(item);
 	gtk_container_add(GTK_CONTAINER(s_popup_menu.widget), item);
 
-	item = gtk_image_menu_item_new_with_mnemonic(_("H_ide Sidebar"));
-	gtk_image_menu_item_set_image(GTK_IMAGE_MENU_ITEM(item),
-					  gtk_image_new_from_stock(GTK_STOCK_CLOSE, GTK_ICON_SIZE_MENU));
-	gtk_widget_show(item);
+	item = menu_item_new("window-close", _("H_ide Sidebar"));
 	gtk_container_add(GTK_CONTAINER(s_popup_menu.widget), item);
 	g_signal_connect_swapped((gpointer) item, "activate",
 				 G_CALLBACK(keybindings_send_command),

--- a/projectorganizer/src/prjorg-utils.c
+++ b/projectorganizer/src/prjorg-utils.c
@@ -226,3 +226,18 @@ gchar *get_project_base_path(void)
 	}
 	return NULL;
 }
+
+
+GtkWidget *menu_item_new(const gchar *icon_name, const gchar *label)
+{
+	GtkWidget *item = gtk_image_menu_item_new_with_mnemonic(label);
+
+	if (icon_name != NULL)
+	{
+		GtkWidget *image = gtk_image_new_from_icon_name(icon_name, GTK_ICON_SIZE_MENU);
+		gtk_image_menu_item_set_image(GTK_IMAGE_MENU_ITEM(item), image);
+		gtk_widget_show(image);
+	}
+	gtk_widget_show(item);
+	return item;
+}

--- a/projectorganizer/src/prjorg-utils.h
+++ b/projectorganizer/src/prjorg-utils.h
@@ -35,4 +35,6 @@ gboolean rename_file_or_dir(gchar *utf8_oldname, gchar *utf8_newname);
 gchar *get_selection(void);
 gchar *get_project_base_path(void);
 
+GtkWidget *menu_item_new(const gchar *icon_name, const gchar *label);
+
 #endif


### PR DESCRIPTION
There is more choice when using icons based on freedesktop icon name
so we can use better icons.

This is mainly because of "New file" and "New directory" icons in the popup menu in the sidebar which should use action icons instead of icons of a file and a directory (with some themes all action icons are black and white while document/directory icons have a color which looks inappropriate in this case).