### PR TITLE
projectorganizer: Restore tree state in the sidebar

### DIFF
--- a/projectorganizer/src/prjorg-main.c
+++ b/projectorganizer/src/prjorg-main.c
@@ -136,7 +136,6 @@ static void on_project_open(G_GNUC_UNUSED GObject * obj, GKeyFile * config,
 		prjorg_sidebar_update_full(TRUE, arr);
 		prjorg_sidebar_activate(TRUE);
 		prjorg_menu_activate_menu_items(TRUE);
-		g_strfreev(arr);
 	}
 }
 

--- a/projectorganizer/src/prjorg-main.c
+++ b/projectorganizer/src/prjorg-main.c
@@ -130,10 +130,13 @@ static void on_project_open(G_GNUC_UNUSED GObject * obj, GKeyFile * config,
 {
 	if (!prj_org)
 	{
+		gchar **arr = prjorg_project_load_expanded_paths(config);
+
 		prjorg_project_open(config);
-		prjorg_sidebar_update(TRUE);
+		prjorg_sidebar_update_full(TRUE, arr);
 		prjorg_sidebar_activate(TRUE);
 		prjorg_menu_activate_menu_items(TRUE);
+		g_strfreev(arr);
 	}
 }
 

--- a/projectorganizer/src/prjorg-project.c
+++ b/projectorganizer/src/prjorg-project.c
@@ -27,6 +27,7 @@
 
 #include "prjorg-utils.h"
 #include "prjorg-project.h"
+#include "prjorg-sidebar.h"
 
 extern GeanyPlugin *geany_plugin;
 extern GeanyData *geany_data;
@@ -377,6 +378,22 @@ static void update_project(
 }
 
 
+static void save_expanded_paths(GKeyFile * key_file)
+{
+	GPtrArray *expanded_paths = prjorg_sidebar_get_expanded_paths();
+	gchar **expanded_paths_v = g_new (gchar *, expanded_paths->len + 1);
+	guint i;
+
+	for (i = 0; i < expanded_paths->len; i++)
+		expanded_paths_v[i] = expanded_paths->pdata[i];
+	expanded_paths_v[expanded_paths->len] = NULL;
+	g_key_file_set_string_list(key_file, "prjorg", "expanded_paths",
+		(const gchar**) expanded_paths_v, g_strv_length(expanded_paths_v));
+	g_free(expanded_paths_v);
+	g_ptr_array_free(expanded_paths, TRUE);
+}
+
+
 void prjorg_project_save(GKeyFile * key_file)
 {
 	GPtrArray *array;
@@ -384,6 +401,8 @@ void prjorg_project_save(GKeyFile * key_file)
 
 	if (!prj_org)
 		return;
+
+	save_expanded_paths(key_file);
 
 	g_key_file_set_string_list(key_file, "prjorg", "source_patterns",
 		(const gchar**) prj_org->source_patterns, g_strv_length(prj_org->source_patterns));
@@ -475,6 +494,12 @@ void prjorg_project_remove_external_dir(const gchar *utf8_dirname)
 		prjorg_project_rescan();
 	}
 	close_root(test_root, NULL);
+}
+
+
+gchar **prjorg_project_load_expanded_paths(GKeyFile * key_file)
+{
+	return g_key_file_get_string_list(key_file, "prjorg", "expanded_paths", NULL, NULL);
 }
 
 

--- a/projectorganizer/src/prjorg-project.c
+++ b/projectorganizer/src/prjorg-project.c
@@ -380,17 +380,11 @@ static void update_project(
 
 static void save_expanded_paths(GKeyFile * key_file)
 {
-	GPtrArray *expanded_paths = prjorg_sidebar_get_expanded_paths();
-	gchar **expanded_paths_v = g_new (gchar *, expanded_paths->len + 1);
-	guint i;
+	gchar **expanded_paths = prjorg_sidebar_get_expanded_paths();
 
-	for (i = 0; i < expanded_paths->len; i++)
-		expanded_paths_v[i] = expanded_paths->pdata[i];
-	expanded_paths_v[expanded_paths->len] = NULL;
 	g_key_file_set_string_list(key_file, "prjorg", "expanded_paths",
-		(const gchar**) expanded_paths_v, g_strv_length(expanded_paths_v));
-	g_free(expanded_paths_v);
-	g_ptr_array_free(expanded_paths, TRUE);
+		(const gchar**) expanded_paths, g_strv_length(expanded_paths));
+	g_strfreev(expanded_paths);
 }
 
 

