### PR TITLE
Make libgit2 version preprocessor conditionals compatible with libgit…

### DIFF
--- a/git-changebar/src/gcb-plugin.c
+++ b/git-changebar/src/gcb-plugin.c
@@ -32,11 +32,11 @@
 #include <geany.h>
 #include <document.h>
 
-#if ! defined (LIBGIT2_SOVERSION) || LIBGIT2_SOVERSION < 22
+#if ! defined (LIBGIT2_VER_MINOR) || ( (LIBGIT2_VER_MAJOR == 0) && (LIBGIT2_VER_MINOR < 22) )
 # define git_libgit2_init     git_threads_init
 # define git_libgit2_shutdown git_threads_shutdown
 #endif
-#if ! defined (LIBGIT2_SOVERSION) || LIBGIT2_SOVERSION < 23
+#if ! defined (LIBGIT2_VER_MINOR) || ( (LIBGIT2_VER_MAJOR == 0) && (LIBGIT2_VER_MINOR < 23) )
 /* 0.23 added @p binary_cb */
 # define git_diff_buffers(old_buffer, old_len, old_as_path, \
                           new_buffer, new_len, new_as_path, options, \
@@ -45,7 +45,7 @@
                     new_buffer, new_len, new_as_path, options, \
                     file_cb, hunk_cb, line_cb, payload)
 #endif
-#if ! defined (LIBGIT2_SOVERSION) || LIBGIT2_SOVERSION < 28
+#if ! defined (LIBGIT2_VER_MINOR) || ( (LIBGIT2_VER_MAJOR == 0) && (LIBGIT2_VER_MINOR < 28) )
 # define git_buf_dispose  git_buf_free
 # define git_error_last   giterr_last
 #endif

--- a/workbench/src/plugin_main.c
+++ b/workbench/src/plugin_main.c
@@ -36,7 +36,7 @@
 #include "tm_control.h"
 
 
-#if ! defined (LIBGIT2_SOVERSION) || LIBGIT2_SOVERSION < 22
+#if ! defined (LIBGIT2_VER_MINOR) || ( (LIBGIT2_VER_MAJOR == 0) && (LIBGIT2_VER_MINOR < 22))
 # define git_libgit2_init     git_threads_init
 # define git_libgit2_shutdown git_threads_shutdown
 #endif


### PR DESCRIPTION
…2-0.99

LIBGIT2_SOVERSION is defined as string literal, e.g. "0.99",
from libgit2-0.99 and beyond. Arithmetic checks against this
variable whill hence fail. This patch switches the checks to
compare against the LIBGIT2_VER_* family, which should be more stable.