### PR TITLE
Markdown: Modify replace_all to avoid infinite loop

### DIFF
--- a/markdown/src/viewer.c
+++ b/markdown/src/viewer.c
@@ -194,12 +194,14 @@ replace_all(MarkdownViewer *self,
 {
   gchar *ptr;
   gsize needle_len = strlen(needle);
+  goffset offset = 0;
 
   /* For each occurrence of needle in haystack */
-  while ((ptr = strstr(haystack->str, needle)) != NULL) {
-    goffset offset = ptr - haystack->str;
+  while ((ptr = strstr(haystack->str + offset, needle)) != NULL) {
+    offset = ptr - haystack->str;
     g_string_erase(haystack, offset, needle_len);
     g_string_insert(haystack, offset, replacement);
+    offset += strlen(replacement) - 1;
   }
 }
 

--- a/markdown/src/viewer.c
+++ b/markdown/src/viewer.c
@@ -194,6 +194,7 @@ replace_all(MarkdownViewer *self,
 {
   gchar *ptr;
   gsize needle_len = strlen(needle);
+  gsize replacement_len_minus_one = strlen(replacement) - 1;
   goffset offset = 0;
 
   /* For each occurrence of needle in haystack */
@@ -201,7 +202,7 @@ replace_all(MarkdownViewer *self,
     offset = ptr - haystack->str;
     g_string_erase(haystack, offset, needle_len);
     g_string_insert(haystack, offset, replacement);
-    offset += strlen(replacement) - 1;
+    offset += replacement_len_minus_one;
   }
 }
 

--- a/markdown/src/viewer.c
+++ b/markdown/src/viewer.c
@@ -194,7 +194,7 @@ replace_all(MarkdownViewer *self,
 {
   gchar *ptr;
   gsize needle_len = strlen(needle);
-  gsize replacement_len_minus_one = strlen(replacement) - 1;
+  gsize replacement_len = strlen(replacement);
   goffset offset = 0;
 
   /* For each occurrence of needle in haystack */
@@ -202,7 +202,7 @@ replace_all(MarkdownViewer *self,
     offset = ptr - haystack->str;
     g_string_erase(haystack, offset, needle_len);
     g_string_insert(haystack, offset, replacement);
-    offset += replacement_len_minus_one;
+    offset += replacement_len;
   }
 }
 


### PR DESCRIPTION
This PR modifies `replace_all` to avoid the infinite loop.  In each iteration, `replace_all` searches for `needle` starting from the beginning of `haystack`.  If `replacement` contains `needle`, the result is an infinite loop.  To prevent this from happening, `replace_all` should continue searching for `needle` from the end of the previous `replacement`.

Resolves #936.