### PR TITLE
Replace Sourceforge references

### DIFF
--- a/geanyprj/README
+++ b/geanyprj/README
@@ -71,7 +71,7 @@ Example of usage
 
 Lets see plugin work at Geany source code example:
 
-1) Download geany-0.15.tar.gz (http://prdownloads.sourceforge.net/geany/geany-0.15.tar.gz?download)
+1) Download geany-0.15.tar.gz (https://download.geany.org/old/geany-0.15.tar.gz)
 
 2) Unpack it somewhere, for example in ~/src/geany-0.15
 

--- a/latex/doc/latex.html
+++ b/latex/doc/latex.html
@@ -2724,8 +2724,8 @@ class="cmr-10">New features are always highly welcome. The TODO file inside sour
 class="cmr-10">wished features and which are being worked on. Also you can have a look onto the feature request tracker of</span>
 <span 
 class="cmr-10">geany-plugins project at </span><a 
-href="https://sourceforge.net/projects/geany-plugins/" class="url" ><span 
-class="cmtt-10">https://sourceforge.net/projects/geany-plugins/</span></a> <span 
+href="https://github.com/geany/geany-plugins/" class="url" ><span 
+class="cmtt-10">https://github.com/geany/geany-plugins/</span></a> <span 
 class="cmr-10">whether you find something</span>
 <span 
 class="cmr-10">interesting. Of course we are also open for not in the sources mentioned before listed items. Just contact one of the</span>
@@ -2920,8 +2920,8 @@ class="cmr-10">At time of the the documentation was created no issue were known.
 <span 
 class="cmr-10">recent information for all reported issues bug tracking system of SF at </span><br 
 class="newline" /><a 
-href="https://sourceforge.net/projects/geany-plugins/" class="url" ><span 
-class="cmtt-10">https://sourceforge.net/projects/geany-plugins/</span></a>
+href="https://github.com/geany/geany-plugins/" class="url" ><span 
+class="cmtt-10">https://github.com/geany/geany-plugins/</span></a>
 </p><!--l. 945--><p class="noindent" >
 </p>
 <h3 class="sectionHead"><span class="titlemark"><span 


### PR DESCRIPTION
See also #1049.

There are two occurrences left:
`scope/docs/scope.html:<p>A. Your Geany does not support this signal. Either apply the patch from Geany sourceforge patch tracker <a href="http://sourceforge.net/tracker/?func=detail&amp;aid=3594050&amp;...`

The referenced issue exists (https://sourceforge.net/p/geany/patches/21/) but will also be deleted some time when we clean the Geany Sourceforge project as well.
I tend to keep the reference as is, put up with having a broken link. Other ideas are welcome.

`treebrowser/ChangeLog:  (FIXED) http://sourceforge.net/tracker/?func=detail&aid=3034450&group_id=222729&atid=1056532`

I would keep this as is, manipulating a ChangeLog entry feels as wrong as having a broken link there.