### PR TITLE
vimode: Set default height of excmd popup to a small number

### DIFF
--- a/vimode/src/excmd-prompt.c
+++ b/vimode/src/excmd-prompt.c
@@ -225,6 +225,7 @@ void ex_prompt_init(GtkWidget *parent_window, CmdContext *c)
 	prompt = g_object_new(GTK_TYPE_WINDOW,
 			"decorated", FALSE,
 			"default-width", PROMPT_WIDTH,
+			"default-height", 1,
 			"transient-for", parent_window,
 			"window-position", GTK_WIN_POS_CENTER_ON_PARENT,
 			"type-hint", GDK_WINDOW_TYPE_HINT_DIALOG,


### PR DESCRIPTION
On macOS there seems to be some bigger default height so the excmd popup
is too tall. When default-height is set to 1, it is automatically resized
to the height of the text entry it contains and has correct size on both
linux and macOS.