### PR TITLE
vimode: Enable '.' to also repeat last inserted text

### DIFF
--- a/vimode/src/context.h
+++ b/vimode/src/context.h
@@ -22,7 +22,7 @@
 #include "vi.h"
 #include "sci.h"
 
-#define INSERT_BUF_LEN 4096
+#define INSERT_BUF_LEN 131072
 
 typedef struct
 {
@@ -54,7 +54,7 @@ typedef struct
 	gint num;
 
 	/* buffer used in insert/replace mode to record entered text so it can be
-	 * copied N times when e.g. 'i' is preceded by a number */
+	 * copied N times when e.g. 'i' is preceded by a number or when using '.' */
 	gchar insert_buf[INSERT_BUF_LEN];
 	gint insert_buf_len;
 } CmdContext;

--- a/vimode/src/vi.c
+++ b/vimode/src/vi.c
@@ -109,8 +109,6 @@ static void repeat_insert(gboolean replace)
 		SSM(sci, SCI_ENDUNDOACTION, 0, 0);
 	}
 	ctx.num = 1;
-	ctx.insert_buf_len = 0;
-	ctx.insert_buf[0] = '\0';
 	ctx.newline_insert = FALSE;
 }
 
@@ -156,6 +154,10 @@ void vi_set_mode(ViMode mode)
 				gint start_pos = SSM(sci, SCI_POSITIONFROMLINE, GET_CUR_LINE(sci), 0);
 				if (pos > start_pos)
 					SET_POS(sci, PREV(sci, pos), FALSE);
+
+				/* erase kpl so '.' command repeats last inserted text and not command */
+				g_slist_free_full(ctx.kpl, g_free);
+				ctx.kpl = NULL;
 			}
 			else if (VI_IS_VISUAL(prev_mode))
 				SSM(sci, SCI_SETEMPTYSELECTION, pos, 0);


### PR DESCRIPTION
Currently, '.' only repeats the last command inserted in the command mode
and doesn't repeat text inserted in the (just exited) insert mode which
vim does.

Since we already support commands like

10iwrite_text_to_be_repeated_10_times<esc>

we can reuse the code also for the '.' command.

Fixes #1011 