### PR TITLE
vimode: add some more ex commands

### DIFF
--- a/vimode/README
+++ b/vimode/README
@@ -550,12 +550,22 @@ a new command, please do not forget to update the table below.::
     tag           command         action 
     ------------------------------------------------------------------------------
     :&            :&              repeat last ":substitute"
+    :<            :<              shift lines one 'shiftwidth' left
+    :>            :>              shift lines one 'shiftwidth' right
+    :copy         :co[py]         copy lines
     :cquit        :cq[uit]        quit Vim with an error code
+    :delete       :d[elete]       delete lines
     :exit         :exi[t]         same as ":xit"
+    :join         :j[oin]         join lines
+    :move         :m[ove]         move lines
+    :put          :pu[t]          insert contents of register in the text
     :quit         :q[uit]         quit current window (when one window quit Vim)
     :quitall      :quita[ll]      quit Vim
     :qall         :qa[ll]         quit Vim
+    :redo         :red[o]         redo one undone change
     :substitute   :s[ubstitute]   find and replace text
+    :t            :t              same as ":copy"
+    :undo         :u[ndo]         undo last change(s)
     :update       :up[date]       write buffer if modified
     :write        :w[rite]        write to a file
     :wall         :wa[ll]         write all (changed) buffers
@@ -563,3 +573,5 @@ a new command, please do not forget to update the table below.::
     :wqall        :wqa[ll]        write all changed buffers and quit Vim
     :xit          :x[it]          write if buffer changed and quit window or Vim
     :xall         :xa[ll]         same as ":wqall"
+    :yank         :y[ank]         yank lines into a register
+    :~            :~              repeat last ":substitute"

--- a/vimode/src/Makefile.am
+++ b/vimode/src/Makefile.am
@@ -36,8 +36,8 @@ vi_srcs = \
 	cmds/special.c \
 	cmds/edit.h \
 	cmds/edit.c \
-	excmds/excmds.h \
-	excmds/excmds.c
+	cmds/excmds.h \
+	cmds/excmds.c
 
 vimode_la_SOURCES = \
 	backends/backend-geany.c \

--- a/vimode/src/cmd-params.c
+++ b/vimode/src/cmd-params.c
@@ -26,7 +26,7 @@ void cmd_params_init(CmdParams *param, ScintillaObject *sci,
 
 	param->num = num;
 	param->num_present = num_present;
-	param->last_kp = g_slist_nth_data(kpl, 0);
+	param->last_kp = kpl != NULL ? g_slist_nth_data(kpl, 0) : NULL;
 	param->is_operator_cmd = is_operator_cmd;
 
 	param->sel_start = sel_start;

--- a/vimode/src/cmds/excmds.c
+++ b/vimode/src/cmds/excmds.c
@@ -16,7 +16,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-#include "excmds/excmds.h"
+#include "cmds/excmds.h"
 #include "utils.h"
 
 void excmd_save(CmdContext *c, ExCmdParams *p)

--- a/vimode/src/cmds/excmds.c
+++ b/vimode/src/cmds/excmds.c
@@ -17,6 +17,7 @@
  */
 
 #include "cmds/excmds.h"
+#include "cmds/edit.h"
 #include "utils.h"
 
 void excmd_save(CmdContext *c, ExCmdParams *p)
@@ -64,3 +65,71 @@ void excmd_repeat_subst_orig_flags(CmdContext *c, ExCmdParams *p)
 {
 	perform_substitute(c->sci, c->substitute_text, p->range_from, p->range_to, NULL);
 }
+
+
+static void prepare_cmd_params(CmdParams *params, CmdContext *c, ExCmdParams *p)
+{
+	gint start = SSM(c->sci, SCI_POSITIONFROMLINE, p->range_from, 0);
+	SET_POS(c->sci, start, TRUE);
+	cmd_params_init(params, c->sci, p->range_to - p->range_from + 1, FALSE, NULL, FALSE, 0, 0);
+}
+
+
+void excmd_yank(CmdContext *c, ExCmdParams *p)
+{
+	CmdParams params;
+	prepare_cmd_params(&params, c, p);
+	cmd_copy_line(c, &params);
+}
+
+
+void excmd_put(CmdContext *c, ExCmdParams *p)
+{
+	CmdParams params;
+	prepare_cmd_params(&params, c, p);
+	cmd_paste_after(c, &params);
+}
+
+
+void excmd_undo(CmdContext *c, ExCmdParams *p)
+{
+	SSM(c->sci, SCI_UNDO, 0, 0);
+}
+
+
+void excmd_redo(CmdContext *c, ExCmdParams *p)
+{
+	SSM(c->sci, SCI_REDO, 0, 0);
+}
+
+
+void excmd_shift_left(CmdContext *c, ExCmdParams *p)
+{
+	CmdParams params;
+	prepare_cmd_params(&params, c, p);
+	cmd_unindent(c, &params);
+}
+
+
+void excmd_shift_right(CmdContext *c, ExCmdParams *p)
+{
+	CmdParams params;
+	prepare_cmd_params(&params, c, p);
+	cmd_indent(c, &params);
+}
+
+
+void excmd_delete(CmdContext *c, ExCmdParams *p)
+{
+	CmdParams params;
+	prepare_cmd_params(&params, c, p);
+	cmd_delete_line(c, &params);
+}
+
+void excmd_join(CmdContext *c, ExCmdParams *p)
+{
+	CmdParams params;
+	prepare_cmd_params(&params, c, p);
+	cmd_join_lines(c, &params);
+}
+

--- a/vimode/src/cmds/excmds.c
+++ b/vimode/src/cmds/excmds.c
@@ -133,3 +133,31 @@ void excmd_join(CmdContext *c, ExCmdParams *p)
 	cmd_join_lines(c, &params);
 }
 
