### PR TITLE
Remove GTK2 jobs from Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,21 +5,14 @@ sudo: false
 compiler:
   - gcc
 
-env:
-  matrix:
-    - GTK3=no
-    - GTK3=yes
-
 cache:
   ccache: true
   directories:
     - $HOME/geany/gtk3
-    - $HOME/geany/gtk2
 
 addons:
   apt:
     packages:
-    - libgtk2.0-dev
     - libgtk-3-dev
     - intltool
     - libtool
@@ -27,7 +20,6 @@ addons:
     - check
     - cppcheck
     # debugger
-    - libvte-dev
     - libvte-2.91-dev
     # devhelp
     - libwebkitgtk-dev
@@ -42,7 +34,6 @@ addons:
     - libgpgme11-dev
     # geanypy
     - python-dev
-    - python-gtk2-dev
     # geanyvc
     - libgtkspell-dev
     - libgtkspell3-3-dev
@@ -66,8 +57,7 @@ before_install:
   - TEMPDIR=$(mktemp -d)
   - git clone git://github.com/geany/geany.git "$TEMPDIR/geany"
   - geany_commit=$(cd "$TEMPDIR/geany" && git rev-parse HEAD)
-  - gtkver=gtk2
-  - test "x$GTK3" = xno || gtkver=gtk3
+  - gtkver=gtk3
   - cachedir="$HOME/geany/$gtkver/"
   - cache_id=$(cat "$cachedir/commit-id" 2>/dev/null || echo "none")
   # check if the cache is up-to-date, and either use it, or (re-)create it
@@ -81,7 +71,7 @@ before_install:
       rm "$cachedir" -rf || exit 1;
       ( cd "$TEMPDIR/geany"                                   &&
         NOCONFIGURE=1 ./autogen.sh                            &&
-        ./configure --prefix="$cachedir" --enable-gtk3=$GTK3  &&
+        ./configure --prefix="$cachedir"                      &&
         make -j2                                              &&
         make install || exit 1;
         git rev-parse HEAD > "$cachedir/commit-id" || exit 2;


### PR DESCRIPTION
While we don't support GTK2 anymore, the Travis CI config still tried to build it but actually built against GTK3 twice because Geany is always built against GTK3.

I'm going to migrate this soon to Github Actions and so this is only a quick'n'dirty attempt to prevent unnecessary builds.