### PR TITLE
Overview: hide markers

### DIFF
--- a/overview/overview/overviewscintilla.c
+++ b/overview/overview/overviewscintilla.c
@@ -934,9 +934,12 @@ overview_scintilla_sync (OverviewScintilla *self)
 
   overview_scintilla_clone_styles (self);
 
-  for (gint i = 0; i < SC_MAX_MARGIN; i++)
+  for (gint i = 0; i <= SC_MAX_MARGIN; i++)
     sci_send (self, SETMARGINWIDTHN, i, 0);
 
+  for (gint i = 0; i <= MARKER_MAX; i++)
+    sci_send (self, MARKERSETALPHA, i, 0);
+  
   sci_send (self, SETVIEWEOL, 0, 0);
   sci_send (self, SETVIEWWS, 0, 0);
   sci_send (self, SETHSCROLLBAR, 0, 0);


### PR DESCRIPTION
According to the Scintilla Documentation:

> Any markers not associated with a visible margin will be displayed as changes in background colour in the text. A width in pixels can be set for each margin. Margins with a zero width are ignored completely.

All lines with markers, either builtin or used by plugins (`git-changebar`), appear on the white background, which is ugly, especially in dark themes.

This MR disables rendering of markers by making them fully transparent on the overview.

Additionally, it fixes `SETMARGINWIDTHN` for the last (missing) margin:

> 5 margins are allocated initially numbered from 0 to SC_MAX_MARGIN (4).