+
+void excmd_copy(CmdContext *c, ExCmdParams *p)
+{
+	CmdParams params;
+	gint dest = SSM(c->sci, SCI_POSITIONFROMLINE, p->dest, 0);
+	excmd_yank(c, p);
+	SET_POS(c->sci, dest, TRUE);
+	cmd_params_init(&params, c->sci, 1, FALSE, NULL, FALSE, 0, 0);
+	cmd_paste_after(c, &params);
+}
+
+
+void excmd_move(CmdContext *c, ExCmdParams *p)
+{
+	CmdParams params;
+	gint dest;
+
+	if (p->dest >= p->range_from && p->dest <= p->range_to)
+		return;
+
+	excmd_delete(c, p);
+	if (p->dest > p->range_to)
+		p->dest -= p->range_to - p->range_from + 1;
+	dest = SSM(c->sci, SCI_POSITIONFROMLINE, p->dest, 0);
+	SET_POS(c->sci, dest, TRUE);
+	cmd_params_init(&params, c->sci, 1, FALSE, NULL, FALSE, 0, 0);
+	cmd_paste_after(c, &params);
+}

--- a/vimode/src/cmds/excmds.h
+++ b/vimode/src/cmds/excmds.h
@@ -37,5 +37,7 @@ void excmd_shift_left(CmdContext *c, ExCmdParams *p);
 void excmd_shift_right(CmdContext *c, ExCmdParams *p);
 void excmd_delete(CmdContext *c, ExCmdParams *p);
 void excmd_join(CmdContext *c, ExCmdParams *p);
+void excmd_copy(CmdContext *c, ExCmdParams *p);
+void excmd_move(CmdContext *c, ExCmdParams *p);
 
 #endif

--- a/vimode/src/cmds/excmds.h
+++ b/vimode/src/cmds/excmds.h
@@ -16,8 +16,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-#ifndef __VIMODE_EXCMDS_EXCMDS_H__
-#define __VIMODE_EXCMDS_EXCMDS_H__
+#ifndef __VIMODE_CMDS_EXCMDS_H__
+#define __VIMODE_CMDS_EXCMDS_H__
 
 #include "excmd-params.h"
 #include "context.h"

