### PR TITLE
Addons: Bookmarks: Prevent duplicating bookmarks when editing line

### DIFF
--- a/addons/src/ao_bookmarklist.c
+++ b/addons/src/ao_bookmarklist.c
@@ -190,11 +190,27 @@ static void add_line(AoBookmarkList *bm, ScintillaObject *sci, gint line_nr)
 		line = g_strdup(_("(Empty Line)"));
 	tooltip = g_markup_escape_text(line, -1);
 
-	gtk_list_store_insert_with_values(priv->store, NULL, -1,
-		BMLIST_COL_LINE, line_nr + 1,
-		BMLIST_COL_NAME, line,
-		BMLIST_COL_TOOLTIP, tooltip,
-		-1);
+	/* search for existing bookmark on current line */
+	priv->search_line = line_nr + 1;
+	priv->search_iter = NULL;
+	gtk_tree_model_foreach(GTK_TREE_MODEL(priv->store), tree_model_foreach, bm);
+	if (priv->search_iter != NULL)
+	{	/* update existing bookmark with current line content */
+		gtk_list_store_set(priv->store, priv->search_iter,
+			BMLIST_COL_LINE, line_nr + 1,
+			BMLIST_COL_NAME, line,
+			BMLIST_COL_TOOLTIP, tooltip,
+			-1);
+		gtk_tree_iter_free(priv->search_iter);
+	}
+	else
+	{	/* add bookmark */
+		gtk_list_store_insert_with_values(priv->store, NULL, -1,
+			BMLIST_COL_LINE, line_nr + 1,
+			BMLIST_COL_NAME, line,
+			BMLIST_COL_TOOLTIP, tooltip,
+			-1);
+	}
 	g_free(line);
 	g_free(tooltip);
 }


### PR DESCRIPTION
For some filetypes (more specifically some Scintilla lexers) it might
happen that an event with modificationType SC_MOD_CHANGEMARKER is
sent and so the current line is added as bookmark again.
To avoid this, check if the current line has already a bookmark and
update it in this case.

Might be related to #964.