### PR TITLE
Debugger: Fix debugging of multi-threaded programs

### DIFF
--- a/debugger/src/debug.c
+++ b/debugger/src/debug.c
@@ -966,6 +966,10 @@ static void on_select_thread(int thread_id)
 {
 	gboolean success;
 
+	/* interactive use - only when in stopped state */
+	if (debug_state != DBS_STOPPED)
+		return;
+
 	if (stack)
 		remove_stack_markers();
 


### PR DESCRIPTION
- By the original design, the debugger allows thread context switching only
  interactively, while in the Call Stack pane (in Stopped mode). This is
  being handled directly through GtkTreeView::cursor-changed event.
- However, this event was also getting triggered when clearing the latest
  thread's Call Stack after continuing the execution (Running mode).
- This behavior does not seem to have being intended, and it lead to a
  number of issues: stepping hangs, corruption of GDB output processing,
  unnecessary attempts at opening of source files corresponding to thread's
  call-stack frames.
- To avoid all of these issues, GtkTreeView::cursor-changed event is left
  unhandled while clearing the frames. Also the handler for thread-context
  switching is allowed processing only in debugger's Stopped mode to enforce
  the intended behavior.

Fixes #1069 