--- a/vimode/src/cmds/excmds.h
+++ b/vimode/src/cmds/excmds.h
@@ -29,5 +29,13 @@ void excmd_save_quit(CmdContext *c, ExCmdParams *p);
 void excmd_save_all_quit(CmdContext *c, ExCmdParams *p);
 void excmd_repeat_subst(CmdContext *c, ExCmdParams *p);
 void excmd_repeat_subst_orig_flags(CmdContext *c, ExCmdParams *p);
+void excmd_yank(CmdContext *c, ExCmdParams *p);
+void excmd_put(CmdContext *c, ExCmdParams *p);
+void excmd_undo(CmdContext *c, ExCmdParams *p);
+void excmd_redo(CmdContext *c, ExCmdParams *p);
+void excmd_shift_left(CmdContext *c, ExCmdParams *p);
+void excmd_shift_right(CmdContext *c, ExCmdParams *p);
+void excmd_delete(CmdContext *c, ExCmdParams *p);
+void excmd_join(CmdContext *c, ExCmdParams *p);
 
 #endif

--- a/vimode/src/excmd-params.h
+++ b/vimode/src/excmd-params.h
@@ -30,6 +30,8 @@ typedef struct
 	/* ex range start and end */
 	gint range_from;
 	gint range_to;
+	/* "address" destination for copy/move */
+	gint dest;
 } ExCmdParams;
 
 typedef void (*ExCmd)(CmdContext *c, ExCmdParams *p);

--- a/vimode/src/excmd-runner.c
+++ b/vimode/src/excmd-runner.c
@@ -18,7 +18,7 @@
 
 #include "excmd-runner.h"
 #include "excmd-params.h"
-#include "excmds/excmds.h"
+#include "cmds/excmds.h"
 #include "utils.h"
 
 #include <string.h>
@@ -64,7 +64,27 @@ ExCmdDef ex_cmds[] = {
 	{excmd_repeat_subst, "s"},
 	{excmd_repeat_subst, "substitute"},
 	{excmd_repeat_subst, "&"},
+	{excmd_repeat_subst, "~"},
 	{excmd_repeat_subst_orig_flags, "&&"},
+
+	{excmd_yank, "yank"},
+	{excmd_yank, "y"},
+	{excmd_put, "put"},
+	{excmd_put, "pu"},
+
+	{excmd_undo, "undo"},
+	{excmd_undo, "u"},
+	{excmd_redo, "redo"},
+	{excmd_redo, "red"},
+
+	{excmd_shift_left, "<"},
+	{excmd_shift_right, ">"},
+
+	{excmd_delete, "delete"},
+	{excmd_delete, "d"},
+
+	{excmd_join, "join"},
+	{excmd_join, "j"},
 
 	{NULL, NULL}
 };

--- a/vimode/src/excmd-runner.c
+++ b/vimode/src/excmd-runner.c
@@ -86,6 +86,13 @@ ExCmdDef ex_cmds[] = {
 	{excmd_join, "join"},
 	{excmd_join, "j"},
 
+	{excmd_copy, "copy"},
+	{excmd_copy, "co"},
+	{excmd_copy, "t"},
+
+	{excmd_move, "move"},
+	{excmd_move, "m"},
+
 	{NULL, NULL}
 };
 
@@ -433,7 +440,11 @@ static void perform_simple_ex_cmd(CmdContext *ctx, const gchar *cmd)
 			ExCmdDef *def = &ex_cmds[i];
 			if (strcmp(def->name, cmd_name) == 0)
 			{
+				if (def->cmd == excmd_copy || def->cmd == excmd_move)
+					parse_ex_range(&(params.param1), ctx, &(params.dest), &(params.dest));
+				SSM(ctx->sci, SCI_BEGINUNDOACTION, 0, 0);
 				def->cmd(ctx, &params);
+				SSM(ctx->sci, SCI_ENDUNDOACTION, 0, 0);
 				break;
 			}
 		}


### PR DESCRIPTION
These patches add the following ex commands:

```
:y[ank]
:pu[t]
:u[ndo]
:red[o]
:<
:>
:d[elete]
:j[oin]
:co[py]
:m[ove]
```

Fixes the `:delete` command missing part of #1060.