### PR TITLE
Replace deprecated setptr macro with SETPTR

### DIFF
--- a/addons/src/ao_openuri.c
+++ b/addons/src/ao_openuri.c
@@ -256,7 +256,7 @@ void ao_open_uri_update_menu(AoOpenUri *openuri, GeanyDocument *doc, gint pos)
 		if (text[len - 1] == '.' || text[len - 1] == ':')
 			text[len - 1] = '\0';
 
-		setptr(priv->uri, text);
+		SETPTR(priv->uri, text);
 
 		gtk_widget_show(priv->menu_item_open);
 		gtk_widget_show(priv->menu_item_copy);

--- a/addons/src/ao_tasks.c
+++ b/addons/src/ao_tasks.c
@@ -538,7 +538,7 @@ static void create_task(AoTasks *t, GeanyDocument *doc, gint line, const gchar *
 
 	/* retrieve the following line and use it for the tooltip */
 	context = g_strstrip(sci_get_line(doc->editor->sci, line + 1));
-	setptr(context, g_strconcat(
+	SETPTR(context, g_strconcat(
 		_("Context:"), "\n", line_buf, "\n", context, NULL));
 	tooltip = g_markup_escape_text(context, -1);
 

--- a/geanydoc/src/config.c
+++ b/geanydoc/src/config.c
@@ -60,7 +60,7 @@ config_init(void)
 	config_file = g_build_filename(geany->app->configdir, "plugins", "geanydoc", NULL);
 	utils_mkdir(config_file, TRUE);
 
-	setptr(config_file, g_build_filename(config_file, "geanydoc.conf", NULL));
+	SETPTR(config_file, g_build_filename(config_file, "geanydoc.conf", NULL));
 
 	config = g_key_file_new();
 	if (!g_key_file_load_from_file(config, config_file, G_KEY_FILE_KEEP_COMMENTS, NULL))

--- a/geanydoc/src/geanydoc.c
+++ b/geanydoc/src/geanydoc.c
@@ -184,7 +184,7 @@ show_doc(const gchar * word, gint cmd_num)
 	if (tmp != NULL)
 	{
 		tmp[1] = 's';
-		setptr(command, g_strdup_printf(command, word));
+		SETPTR(command, g_strdup_printf(command, word));
 	}
 
 	if (intern)

--- a/geanymacro/src/geanymacro.c
+++ b/geanymacro/src/geanymacro.c
@@ -687,7 +687,7 @@ static void SaveSettings(void)
 	g_mkdir_with_parents(config_file,0755);
 
 	/* make config_file hold name of settings file */
-	setptr(config_file,g_build_filename(config_file,"settings.conf",NULL));
+	SETPTR(config_file,g_build_filename(config_file,"settings.conf",NULL));
 
 	/* write data */
 	utils_write_file(config_file, data);
@@ -719,7 +719,7 @@ static void LoadSettings(void)
 	g_mkdir_with_parents(config_file,0755);
 
 	/* make config_file hold name of settings file */
-	setptr(config_file,g_build_filename(config_file,"settings.conf",NULL));
+	SETPTR(config_file,g_build_filename(config_file,"settings.conf",NULL));
 
 	/* either load settings file, or create one from default */
 	config=g_key_file_new();

--- a/geanyprj/src/sidebar.c
+++ b/geanyprj/src/sidebar.c
@@ -63,8 +63,8 @@ static gchar *get_tree_path_filename(GtkTreePath *treepath)
 
 	gtk_tree_model_get_iter(model, &iter, treepath);
 	gtk_tree_model_get(model, &iter, FILEVIEW_COLUMN_NAME, &name, -1);
-	setptr(name, utils_get_locale_from_utf8(name));
-	setptr(name, get_full_path(g_current_project->path, name));
+	SETPTR(name, utils_get_locale_from_utf8(name));
+	SETPTR(name, get_full_path(g_current_project->path, name));
 	return name;
 }
 

--- a/geanyprj/src/utils.c
+++ b/geanyprj/src/utils.c
@@ -121,8 +121,8 @@ gchar *get_full_path(const gchar *location, const gchar *path)
 	gchar *dir;
 
 	dir = g_path_get_dirname(location);
-	setptr(dir, g_build_filename(dir, path, NULL));
-	setptr(dir, normpath(dir));
+	SETPTR(dir, g_build_filename(dir, path, NULL));
+	SETPTR(dir, normpath(dir));
 	return dir;
 }
 
@@ -139,7 +139,7 @@ gchar *get_relative_path(const gchar *location, const gchar *path)
 	}
 
 	dir = g_path_get_dirname(location);
