### PR TITLE
TreeBrowser: Avoid double node clear

### DIFF
--- a/treebrowser/src/treebrowser.c
+++ b/treebrowser/src/treebrowser.c
@@ -1629,8 +1629,7 @@ on_treeview_changed(GtkWidget *widget, gpointer user_data)
 		if (g_file_test(uri, G_FILE_TEST_EXISTS)) {
 			if (!g_file_test(uri, G_FILE_TEST_IS_DIR) && CONFIG_ONE_CLICK_CHDOC)
 				document_open_file(uri, FALSE, NULL, NULL);
-		} else
-			treebrowser_tree_store_iter_clear_nodes(&iter, TRUE);
+		}
 
 		g_free(uri);
 	}


### PR DESCRIPTION
Fixes #675 

`on_treeview_changed` is triggered during `treebrowser_tree_store_iter_clear_nodes`, leading to a double-delete.

Consistent (as far as I can tell) reproduction steps:
1. Create a folder
2. Create two new files in folder
3. Delete second file