### PR TITLE
Lineoperations: version compare with strverscmp

### DIFF
--- a/lineoperations/ChangeLog
+++ b/lineoperations/ChangeLog
@@ -1,3 +1,8 @@
+2020-11-29  Sylvan Mostert  <smostert.dev@gmail.com>
+
+ * add version sort
+
+
 2019-08-11  Sylvan Mostert  <smostert.dev@gmail.com>
 
  * added preferences to compare strings using linguistically correct rules

--- a/lineoperations/README
+++ b/lineoperations/README
@@ -39,16 +39,28 @@ To enable preferences ("Tools" > "Plugin Manager"), check the checkbox to
 enable Line Operations, and with the item highlighted click "Preferences"
 on bottom of the "Plugin Manager" frame.
 
-**Use collation based string compare** - When this option is enabled it will
+**Lexical Compare** - When this option is enabled it will
+compare strings based on numerical value of the characters (strcmp).
+
+  Example: Sort order using **Lexical Compare** enabled
+
+  ::
+
+    D U+0044 : LATIN CAPITAL LETTER D
+    E U+0045 : LATIN CAPITAL LETTER E
+    F U+0046 : LATIN CAPITAL LETTER F
+    d U+0064 : LATIN SMALL LETTER D
+    e U+0065 : LATIN SMALL LETTER E
+    f U+0066 : LATIN SMALL LETTER F
+    Ê U+00CA : LATIN CAPITAL LETTER E WITH CIRCUMFLEX
+    é U+00E9 : LATIN SMALL LETTER E WITH ACUTE
+
+
+**Collation Compare** - When this option is enabled it will
 compare strings using linguistically correct rules for the current locale
 (g_utf8_collate).
 
-When it is disabled it will compare strings based on numerical value of the
-characters (strcmp).
-
-This option is disabled by default.
-
-  Example: Sort order using **Use collation based string compare** enabled
+  Example: Sort order using **Collation Compare** enabled
 
   ::
 
@@ -64,20 +76,22 @@ This option is disabled by default.
   Note: all 'e' characters appear after any 'd' character and before any 'f'
   character.
 
-  Example: Sort order **Use collation based string compare** disabled
+**Version Compare** - When this option is enabled it will
+compare strings using order that feels more natural to people, when the 
+text contains a mixture of letters and digits. It first breaks down the 
+string into digits and non-digits parts, and only then compares each part
+
+  Example: Sort order using **Version Compare** enabled
 
   ::
 
-    D U+0044 : LATIN CAPITAL LETTER D
-    E U+0045 : LATIN CAPITAL LETTER E
-    F U+0046 : LATIN CAPITAL LETTER F
-    d U+0064 : LATIN SMALL LETTER D
-    e U+0065 : LATIN SMALL LETTER E
-    f U+0066 : LATIN SMALL LETTER F
-    Ê U+00CA : LATIN CAPITAL LETTER E WITH CIRCUMFLEX
-    é U+00E9 : LATIN SMALL LETTER E WITH ACUTE
+    Alphabetical sort:           Version Sort:
 
-  Note: all the 'e' characters do not appear together.
+    a1                           a1
+    a120                         a2
+    a13                          a13
+    a2                           a120
+
 
 
 Selection

--- a/lineoperations/src/lineoperations.c
+++ b/lineoperations/src/lineoperations.c
@@ -377,7 +377,7 @@ void geany_load_module(GeanyPlugin *plugin)
 
 	plugin->info->name        = _("Line Operations");
 	plugin->info->description = _("Line Operations provides a handful of functions that can be applied to a document or selection such as, removing duplicate lines, removing empty lines, removing lines with only whitespace, and sorting lines.");
-	plugin->info->version     = "0.3";
+	plugin->info->version     = "0.4";
 	plugin->info->author      = "Sylvan Mostert <smostert.dev@gmail.com>";
 
 	plugin->funcs->init       = lo_init;

--- a/lineoperations/src/lo_fns.c
+++ b/lineoperations/src/lo_fns.c
@@ -19,6 +19,8 @@
  *      51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
+#define _GNU_SOURCE
+#include <string.h>
 
 #include "lo_fns.h"
 #include "lo_prefs.h"

--- a/lineoperations/src/lo_fns.c
+++ b/lineoperations/src/lo_fns.c
@@ -23,12 +23,19 @@
 #include "lo_fns.h"
 #include "lo_prefs.h"
 
