### PR TITLE
Use stdbool.h istead of redefining bool

### DIFF
--- a/pretty-printer/src/PrettyPrinter.h
+++ b/pretty-printer/src/PrettyPrinter.h
@@ -29,6 +29,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdarg.h>
+#include <stdbool.h>
 
 #ifdef HAVE_GLIB
 #include <glib.h>
@@ -52,15 +53,13 @@
 #define TRUE !(FALSE)
 #endif
 
-typedef unsigned int bool;
-
 /*========================================== STRUCTURES =======================================================*/
 
 /**
  * The PrettyPrintingOptions struct allows the programmer to tell the
  * PrettyPrinter how it must format the XML output.
  */
-typedef struct 
+typedef struct
 {
       const char* newLineChars;                                                             /* char used to generate a new line (generally \r\n) */
       char indentChar;                                                                      /* char used for indentation */


### PR DESCRIPTION
Hi,

I'm maintaining the `geany-plugins` package for Arch Linux.

When compiling the latest version of geany-plugins, I get this error:

```
PrettyPrinter.h:55:22: error: two or more data types in declaration specifiers
   55 | typedef unsigned int bool;
      |                      ^~~~
```

Including `<stdbool.h>` and removing the typdef for `bool` solves this issue.

Tested on GCC 10.2.0.

Thanks for creating and maintaining Geany and Geany Plugins! They are both pretty sweet and usually unproblematic to package.

Fixes #1023 