### PR TITLE
vimode: Correctly ignore unwanted modifiers

### DIFF
--- a/vimode/src/cmd-runner.c
+++ b/vimode/src/cmd-runner.c
@@ -431,7 +431,7 @@ static gboolean is_cmdpart(GSList *kpl, CmdDef *cmds)
 
 static gboolean is_printable(GSList *kpl)
 {
-	guint mask = GDK_MODIFIER_MASK & ~(GDK_SHIFT_MASK | GDK_LOCK_MASK);
+	guint mask = gtk_accelerator_get_default_mod_mask() & ~GDK_SHIFT_MASK;
 	KeyPress *kp = g_slist_nth_data(kpl, 0);
 
 	if (kp->modif & mask)

--- a/vimode/src/excmd-prompt.c
+++ b/vimode/src/excmd-prompt.c
@@ -71,7 +71,7 @@ static void set_prompt_text(const gchar *val)
 static gboolean on_prompt_key_press_event(GtkWidget *widget, GdkEventKey *event, gpointer dummy)
 {
 	const gchar *text = gtk_entry_get_text(GTK_ENTRY(entry));
-	guint modif_mask = GDK_MODIFIER_MASK & ~GDK_LOCK_MASK;
+	guint modif_mask = gtk_accelerator_get_default_mod_mask();
 
 	ignore_change = FALSE;
 


### PR DESCRIPTION
Use gtk_accelerator_get_default_mod_mask() which should ignore caps lock
and num lock keys for us.

Fixes #941.