### PR TITLE
Sundry fixes and enhancements to the keystrokes recorder plugin

### DIFF
--- a/keyrecord/src/keyrecord.c
+++ b/keyrecord/src/keyrecord.c
@@ -42,6 +42,19 @@ static GdkEventKey** recorded_pattern;
 static guint recorded_size;
 int CAPACITY = 2;
 GeanyKeyBinding *record, *play;
+
+static GtkStatusbar *geany_statusbar;
+static GtkWidget *keyrecord_statusbar_box;
+static GtkLabel *keyrecord_state_label;
+
+static void update_status()
+{
+	if (recording)
+		gtk_widget_show(keyrecord_state_label);
+	else
+		gtk_widget_hide(keyrecord_state_label);
+}
+
 static gboolean is_record_key(GdkEventKey *event)
 {
 	return event->keyval == record->key
@@ -120,6 +133,7 @@ on_record (guint key_id)
 	{
 		recording = FALSE;
 	}
+	update_status();
 }
 
 
@@ -162,6 +176,16 @@ static gboolean keyrecord_init(GeanyPlugin *plugin, gpointer data)
 	
 	g_plugin = plugin;
 	
+	geany_statusbar = gtk_widget_get_parent(geany->main_widgets->progressbar);
+	keyrecord_statusbar_box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 5);
+	keyrecord_state_label = gtk_label_new(NULL);
+	gtk_label_set_markup(keyrecord_state_label,
+        "<span foreground='red' weight='bold'>REC</span>");
+	gtk_widget_show(keyrecord_statusbar_box);
+	gtk_container_add(keyrecord_statusbar_box, keyrecord_state_label);
+	gtk_box_pack_end(geany_statusbar, keyrecord_statusbar_box, FALSE, FALSE, 0);
+	update_status();
+
 	return TRUE;
 }
 
@@ -188,6 +212,8 @@ static void keyrecord_cleanup(GeanyPlugin *plugin, gpointer _data)
 		g_free(data);
 	}
 
+	gtk_widget_destroy(keyrecord_state_label);
+	gtk_widget_destroy(keyrecord_statusbar_box);
 }
 
 void geany_load_module(GeanyPlugin *plugin)

--- a/keyrecord/src/keyrecord.c
+++ b/keyrecord/src/keyrecord.c
@@ -126,12 +126,13 @@ on_record (guint key_id)
 static void
 on_play (guint key_id)
 {
-	//fprintf(stderr, "play: %d\n", key_id);
-	guint i;
-////	sci_start_undo_action(doc->editor->sci);
+	if (!recording)
 	{
+	//fprintf(stderr, "play: %d\n", key_id);
+    	guint i;
+////	sci_start_undo_action(doc->editor->sci);
 		for (i = 0; i < (recorded_size); i++)
-				gtk_main_do_event(recorded_pattern[i]);
+			gtk_main_do_event(recorded_pattern[i]);
 	}
 //	sci_end_undo_action(doc->editor->sci);
 }

--- a/keyrecord/src/keyrecord.c
+++ b/keyrecord/src/keyrecord.c
@@ -42,7 +42,6 @@ static GdkEventKey** recorded_pattern;
 static guint recorded_size;
 int CAPACITY = 2;
 GeanyKeyBinding *record, *play;
-GtkWidget *cur_widget;
 static gboolean is_record_key(GdkEventKey *event)
 {
 	//return (event->state & GDK_CONTROL_MASK) && (event->keyval == GDK_KEY_F1);
@@ -58,17 +57,14 @@ static gboolean is_play_key(GdkEventKey *event)
 
 
 static gboolean
-on_key_press(GtkWidget *widget, GdkEventKey *event, gpointer data)
+on_key_press(GObject *object, GdkEventKey *event, gpointer user_data)
 {
-	cur_widget = widget;
-	//GeanyDocument* doc = (GeanyDocument*)data;
 	guint i;
 	GdkEventKey** tmp = NULL;
 	
 	if ((recording) && !(is_record_key(event)||is_play_key(event)))
 	{
-		GdkEventKey* new_event = g_new0(GdkEventKey, 1);
-		*new_event = *event;
+		GdkEventKey* new_event = gdk_event_copy(event);
 		if (recorded_size == CAPACITY)
 		{
 			tmp = g_new0(GdkEventKey*, CAPACITY * 2);
@@ -80,7 +76,7 @@ on_key_press(GtkWidget *widget, GdkEventKey *event, gpointer data)
 		}
 		assert(recorded_size < CAPACITY);
 		if (recorded_pattern[(recorded_size)] != NULL)
-		   g_free(recorded_pattern[recorded_size]);
+		   gdk_event_free(recorded_pattern[recorded_size]);
 		recorded_pattern[recorded_size++] = new_event;
 	}
 	
@@ -96,8 +92,6 @@ on_document_open(GObject *obj, GeanyDocument *doc, gpointer user_data)
 	sci = doc->editor->sci;
 	data = g_new0(GeanyDocument, 1);
 	*data = *doc;
-	plugin_signal_connect(g_plugin, G_OBJECT(sci), "key-press-event",
-			FALSE, G_CALLBACK(on_key_press), data);
 	/* This will free the data when the sci is destroyed */
 	g_object_set_data_full(G_OBJECT(sci), "keyrecord-userdata", data, g_free);
 }
@@ -109,6 +103,7 @@ static PluginCallback keyrecord_callbacks[] =
 	 * can prevent Geany from processing the notification. Use this with care. */
 	{ "document-open",  (GCallback) &on_document_open, FALSE, NULL },
 	{ "document-new",   (GCallback) &on_document_open, FALSE, NULL },
+	{ "key-press", (GCallback) &on_key_press, FALSE, NULL },
 	//{ "editor-notify", (GCallback) &on_editor_notify, FALSE, NULL },
 	{ NULL, NULL, FALSE, NULL }
 };
