### PR TITLE
vimode: ignore key-presses containing command on macOS

### DIFF
--- a/vimode/src/keypress.c
+++ b/vimode/src/keypress.c
@@ -25,8 +25,8 @@ KeyPress *kp_from_event_key(GdkEventKey *ev)
 {
 	KeyPress *kp;
 
-	/* ignore keypresses containing Alt - no Vim command uses it */
-	if (ev->state & GDK_MOD1_MASK)
+	/* ignore keypresses containing Alt and Command on macOS - no Vim command uses them */
+	if (ev->state & (GDK_MOD1_MASK | GDK_MOD2_MASK))
 		return NULL;
 
 	switch (ev->keyval)


### PR DESCRIPTION
No vi command uses the command key so we can ignore such key presses
so Geany's keybindings can be performed instead.

Fixes #991