### PR TITLE
Project Organizer: Add option to open current folder in file manager and terminal

### DIFF
--- a/projectorganizer/src/prjorg-menu.c
+++ b/projectorganizer/src/prjorg-menu.c
@@ -43,6 +43,8 @@ enum
 	KB_FIND_FILE,
 	KB_FIND_TAG,
 	KB_FOCUS_SIDEBAR,
+	KB_OPEN_FILE_MANAGER,
+	KB_OPEN_TERMINAL,
 	KB_COUNT
 };
 
@@ -407,6 +409,12 @@ void prjorg_menu_init(void)
 
     keybindings_set_item(key_group, KB_FOCUS_SIDEBAR, (GeanyKeyCallback)prjorg_sidebar_focus_project_tab,
 		0, 0, "focus_project_sidebar", _("Focus Project Sidebar"), NULL);
+
+    keybindings_set_item(key_group, KB_OPEN_FILE_MANAGER, (GeanyKeyCallback)on_open_file_manager,
+		0, 0, "open_file_manager", _("Open File Manager at file location"), NULL);
+
+    keybindings_set_item(key_group, KB_OPEN_TERMINAL, (GeanyKeyCallback)on_open_terminal,
+		0, 0, "open_terminal", _("Open Terminal at file location"), NULL);
 
 	s_context_sep_item = gtk_separator_menu_item_new();
 	gtk_widget_show(s_context_sep_item);

--- a/projectorganizer/src/prjorg-project.h
+++ b/projectorganizer/src/prjorg-project.h
@@ -64,6 +64,22 @@ void prjorg_project_remove_single_tm_file(gchar *utf8_filename);
 
 gboolean prjorg_project_is_in_project(const gchar *utf8_filename);
 
+
+/* set open command based on OS */
+#if defined(_WIN32) || defined(G_OS_WIN32)
+#define PRJORG_COMMAND_OPEN "start"
+#define PRJORG_COMMAND_TERMINAL "PowerShell"
+#define PRJORG_COMMAND_TERMINAL_ALT ""
+#elif defined(__APPLE__)
+#define PRJORG_COMMAND_OPEN "open"
+#define PRJORG_COMMAND_TERMINAL "open -b com.apple.terminal"
+#define PRJORG_COMMAND_TERMINAL_ALT ""
+#else
+#define PRJORG_COMMAND_OPEN "xdg-open"
+#define PRJORG_COMMAND_TERMINAL "xterm"
+#define PRJORG_COMMAND_TERMINAL_ALT "/usr/bin/x-terminal-emulator"
+#endif
+
 /* In the code we create a list of all files but we want to keep empty directories
  * in the list for which we create a fake file name with the PROJORG_DIR_ENTRY
  * value. */

--- a/projectorganizer/src/prjorg-sidebar.h
+++ b/projectorganizer/src/prjorg-sidebar.h
@@ -31,5 +31,7 @@ void prjorg_sidebar_update(gboolean reload);
 
 void prjorg_sidebar_focus_project_tab(void);
 
+void on_open_file_manager(G_GNUC_UNUSED GtkMenuItem * menuitem, G_GNUC_UNUSED gpointer user_data);
+void on_open_terminal(G_GNUC_UNUSED GtkMenuItem * menuitem, G_GNUC_UNUSED gpointer user_data);
 
 #endif


### PR DESCRIPTION
File manager/terminal are opened at the location of the selected file in the tree view.  If nothing is selected, the location of the current document is used.  If the current document does not have a path, the project directory is used.  If the project directory cannot be located, the user's home directory is used.

The file manager is opened with the path as the first argument.

The terminal path is set using the PWD.

Note: Does not accept any %f %u %d %p %etc specifiers.  This is left for a future PR if needed.