### PR TITLE
Feature remote debugger

### DIFF
--- a/debugger/ChangeLog
+++ b/debugger/ChangeLog
@@ -1,3 +1,7 @@
+01-29-2022 	Pascal Martin <pascal.fb.martin@gmail.com>
+
+	* add remote and cross development debugging mode.
+
 14-06-2012 	Alexander Petukhov <devel@apetukhov.ru>
 
 	* fixed reverse children order in watch/autos

--- a/debugger/ChangeLog
+++ b/debugger/ChangeLog
@@ -1,4 +1,4 @@
-01-29-2022 	Pascal Martin <pascal.fb.martin@gmail.com>
+29-01-2022 	Pascal Martin <pascal.fb.martin@gmail.com>
 
 	* add remote and cross development debugging mode.
 

--- a/debugger/README
+++ b/debugger/README
@@ -31,6 +31,7 @@ Features
 * Saving debug session data in a Geany project (can be switched through settings)
 * Double or single panel modes
 * Hotkeys
+* Remote and cross development debug sessions.
 
 Usage
 -----

--- a/debugger/src/dconfig.c
+++ b/debugger/src/dconfig.c
@@ -108,6 +108,7 @@ static void debug_load_from_keyfile(GKeyFile *keyfile)
 	g_free(value);
 	/* debugger */
 	tpage_set_debugger(value = g_key_file_get_string(keyfile, DEBUGGER_GROUP, "debugger", NULL));
+	tpage_set_debugger_mode(value = g_key_file_get_string(keyfile, DEBUGGER_GROUP, "debugger_mode", NULL));
 	g_free(value);
 	/* arguments */
 	tpage_set_commandline(value = g_key_file_get_string(keyfile, DEBUGGER_GROUP, "arguments", NULL));
@@ -186,6 +187,7 @@ static void save_to_keyfile(GKeyFile *keyfile)
 	
 	g_key_file_set_string(keyfile, DEBUGGER_GROUP, "target", tpage_get_target());
 	g_key_file_set_string(keyfile, DEBUGGER_GROUP, "debugger", tpage_get_debugger());
+	g_key_file_set_string(keyfile, DEBUGGER_GROUP, "debugger_mode", tpage_get_debugger_mode());
 	g_key_file_set_string(keyfile, DEBUGGER_GROUP, "arguments", tpage_get_commandline());
 	
 	/* environment */
@@ -404,6 +406,7 @@ static void config_set_debug_defaults(GKeyFile *keyfile)
 {
 	g_key_file_set_string(keyfile, DEBUGGER_GROUP, "target", "");
 	g_key_file_set_string(keyfile, DEBUGGER_GROUP, "debugger", "");
+	g_key_file_set_string(keyfile, DEBUGGER_GROUP, "debugger_mode", "");
 	g_key_file_set_string(keyfile, DEBUGGER_GROUP, "arguments", "");
 
 	g_key_file_set_integer(keyfile, DEBUGGER_GROUP, "envvar_count", 0);

--- a/debugger/src/debug.c
+++ b/debugger/src/debug.c
@@ -1189,11 +1189,13 @@ void debug_run(void)
 {
 	if (DBS_IDLE == debug_state)
 	{
+		int mode;
 		gchar *target, *commandline;
 		GList *env, *watches, *breaks;
 
 		target = g_strstrip(tpage_get_target());
-		if (!strlen(target))
+		mode = tpage_get_debug_mode_index();
+		if ((!strlen(target)) && (!mode))
 		{
 			g_free(target);
 			return;
@@ -1205,7 +1207,7 @@ void debug_run(void)
 
 		/* init selected debugger  module */
 		active_module = modules[tpage_get_debug_module_index()].module;
-		if(active_module->run(target, commandline, env, watches, breaks, ttyname(pty_slave), &callbacks))
+		if(active_module->run(mode, target, commandline, env, watches, breaks, ttyname(pty_slave), &callbacks))
 		{
 			/* set target page - readonly */
 			tpage_set_readonly(TRUE);

--- a/debugger/src/debug_module.h
+++ b/debugger/src/debug_module.h
@@ -105,7 +105,7 @@ typedef enum _break_set_activity {
 /* type to hold pointers to describe a debug module */
 typedef struct _dbg_module {
 	
-	gboolean (*run) (const gchar* target, const gchar* commandline, GList* env, GList *witer, GList *biter, const gchar* terminal_device, dbg_callbacks* callbacks);
+	gboolean (*run) (gint dbgmode, const gchar* target, const gchar* commandline, GList* env, GList *witer, GList *biter, const gchar* terminal_device, dbg_callbacks* callbacks);
 	void (*restart) (void);
 	void (*stop) (void);
 	void (*resume) (void);

--- a/debugger/src/tpage.h
+++ b/debugger/src/tpage.h
@@ -33,7 +33,11 @@ void			tpage_set_target(const gchar *newvalue);
 gchar*		tpage_get_debugger(void);
 void			tpage_set_debugger(const gchar *newvalue);
 
+gchar*		tpage_get_debugger_mode(void);
+void			tpage_set_debugger_mode(const gchar *newvalue);
+
 int				tpage_get_debug_module_index(void);
+int             tpage_get_debug_mode_index(void);
 
 gchar*		tpage_get_commandline(void);
 void			tpage_set_commandline(const gchar *newvalue);

--- a/po/fr.po
+++ b/po/fr.po
@@ -694,6 +694,26 @@ msgstr "Débogueur :"
 msgid "Command Line Arguments"
 msgstr "Arguments de la ligne de commande"
 
+#. arguments
+#: ../debugger/src/tpage.c:537
+msgid "Remote Address"
+msgstr "Addresse de la machine distante"
+
+#. arguments
+#: ../debugger/src/tpage.c:537
+msgid "Local Mode"
+msgstr "Mode Local"
+
+#. arguments
+#: ../debugger/src/tpage.c:537
+msgid "Remote Mode"
+msgstr "Mode à Distance"
+
+#. arguments
+#: ../debugger/src/tpage.c:537
+msgid "Cross Development Mode"
+msgstr "Mode Dévelopement Croisé"
+
 #. environment
 #: ../debugger/src/tpage.c:326
 msgid "Environment Variables"


### PR DESCRIPTION
This is a small set of changes in the Debugger plugin to support gdb's remote mode (using gdbserver on the remote side). An additional cross development mode launches gdb-multiarch instead of gdb, so that an amd64 workstation can be used to debug a target running on an ARM board, or any other combination supported by gdb-multiarch.

Large portion of the changes is to adjust the debugger Target page, so that the debug mode is explicit and visible. In addition the label flip-flop between Command line Arguments and Remote Address to reflect how the field is actually used.

The `--multi` option of gdbserver is not supported. Doing so might require modifying the GUI, among other impacts.

A French translation is provided for the new labels. Since I am not familiar with the internationalization tools, I just hand-made a few more entries. Feel free to correct if that was not the right way.