@@ -134,16 +129,13 @@ on_play (guint key_id)
 	//fprintf(stderr, "play: %d\n", key_id);
 	guint i;
 ////	sci_start_undo_action(doc->editor->sci);
-	if (cur_widget != NULL)
 	{
 		for (i = 0; i < (recorded_size); i++)
-			gdk_display_put_event(gtk_widget_get_display(cur_widget),
-				 (GdkEvent*)(recorded_pattern[i]));
-		
-		//return TRUE;
+				gtk_main_do_event(recorded_pattern[i]);
 	}
 //	sci_end_undo_action(doc->editor->sci);
 }
+
 /* Called by Geany to initialize the plugin */
 static gboolean keyrecord_init(GeanyPlugin *plugin, gpointer data)
 {
@@ -173,10 +165,6 @@ static gboolean keyrecord_init(GeanyPlugin *plugin, gpointer data)
 }
 
 
-
-
-
-
 /* Called by Geany before unloading the plugin.
  * Here any UI changes should be removed, memory freed and any other finalization done.
  * Be sure to leave Geany as it was before demo_init(). */
@@ -185,7 +173,8 @@ static void keyrecord_cleanup(GeanyPlugin *plugin, gpointer _data)
 	GeanyData* geany_data = plugin->geany_data;
     guint i;
     for (i = 0; i < CAPACITY; i++)
-        if (recorded_pattern[i] != NULL) g_free(recorded_pattern[i]);
+        if (recorded_pattern[i] != NULL)
+			gdk_event_free(recorded_pattern[i]);
     g_free(recorded_pattern);
    
     foreach_document(i)
@@ -206,7 +195,7 @@ void geany_load_module(GeanyPlugin *plugin)
 	main_locale_init(LOCALEDIR, GETTEXT_PACKAGE);
 	plugin->info->name = _("Keystrokes recorder");
 	plugin->info->description = _("Allows to record some sequence of keystrokes and replay it");
-	plugin->info->version = "0.11";
+	plugin->info->version = "0.12";
 	plugin->info->author =  _("tunyash");
 
 	plugin->funcs->init = keyrecord_init;
@@ -215,6 +204,6 @@ void geany_load_module(GeanyPlugin *plugin)
 	plugin->funcs->cleanup = keyrecord_cleanup;
 	plugin->funcs->callbacks = keyrecord_callbacks;
 
-	GEANY_PLUGIN_REGISTER(plugin, 225);
-	
+	// API 237, Geany 1.34, PR #1829, added "key-press" signal.
+	GEANY_PLUGIN_REGISTER(plugin, 237);
 }

--- a/keyrecord/src/keyrecord.c
+++ b/keyrecord/src/keyrecord.c
@@ -44,14 +44,14 @@ int CAPACITY = 2;
 GeanyKeyBinding *record, *play;
 static gboolean is_record_key(GdkEventKey *event)
 {
-	//return (event->state & GDK_CONTROL_MASK) && (event->keyval == GDK_KEY_F1);
-	return record->key == event->keyval && (event->state & record->mods);
+	return event->keyval == record->key
+		&& (event->state & record->mods) == record->mods;
 }
 
 static gboolean is_play_key(GdkEventKey *event)
 {
-//	return (event->state & GDK_CONTROL_MASK) && (event->keyval == GDK_KEY_F2);
-	return play->key == event->keyval && (event->state & play->mods);
+	return event->keyval == play->key
+		&& (event->state & play->mods) == play->mods;
 }	
 
 


### PR DESCRIPTION
Uses the Geany "key-press" signal, allowing access to all keys, including bound ones.
Fixes a bug that prevent the use of bound keys without modifiers.
Prevents playback during recording.
Displays recording indicator on the status bar.