+#define LEXICAL_ORDER 1
+#define COLLATION_ORDER 2
+#define VERSION_ORDER 3
 
 /* Get sort function based on user preferences */
 lo_strcmpfns
 getcmpfns(void)
 {
-	if(lo_info->use_collation_compare)
+	if (lo_info->compare_type == VERSION_ORDER)
+	{
+		return strverscmp;
+	}
+	else if (lo_info->compare_type == COLLATION_ORDER)
 	{
 		return g_utf8_collate;
 	}

--- a/lineoperations/src/lo_prefs.c
+++ b/lineoperations/src/lo_prefs.c
@@ -21,10 +21,16 @@
 
 #include "lo_prefs.h"
 
+#define LEXICAL_ORDER 1
+#define COLLATION_ORDER 2
+#define VERSION_ORDER 3
+
 
 static struct
 {
-	GtkWidget *collation_cb;
+	GtkWidget *lexicographic_rb;
+	GtkWidget *collation_rb;
+	GtkWidget *version_rb;
 } config_widgets;
 
 
@@ -42,14 +48,24 @@ lo_configure_response_cb(GtkDialog *dialog, gint response, gpointer user_data)
 		gchar *data;
 
 		/* Grabbing options that has been set */
-		lo_info->use_collation_compare =
-			gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(config_widgets.collation_cb));
+		if (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(config_widgets.version_rb)))
+		{
+			lo_info->compare_type = VERSION_ORDER;
+		}
+		else if (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(config_widgets.collation_rb)))
+		{
+			lo_info->compare_type = COLLATION_ORDER;
+		}
+		else
+		{
+			lo_info->compare_type = LEXICAL_ORDER;
+		}
 
 		/* Write preference to file */
 		g_key_file_load_from_file(config, lo_info->config_file, G_KEY_FILE_NONE, NULL);
 
-		g_key_file_set_boolean(config, "general", "use_collation_compare",
-			lo_info->use_collation_compare);
+		g_key_file_set_integer(config, "general", "compare_type",
+			lo_info->compare_type);
 
 		if (!g_file_test(config_dir, G_FILE_TEST_IS_DIR)
 			&& utils_mkdir(config_dir, TRUE) != 0)
@@ -79,13 +95,35 @@ lo_configure(G_GNUC_UNUSED GeanyPlugin *plugin, GtkDialog *dialog, G_GNUC_UNUSED
 
 	vbox = gtk_vbox_new(FALSE, 0);
 
-	config_widgets.collation_cb = gtk_check_button_new_with_label(
-		_("Use collation based string compare"));
+	config_widgets.lexicographic_rb = gtk_radio_button_new_with_mnemonic(NULL,
+		_("_Lexical Compare"));
+	gtk_button_set_focus_on_click(GTK_BUTTON(config_widgets.lexicographic_rb), FALSE);
+	gtk_container_add(GTK_CONTAINER(vbox), config_widgets.lexicographic_rb);
 
-	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(config_widgets.collation_cb),
-		lo_info->use_collation_compare);
+	config_widgets.collation_rb = gtk_radio_button_new_with_mnemonic_from_widget(GTK_RADIO_BUTTON(config_widgets.lexicographic_rb),
+		_("_Collation Compare"));
+	gtk_button_set_focus_on_click(GTK_BUTTON(config_widgets.collation_rb), FALSE);
+	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(config_widgets.collation_rb), FALSE);
+	gtk_container_add(GTK_CONTAINER(vbox), config_widgets.collation_rb);
 
-	gtk_box_pack_start(GTK_BOX(vbox), config_widgets.collation_cb, FALSE, FALSE, 2);
+	config_widgets.version_rb = gtk_radio_button_new_with_mnemonic_from_widget(GTK_RADIO_BUTTON(config_widgets.lexicographic_rb),
+		_("Version Compare"));
+	gtk_button_set_focus_on_click(GTK_BUTTON(config_widgets.version_rb), FALSE);
+	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(config_widgets.version_rb), FALSE);
+	gtk_container_add(GTK_CONTAINER(vbox), config_widgets.version_rb);
+
+	/* recall selected radio button */
+	if (lo_info->compare_type == VERSION_ORDER)
+	{
+		gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(config_widgets.version_rb), TRUE);
+	}
+	else if (lo_info->compare_type == COLLATION_ORDER)
+	{
+		gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(config_widgets.collation_rb), TRUE);
+	}
+	else {
+		gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(config_widgets.lexicographic_rb), TRUE);
+	}
 
 
 	gtk_widget_show_all(vbox);
@@ -110,10 +148,8 @@ lo_init_prefs(GeanyPlugin *plugin)
 
 	g_key_file_load_from_file(config, lo_info->config_file, G_KEY_FILE_NONE, NULL);
 
-	lo_info->use_collation_compare = utils_get_setting_boolean(config,
-		"general", "use_collation_compare", FALSE);
-
-	printf("VALUE: %d\n", lo_info->use_collation_compare);
+	lo_info->compare_type = utils_get_setting_integer(config,
+		"general", "compare_type", LEXICAL_ORDER);
 
 	g_key_file_free(config);
 }

--- a/lineoperations/src/lo_prefs.h
+++ b/lineoperations/src/lo_prefs.h
@@ -30,7 +30,7 @@ typedef struct
 {
 	/* general settings */
 	gchar *config_file;
-	gboolean use_collation_compare;
+	gint compare_type;
 } LineOpsInfo;
 
 


### PR DESCRIPTION
https://github.com/geany/geany-plugins/pull/993 except with @nomadbyte's idea to use `strverscmp()`

Everything seems to work as expected.
