### PR TITLE
GeanyVC:(Fossil) Limit the width of the history log/timeline output

### DIFF
--- a/geanyvc/src/vc_fossil.c
+++ b/geanyvc/src/vc_fossil.c
@@ -27,7 +27,7 @@
 extern GeanyData *geany_data;
 
 #define FOSSIL_CLIENT "fossil"
-#define FOSSIL_CMD_LOG_WIDTH "0"  /* 0:single-line */
+#define FOSSIL_CMD_LOG_WIDTH "100"  /* 0:single-line */
 #define FOSSIL_CMD_LOG_NUM   "300"
 
 static const gchar *FOSSIL_CMD_DIFF_FILE[] = { FOSSIL_CLIENT, "diff", BASENAME, NULL };


### PR DESCRIPTION
Fixes #1003 