### PR TITLE
TreeBrowser: Allow new file/folder in top level

### DIFF
--- a/treebrowser/src/treebrowser.c
+++ b/treebrowser/src/treebrowser.c
@@ -1076,7 +1076,11 @@ on_menu_create_new_object(GtkMenuItem *menuitem, const gchar *type)
 				gtk_tree_model_get(model, &iter_parent, TREEBROWSER_COLUMN_URI, &uri, -1);
 			}
 			else
+			{
+				SETPTR(uri, g_path_get_dirname(uri));
+				
 				refresh_root = TRUE;
+			}
 		}
 	}
 	else


### PR DESCRIPTION
Uses the URI to get parent instead of the tree to allow for insertion at the top level.

Fixes #1152