### PR TITLE
vimode: fix escape not working when numlock is on

### DIFF
--- a/vimode/src/keypress.c
+++ b/vimode/src/keypress.c
@@ -26,7 +26,7 @@ KeyPress *kp_from_event_key(GdkEventKey *ev)
 	KeyPress *kp;
 
 	/* ignore keypresses containing Alt and Command on macOS - no Vim command uses them */
-	if (ev->state & (GDK_MOD1_MASK | GDK_MOD2_MASK))
+	if (ev->state & (GDK_MOD1_MASK | GDK_META_MASK))
 		return NULL;
 
 	switch (ev->keyval)


### PR DESCRIPTION
It seems that GDK_MOD2_MASK isn't the right modifier to check for
command pressed - its mapping is platform-specific and while this works
on macOS, it has undesirable side-effects on linux. Use GDK_META_MASK
instead which based on my testing seems to do the right thing both on
macOS and linux.

Fixes (1) in #1136 