--- a/projectorganizer/src/prjorg-project.h
+++ b/projectorganizer/src/prjorg-project.h
@@ -52,6 +52,7 @@ typedef struct
 extern PrjOrg *prj_org;
 
 void prjorg_project_open(GKeyFile * key_file);
+gchar **prjorg_project_load_expanded_paths(GKeyFile * key_file);
 
 GtkWidget *prjorg_project_add_properties_tab(GtkWidget *notebook);
 

--- a/projectorganizer/src/prjorg-sidebar.c
+++ b/projectorganizer/src/prjorg-sidebar.c
@@ -1556,7 +1556,7 @@ static void on_map_expanded(GtkTreeView *tree_view, GtkTreePath *tree_path, GPtr
 }
 
 
-static GPtrArray *get_expanded_paths(void)
+GPtrArray *prjorg_sidebar_get_expanded_paths(void)
 {
 	GPtrArray *expanded_paths = g_ptr_array_new_with_free_func(g_free);
 
@@ -1580,7 +1580,7 @@ static gchar *get_selected_path(void)
 }
 
 
-void prjorg_sidebar_update(gboolean reload)
+void prjorg_sidebar_update_full(gboolean reload, gchar **expanded_paths)
 {
 	ExpandData *expand_data = g_new0(ExpandData, 1);
 
@@ -1591,8 +1591,15 @@ void prjorg_sidebar_update(gboolean reload)
 		GtkTreeSelection *treesel;
 		GtkTreeIter iter;
 		GtkTreeModel *model;
+		gchar **path;
+		GPtrArray *exp_paths_arr = g_ptr_array_new();
 
-		expand_data->expanded_paths = get_expanded_paths();
+		foreach_strv (path, expanded_paths)
+		{
+			g_ptr_array_add(exp_paths_arr, g_strdup(*path));
+		}
+
+		expand_data->expanded_paths = expanded_paths != NULL ? exp_paths_arr : prjorg_sidebar_get_expanded_paths();
 		expand_data->selected_path = get_selected_path();
 
 		load_project();
@@ -1604,6 +1611,12 @@ void prjorg_sidebar_update(gboolean reload)
 
 	/* perform on idle - avoids unnecessary jumps on project load */
 	plugin_idle_add(geany_plugin, (GSourceFunc)expand_on_idle, expand_data);
+}
+
+
+void prjorg_sidebar_update(gboolean reload)
+{
+	prjorg_sidebar_update_full(reload, NULL);
 }
 
 

--- a/projectorganizer/src/prjorg-sidebar.h
+++ b/projectorganizer/src/prjorg-sidebar.h
@@ -28,8 +28,11 @@ void prjorg_sidebar_find_file_in_active(void);
 void prjorg_sidebar_find_tag_in_active(void);
 
 void prjorg_sidebar_update(gboolean reload);
+void prjorg_sidebar_update_full(gboolean reload, gchar **expanded_paths);
 
 void prjorg_sidebar_focus_project_tab(void);
+
+GPtrArray *prjorg_sidebar_get_expanded_paths(void);
 
 void on_open_file_manager(G_GNUC_UNUSED GtkMenuItem * menuitem, G_GNUC_UNUSED gpointer user_data);
 void on_open_terminal(G_GNUC_UNUSED GtkMenuItem * menuitem, G_GNUC_UNUSED gpointer user_data);

--- a/projectorganizer/src/prjorg-sidebar.h
+++ b/projectorganizer/src/prjorg-sidebar.h
@@ -32,7 +32,7 @@ void prjorg_sidebar_update_full(gboolean reload, gchar **expanded_paths);
 
 void prjorg_sidebar_focus_project_tab(void);
 
-GPtrArray *prjorg_sidebar_get_expanded_paths(void);
+gchar **prjorg_sidebar_get_expanded_paths(void);
 
 void on_open_file_manager(G_GNUC_UNUSED GtkMenuItem * menuitem, G_GNUC_UNUSED gpointer user_data);
 void on_open_terminal(G_GNUC_UNUSED GtkMenuItem * menuitem, G_GNUC_UNUSED gpointer user_data);


### PR DESCRIPTION
This pull request consists of 2 patches:

1. It remembers selection in the sidebar and on project reload the selected row is restored.
2. It stores/loads expanded paths to/from the project file so the state of the tree gets restored when switching between projects.