### PR TITLE
cppcheck: Set Geany include path for it to find header files

### DIFF
--- a/build/compat.m4
+++ b/build/compat.m4
@@ -1,3 +1,9 @@
+dnl taken from Autoconf's m4sh.m4, GPLv3+
+m4_ifndef([AS_VAR_COPY], [
+m4_define([AS_VAR_COPY],
+[AS_LITERAL_WORD_IF([$1[]$2], [$1=$$2], [eval $1=\$$2])])
+])
+
 dnl taken from pkg-config's pkg.m4, GPLv2+
 m4_ifndef([PKG_CHECK_VAR], [
 AC_DEFUN([PKG_CHECK_VAR],

--- a/build/compat.m4
+++ b/build/compat.m4
@@ -1,0 +1,12 @@
+dnl taken from pkg-config's pkg.m4, GPLv2+
+m4_ifndef([PKG_CHECK_VAR], [
+AC_DEFUN([PKG_CHECK_VAR],
+[AC_REQUIRE([PKG_PROG_PKG_CONFIG])dnl
+AC_ARG_VAR([$1], [value of $3 for $2, overriding pkg-config])dnl
+
+_PKG_CONFIG([$1], [variable="][$3]["], [$2])
+AS_VAR_COPY([$1], [pkg_cv_][$1])
+
+AS_VAR_IF([$1], [""], [$5], [$4])dnl
+])dnl PKG_CHECK_VAR
+])

--- a/build/cppcheck.m4
+++ b/build/cppcheck.m4
@@ -21,4 +21,8 @@ AC_DEFUN([GP_CHECK_CPPCHECK],
     AM_CONDITIONAL([HAVE_CPPCHECK], [test "x$gp_have_cppcheck" = xyes])
     GP_STATUS_BUILD_FEATURE_ADD([Static code checking],
                                 [$gp_have_cppcheck])
+
+    GP_GEANY_PKG_CONFIG_PATH_PUSH
+    PKG_CHECK_VAR([GEANY_INCLUDEDIR], [geany], [includedir], [], [])
+    GP_GEANY_PKG_CONFIG_PATH_POP
 ])

--- a/build/cppcheck.mk
+++ b/build/cppcheck.mk
@@ -4,6 +4,7 @@ if HAVE_CPPCHECK
 check-cppcheck: $(srcdir)
 	$(CPPCHECK) \
 		-q --template gcc --error-exitcode=2 \
+		-I$(GEANY_INCLUDEDIR)/geany \
 		$(AM_CPPCHECKFLAGS) $(CPPCHECKFLAGS) \
 		$(srcdir)
 


### PR DESCRIPTION
This fixes build with recent versions of *cppcheck* with some plugins using `PLUGIN_VERSION_CHECK()` macro, like the *latex* plugin.

---

@eht16 already tested this with the nightly build environment, but I'm PRing this to make sure the CI tests here also pass.  And extra review is always welcome ;)