-	setptr(dir, normpath(dir));
+	SETPTR(dir, normpath(dir));
 
 	plen = strlen(path);
 	dlen = strlen(dir);
@@ -148,7 +148,7 @@ gchar *get_relative_path(const gchar *location, const gchar *path)
 	{
 		if (plen > dlen)
 		{
-			setptr(dir, g_strdup(path + strlen(dir) + 1));
+			SETPTR(dir, g_strdup(path + strlen(dir) + 1));
 			return dir;
 		}
 		else if (plen == dlen)
@@ -213,7 +213,7 @@ GSList *get_file_list(const gchar *path, guint * length, gboolean(*func)(const g
 	else
 	{
 		abs_path = g_get_current_dir();
-		setptr(abs_path, g_build_filename(abs_path, path, NULL));
+		SETPTR(abs_path, g_build_filename(abs_path, path, NULL));
 	}
 	if (!g_file_test(abs_path, G_FILE_TEST_IS_DIR))
 	{

--- a/geanyvc/src/geanyvc.c
+++ b/geanyvc/src/geanyvc.c
@@ -397,7 +397,7 @@ get_cmd(const gchar ** argv, const gchar * dir, const gchar * filename, GSList *
 			utils_string_replace_all(repl, P_ABS_FILENAME, filename);
 			utils_string_replace_all(repl, P_BASENAME, basename);
 			ret[j] = g_string_free(repl, FALSE);
-			setptr(ret[j], utils_get_locale_from_utf8(ret[j]));
+			SETPTR(ret[j], utils_get_locale_from_utf8(ret[j]));
 		}
 	}
 	g_free(abs_dir);
@@ -510,11 +510,11 @@ execute_custom_command(const gchar * dir, const gchar ** argv, const gchar ** en
 			tmp = g_string_new(*std_out);
 			utils_string_replace_all(tmp, "\r\n", "\n");
 			utils_string_replace_all(tmp, "\r", "\n");
-			setptr(*std_out, g_string_free(tmp, FALSE));
+			SETPTR(*std_out, g_string_free(tmp, FALSE));
 
 			if (!g_utf8_validate(*std_out, -1, NULL))
 			{
-				setptr(*std_out, encodings_convert_to_utf8(*std_out,
+				SETPTR(*std_out, encodings_convert_to_utf8(*std_out,
 									   strlen(*std_out), NULL));
 			}
 			if (EMPTY(*std_out))
@@ -528,11 +528,11 @@ execute_custom_command(const gchar * dir, const gchar ** argv, const gchar ** en
 			tmp = g_string_new(*std_err);
 			utils_string_replace_all(tmp, "\r\n", "\n");
 			utils_string_replace_all(tmp, "\r", "\n");
-			setptr(*std_err, g_string_free(tmp, FALSE));
+			SETPTR(*std_err, g_string_free(tmp, FALSE));
 
 			if (!g_utf8_validate(*std_err, -1, NULL))
 			{
-				setptr(*std_err, encodings_convert_to_utf8(*std_err,
+				SETPTR(*std_err, encodings_convert_to_utf8(*std_err,
 									   strlen(*std_err), NULL));
 			}
 			if (EMPTY(*std_err))
@@ -635,10 +635,10 @@ vcdiff_file_activated(G_GNUC_UNUSED GtkMenuItem * menuitem, G_GNUC_UNUSED gpoint
 			localename = utils_get_locale_from_utf8(doc->file_name);
 
 			new = g_strconcat(doc->file_name, ".geanyvc.~NEW~", NULL);
-			setptr(new, utils_get_locale_from_utf8(new));
+			SETPTR(new, utils_get_locale_from_utf8(new));
 
 			old = g_strconcat(doc->file_name, ".geanyvc.~BASE~", NULL);
-			setptr(old, utils_get_locale_from_utf8(old));
+			SETPTR(old, utils_get_locale_from_utf8(old));
 
 			if (g_rename(localename, new) != 0)
 			{

--- a/geanyvc/src/utils.c
+++ b/geanyvc/src/utils.c
@@ -95,8 +95,8 @@ get_full_path(const gchar * location, const gchar * path)
 	gchar *dir;
 
 	dir = g_path_get_dirname(location);
-	setptr(dir, g_build_filename(dir, path, NULL));
-	setptr(dir, normpath(dir));
+	SETPTR(dir, g_build_filename(dir, path, NULL));
+	SETPTR(dir, normpath(dir));
 	return dir;
 }
 

--- a/geanyvc/src/vc_svn.c
+++ b/geanyvc/src/vc_svn.c
@@ -142,13 +142,13 @@ get_base_dir(const gchar * path)
 			g_free(test_dir);
 			continue;
 		}
-		setptr(test_dir, g_build_filename(base, "branches", NULL));
+		SETPTR(test_dir, g_build_filename(base, "branches", NULL));
 		if (!g_file_test(test_dir, G_FILE_TEST_IS_DIR))
 		{
 			g_free(test_dir);
 			continue;
 		}
-		setptr(test_dir, g_build_filename(base, "tags", NULL));
+		SETPTR(test_dir, g_build_filename(base, "tags", NULL));
 		if (!g_file_test(test_dir, G_FILE_TEST_IS_DIR))
 		{
 			g_free(test_dir);

--- a/spellcheck/src/gui.c
+++ b/spellcheck/src/gui.c
@@ -463,7 +463,7 @@ void sc_gui_update_editor_menu_cb(GObject *obj, const gchar *word, gint pos,
 
 		clickinfo.pos = pos;
 		clickinfo.doc = doc;
-		setptr(clickinfo.word, search_word);
+		SETPTR(clickinfo.word, search_word);
 
 		update_editor_menu_items(search_word, (const gchar**) suggs, n_suggs);
 
@@ -644,7 +644,7 @@ static void menu_item_toggled_cb(GtkCheckMenuItem *menuitem, gpointer gdata)
 	/* Another language was chosen from the menu item, so make it default for this session. */
     if (gdata != NULL)
 	{
-		setptr(sc_info->default_language, g_strdup(gdata));
+		SETPTR(sc_info->default_language, g_strdup(gdata));
 		sc_speller_reinit_enchant_dict();
 		sc_gui_update_menu();
 		update_labels();

--- a/spellcheck/src/scplugin.c
+++ b/spellcheck/src/scplugin.c
@@ -141,9 +141,9 @@ static void configure_response_cb(GtkDialog *dialog, gint response, gpointer use
 	{
 		GtkComboBox *combo = GTK_COMBO_BOX(g_object_get_data(G_OBJECT(dialog), "combo"));
 
-		setptr(sc_info->default_language, gtk_combo_box_text_get_active_text(GTK_COMBO_BOX_TEXT(combo)));
+		SETPTR(sc_info->default_language, gtk_combo_box_text_get_active_text(GTK_COMBO_BOX_TEXT(combo)));
 #ifdef HAVE_ENCHANT_1_5
-		setptr(sc_info->dictionary_dir, g_strdup(gtk_entry_get_text(GTK_ENTRY(
+		SETPTR(sc_info->dictionary_dir, g_strdup(gtk_entry_get_text(GTK_ENTRY(
 			g_object_get_data(G_OBJECT(dialog), "dict_dir")))));
 #endif
 		sc_speller_reinit_enchant_dict();

--- a/treebrowser/src/treebrowser.c
+++ b/treebrowser/src/treebrowser.c
@@ -480,7 +480,7 @@ treebrowser_chroot(const gchar *dir)
 	gtk_entry_set_text(GTK_ENTRY(addressbar), directory);
 
 	if (!directory || strlen(directory) == 0)
-		setptr(directory, g_strdup(G_DIR_SEPARATOR_S));
+		SETPTR(directory, g_strdup(G_DIR_SEPARATOR_S));
 
 	if (! treebrowser_checkdir(directory))
 	{
@@ -490,7 +490,7 @@ treebrowser_chroot(const gchar *dir)
 
 	treebrowser_bookmarks_set_state();
 
-	setptr(addressbar_last_address, directory);
+	SETPTR(addressbar_last_address, directory);
 
 	treebrowser_browse(addressbar_last_address, NULL);
 	treebrowser_load_bookmarks();
@@ -1098,7 +1098,7 @@ on_menu_create_new_object(GtkMenuItem *menuitem, const gchar *type)
 			gboolean creation_success = FALSE;
 
 			while(g_file_test(uri_new, G_FILE_TEST_EXISTS))
-				setptr(uri_new, g_strconcat(uri_new, "_", NULL));
+				SETPTR(uri_new, g_strconcat(uri_new, "_", NULL));
 
 			if (utils_str_equal(type, "directory"))
 				creation_success = (g_mkdir(uri_new, 0755) == 0);


### PR DESCRIPTION
`setptr` is deprecated and a candidate for removal.  This PR replaces instances with `SETPTR`.

Affected plugins: addons, geanydoc, geanymacro, geanyprj, geanyvc, spellcheck, treebrowser

See geany/geany#3019.