### PR TITLE
#981: ReadMe install instructions

### DIFF
--- a/autoclose/README
+++ b/autoclose/README
@@ -42,8 +42,8 @@ Features
 Usage
 -----
 
-After installed successfully, load the plugin in Geany's plugin manager. You may
-change module preferences.
+Install the plugin (https://plugins.geany.org/install.html) then
+load it in Geany's plugin manager. You may change module preferences.
 
 Requirements
 ------------

--- a/automark/README
+++ b/automark/README
@@ -17,7 +17,8 @@ under cursor (see screenshot).
 Usage
 -----
 
-After installed successfully, load the plugin in Geany's plugin manager.
+Install the plugin (https://plugins.geany.org/install.html) then
+load it in Geany's plugin manager.
 As soon as the cursor is moved on a word, all occurences of that word will
 be highlighted. The highlight color is "marker_search".
 

--- a/codenav/README
+++ b/codenav/README
@@ -17,9 +17,10 @@ Features
 Usage
 -----
 
-After installed successfully, load the plugin in Geany's plugin manager
-and new menu items in the Edit menu will appear. You can
-change the keyboard shortcuts in Geany's preferences dialog.
+Install the plugin (https://plugins.geany.org/install.html) then
+load it in Geany's plugin manager. A new menu item in the Edit menu
+will appear. You can change the keyboard shortcuts in Geany's
+preferences dialog.
 
 
 *Switch header/implementation*

--- a/defineformat/README
+++ b/defineformat/README
@@ -12,7 +12,8 @@ write multiline defines with aligned backslash.
 Usage
 -----
 
-After installed successfully, load the plugin in Geany's plugin manager.
+Install the plugin (https://plugins.geany.org/install.html) then
+load it in Geany's plugin manager.
 Try it: open C/C++ file and type:
 
 #define A() do { \

--- a/geanypg/README
+++ b/geanypg/README
@@ -10,8 +10,9 @@ and verify signatures with GnuPG.
 Usage
 -----
 
-After installed successfully, load the plugin in Geany's plugin manager
-and a new menu item in the Tools menu will appear.
+Install the plugin (https://plugins.geany.org/install.html) then
+load it in Geany's plugin manager and a new menu item in the Tools menu
+will appear.
 
 If any text is selected, only the selected text will be encrypted/
 signed/decrypted. When encrypting a message you can choose to sign at

--- a/lipsum/README
+++ b/lipsum/README
@@ -15,6 +15,7 @@ Installation
 
 This version of the plugin is installed with the combined
 geany-plugins release. Please check README of this package
+and/or https://plugins.geany.org/install.html.
 
 
 Usage

--- a/pretty-printer/README
+++ b/pretty-printer/README
@@ -14,6 +14,7 @@ Installation
 
 This version of the plugin is installed with the combined
 geany-plugins release. Please check README of this package
+and/or https://plugins.geany.org/install.html.
 
 
 Features

--- a/shiftcolumn/README
+++ b/shiftcolumn/README
@@ -26,6 +26,7 @@ $ ./configure --help
 
 If there are any errors during compilation, check your build environment
 and try to find the error, otherwise contact one of the authors.
+More information can be found at https://plugins.geany.org/install.html.
 
 
 Usage

--- a/spellcheck/README
+++ b/spellcheck/README
@@ -28,7 +28,7 @@ Features
 
 Usage
 -----
-[Install the plugin](https://plugins.geany.org/install.html) then
+Install the plugin (https://plugins.geany.org/install.html) then
 load it in Geany's plugin manager. A new menu item in the Tools menu
 will appear. Alternatively, you can assign a keyboard shortcut in
 Geany's preferences dialog to perform a spell check.

--- a/spellcheck/README
+++ b/spellcheck/README
@@ -28,15 +28,15 @@ Features
 
 Usage
 -----
-After installed successfully, load the plugin in Geany's plugin manager
-and a new menu item in the Tools menu will appear. Alternatively, you can
-assign a keyboard shortcut in Geany's preferences dialog to perform a
-spell check.
+[Install the plugin](https://plugins.geany.org/install.html) then
+load it in Geany's plugin manager. A new menu item in the Tools menu
+will appear. Alternatively, you can assign a keyboard shortcut in
+Geany's preferences dialog to perform a spell check.
 
 
 Configuring custom dictionaries
 -------------------------------
-Especially Windows, you might need to install the dictionaries (the files
+Especially on Windows, you might need to install the dictionaries (the files
 containing the information for spell checking) manually.
 First, you need to download the dictionary files for the
 languages you want, e.g. from

--- a/updatechecker/README
+++ b/updatechecker/README
@@ -15,6 +15,7 @@ Installation
 
 This version of the plugin is installed with the combined
 geany-plugins release. Please check README of this package
+and/or https://plugins.geany.org/install.html.
 
 
 Usage


### PR DESCRIPTION
Follow-up of #981 to fix restructuredText formatting and add the install instruction link to other plugins' READMEs as well which are similarly structured.

Closes https://github.com/geany/geany/issues/2508.