### PR TITLE
Debugger: Fix typos in code comments

### DIFF
--- a/debugger/src/bptree.c
+++ b/debugger/src/bptree.c
@@ -79,7 +79,7 @@ static GHashTable *files;
 move_to_line_cb on_break_clicked = NULL;
 
 /* 
- * gets tree row reference for an unsected row at the same depth
+ * gets tree row reference for an unselected row at the same depth
  */
 static GtkTreeRowReference* get_unselected_sibling(GtkTreePath *path)
 {
@@ -119,7 +119,7 @@ static GtkTreeRowReference* get_unselected_sibling(GtkTreePath *path)
 }
 
 /* 
- * checks file ENABLED column if all childs are enabled and unchecks otherwise
+ * checks file ENABLED column if all children are enabled and unchecks otherwise
  */
 static void update_file_node(GtkTreeIter *file_iter)
 {
@@ -378,7 +378,7 @@ static void on_hitscount_changed(GtkCellRendererText *renderer, gchar *path, gch
 }                                                        
 
 /*
- * enable / disable all breaks for a file when it's checkbox icon has been clicked
+ * enable / disable all breaks for a file when its checkbox icon has been clicked
  */
 static void on_enable_for_file(GtkCellRendererToggle *cell_renderer, gchar *path, gpointer user_data)
 {
@@ -418,7 +418,7 @@ static void on_enable_for_file(GtkCellRendererToggle *cell_renderer, gchar *path
 }
 
 /*
- * enable / disable particulary break when it's icon has been clicked
+ * enable / disable particularly break when its icon has been clicked
  */
 static void on_enable_break(CellRendererBreakIcon *cell_renderer, gchar *path, gpointer user_data)
 {
@@ -599,7 +599,7 @@ static gboolean on_key_pressed(GtkWidget *widget, GdkEvent *event, gpointer user
  */
 
 /*
- * init breaks tree view and return it if succesfull
+ * init breaks tree view and return it if successful
  * arguments:
  * 		cb - callback to call on treeview double click
  */
@@ -612,7 +612,7 @@ gboolean bptree_init(move_to_line_cb cb)
 	/* save double click callback */
 	on_break_clicked = cb;
 	
-	/* crete hash table for file nodes */
+	/* create hash table for file nodes */
 	files = g_hash_table_new_full(
 		g_str_hash,
 		g_str_equal,

--- a/debugger/src/breakpoints.c
+++ b/debugger/src/breakpoints.c
@@ -83,7 +83,7 @@ static void hash_table_foreach_add_to_list(gpointer key, gpointer value, gpointe
 }
 
 /*
- * functions to perform markers and tree vew operation when breakpoint
+ * functions to perform markers and tree view operation when breakpoint
  * is finally updated/added/removed
  */
 static void on_add(breakpoint *bp)
@@ -175,7 +175,7 @@ static gint compare_func(gconstpointer a, gconstpointer b, gpointer user_data)
 }
 
 /*
- * functions that are called when a breakpoint is altered while debuginng session is active.
+ * functions that are called when a breakpoint is altered while debugging session is active.
  * Therefore, these functions try to alter break in debug session first and if successful -
  * do what on_... do or simply call on_... function directly
  */
@@ -366,7 +366,7 @@ void breaks_add(const char* file, int line, char* condition, int enabled, int hi
 	enum dbs state = debug_get_state();
 
 	/* do not process async break manipulation on modules
-	that do not support async interuppt */
+	that do not support async interrupt */
 	if (DBS_RUNNING == state &&  !debug_supports_async_breaks())
 		return;
 	
@@ -385,7 +385,7 @@ void breaks_add(const char* file, int line, char* condition, int enabled, int hi
 	g_tree_insert(tree, GINT_TO_POINTER(bp->line), bp);
 
 	/* handle creation instantly if debugger is idle or stopped
-	and request debug module interruption overwise */
+	and request debug module interruption otherwise */
 	if (DBS_IDLE == state)
 	{
 		on_add(bp);
@@ -409,7 +409,7 @@ void breaks_remove(const char* file, int line)
 	enum dbs state = debug_get_state();
 
 	/* do not process async break manipulation on modules
-	that do not support async interuppt */
+	that do not support async interrupt */
 	if (DBS_RUNNING == state &&  !debug_supports_async_breaks())
 		return;
 
@@ -418,7 +418,7 @@ void breaks_remove(const char* file, int line)
 		return;
 
 	/* handle removing instantly if debugger is idle or stopped
-	and request debug module interruption overwise */
+	and request debug module interruption otherwise */
 	if (DBS_IDLE == state)
 	{
 		on_remove(bp);
@@ -438,13 +438,13 @@ void breaks_remove(const char* file, int line)
 void breaks_remove_list(GList *list)
 {
 	/* do not process async break manipulation on modules
-	that do not support async interuppt */
+	that do not support async interrupt */
 	enum dbs state = debug_get_state();
 	if (DBS_RUNNING == state &&  !debug_supports_async_breaks())
 		return;
 
 	/* handle removing instantly if debugger is idle or stopped
-	and request debug module interruption overwise */
+	and request debug module interruption otherwise */
 	if (DBS_IDLE == state)
 	{
 		on_remove_list(list);
@@ -472,7 +472,7 @@ void breaks_remove_all(void)
  * sets all breakpoints fo the file enabled or disabled.
  * arguments:
  * 		file - list of breakpoints
- * 		enabled - anble or disable breakpoints
+ * 		enabled - enable or disable breakpoints
  */
 void breaks_set_enabled_for_file(const char *file, gboolean enabled)
 {
@@ -480,14 +480,14 @@ void breaks_set_enabled_for_file(const char *file, gboolean enabled)
 	enum dbs state = debug_get_state();
 
 	/* do not process async break manipulation on modules
-	that do not support async interuppt */
+	that do not support async interrupt */
 	if (DBS_RUNNING == state &&  !debug_supports_async_breaks())
 		return;
 
 	breaks = breaks_get_for_document(file);
 
 	/* handle switching instantly if debugger is idle or stopped
-	and request debug module interruption overwise */
+	and request debug module interruption otherwise */
 	if (DBS_IDLE == state)
 	{
 		on_set_enabled_list(breaks, enabled);
@@ -512,7 +512,7 @@ void breaks_switch(const char* file, int line)
 	enum dbs state = debug_get_state();
 
 	/* do not process async break manipulation on modules
-	that do not support async interuppt */
+	that do not support async interrupt */
 	if (DBS_RUNNING == state &&  !debug_supports_async_breaks())
 		return;
 
@@ -524,7 +524,7 @@ void breaks_switch(const char* file, int line)
 	bp->enabled = !bp->enabled;
 	
 	/* handle switching instantly if debugger is idle or stopped
-	and request debug module interruption overwise */
+	and request debug module interruption otherwise */
 	if (DBS_IDLE == state)
 	{
 		on_switch(bp);
@@ -549,7 +549,7 @@ void breaks_set_hits_count(const char* file, int line, int count)
 	enum dbs state = debug_get_state();
 
 	/* do not process async break manipulation on modules
-	that do not support async interuppt */
+	that do not support async interrupt */
 	if (DBS_RUNNING == state &&  !debug_supports_async_breaks())
 		return;
 
@@ -561,7 +561,7 @@ void breaks_set_hits_count(const char* file, int line, int count)
 	bp->hitscount = count;
 	
 	/* handle setting hits count instantly if debugger is idle or stopped
-	and request debug module interruption overwise */
+	and request debug module interruption otherwise */
 	if (state == DBS_IDLE)
 	{
 		on_set_hits_count(bp);
@@ -586,7 +586,7 @@ void breaks_set_condition(const char* file, int line, const char* condition)
 	enum dbs state = debug_get_state();
 
 	/* do not process async break manipulation on modules
-	that do not support async interuppt */
+	that do not support async interrupt */
 	if (DBS_RUNNING == state &&  !debug_supports_async_breaks())
 		return;
 
@@ -598,7 +598,7 @@ void breaks_set_condition(const char* file, int line, const char* condition)
 	strncpy(bp->condition, condition, G_N_ELEMENTS(bp->condition) - 1);
 	
 	/* handle setting condition instantly if debugger is idle or stopped
-	and request debug module interruption overwise */
+	and request debug module interruption otherwise */
 	if (state == DBS_IDLE)
 	{
 		on_set_condition(bp);

--- a/debugger/src/callbacks.c
+++ b/debugger/src/callbacks.c
@@ -94,12 +94,12 @@ static void set_markers_for_file(const gchar* file)
 
 /*
  * 	Following group of callbacks are used for
- * 	checking of existance of the config file
+ * 	checking of existence of the config file
  * 	and changing buttons state in the target page
  */
 
 /*
- * 	Occures before document is going to be saved
+ * 	Occurs before document is going to be saved
  */
 static gboolean _unexisting_file = FALSE;
 void on_document_before_save(GObject *obj, GeanyDocument *doc, gpointer user_data)
@@ -114,7 +114,7 @@ void on_document_before_save(GObject *obj, GeanyDocument *doc, gpointer user_dat
 }
 
 /*
- * 	Occures on saving document
+ * 	Occurs on saving document
  */
 void on_document_save(GObject *obj, GeanyDocument *doc, gpointer user_data)
 {
@@ -131,7 +131,7 @@ void on_document_save(GObject *obj, GeanyDocument *doc, gpointer user_data)
 }
 
 /*
- * 	Occures on document opening.
+ * 	Occurs on document opening.
  * 	Used to set breaks markers 
  */
 void on_document_open(GObject *obj, GeanyDocument *doc, gpointer user_data)
@@ -173,7 +173,7 @@ static gboolean on_mouse_leave(GtkWidget *widget, GdkEvent *event, gpointer user
 }
 
 /*
- * 	Occures on notify from editor.
+ * 	Occurs on notify from editor.
  * 	Handles margin click to set/remove breakpoint 
  */
 gboolean on_editor_notify(
@@ -304,7 +304,7 @@ gboolean on_editor_notify(
 }
 
 /*
- * 	Occures when key is pressed.
+ * 	Occurs when key is pressed.
  * 	Handles debug Run/Stop/... and add/remove breakpoint activities  
  */
 gboolean keys_callback(guint key_id)

--- a/debugger/src/cell_renderers/cellrendererframeicon.c
+++ b/debugger/src/cell_renderers/cellrendererframeicon.c
@@ -21,7 +21,7 @@
 
 /*
  * 		cell renderer class that renders frame icon, that in turn depends on whether a
- * 		row is the first vhildren (uppermost frame) and whether a renderer is under the cursor
+ * 		row is the first child (uppermost frame) and whether a renderer is under the cursor
  */
 
 #include <string.h>

--- a/debugger/src/cell_renderers/cellrenderertoggle.c
+++ b/debugger/src/cell_renderers/cellrenderertoggle.c
@@ -22,7 +22,7 @@
 /*
  * 		cell renderer that inherits from toggle
  * 		the only difference - checks for a x position in "activate" signal
- * 		to ensure the "toggled" signal is sent only when clicked on a particulary cell renderer
+ * 		to ensure the "toggled" signal is sent only when clicked on a particular cell renderer
  */
 
 #include <geanyplugin.h>

--- a/debugger/src/dbm_gdb.c
+++ b/debugger/src/dbm_gdb.c
@@ -115,7 +115,7 @@ static GList *watches = NULL;
 static GList *files = NULL;
 
 /* set to true if library was loaded/unloaded
-and it's nessesary to refresh files list */
+and it's necessary to refresh files list */
 static gboolean file_refresh_needed = FALSE;
 
 /* current frame number */
@@ -219,7 +219,7 @@ static GList* read_until_prompt(void)
 }
 
 /*
- * write a command to a gdb channel and flush with a newlinw character
+ * write a command to a gdb channel and flush with a newline character
  */
 static void gdb_input_write_line(const gchar *line)
 {
@@ -251,9 +251,9 @@ static void gdb_input_write_line(const gchar *line)
 	{
 		if (err)
 		{
-			#ifdef DEBUG_OUTPUT
+#ifdef DEBUG_OUTPUT
 			dbg_cbs->send_message(err->message, "red");
-			#endif
+#endif
 			g_clear_error(&err);
 		}
 	}
@@ -299,9 +299,9 @@ static GList* add_to_queue(GList* queue, const gchar *message, const gchar *comm
 }
 
 /*
- * asyncronous output reader
+ * asynchronous output reader
  * reads from startup async commands.
- * looks for a command completion (normal or abnormal), if noraml - executes next command
+ * looks for a command completion (normal or abnormal), if normal - executes next command
  */
 static void exec_async_command(const gchar* command);
 static gboolean on_read_async_output(GIOChannel * src, GIOCondition cond, gpointer data)
@@ -334,10 +334,10 @@ static gboolean on_read_async_output(GIOChannel * src, GIOCondition cond, gpoint
 
 		if (!strcmp(record->klass, "done"))
 		{
-			/* command completed succesfully - run next command if exists */
+			/* command completed successfully - run next command if exists */
 			if (commands->next)
 			{
-				/* if there are commads left */
+				/* if there are commands left */
 				queue_item *item;
 
 				commands = commands->next;
@@ -405,7 +405,7 @@ static gboolean on_read_async_output(GIOChannel * src, GIOCondition cond, gpoint
 }
 
 /*
- * asyncronous gdb output reader
+ * asynchronous gdb output reader
  * looks for a stopped event, then notifies "debug" module and removes async handler
  */
 enum dbs debug_get_state(void);
@@ -458,7 +458,7 @@ static gboolean on_read_from_gdb(GIOChannel * src, GIOCondition cond, gpointer d
 		dbg_cbs->remove_thread(atoi(id));
 	}
 	else if (gdb_mi_record_matches(record, '=', "library-loaded", NULL) ||
-			 gdb_mi_record_matches(record, '=', "library-unloaded", NULL))
+		 gdb_mi_record_matches(record, '=', "library-unloaded", NULL))
 	{
 		file_refresh_needed = TRUE;
 	}
@@ -468,7 +468,7 @@ static gboolean on_read_from_gdb(GIOChannel * src, GIOCondition cond, gpointer d
 	{
 		const gchar *reason;
 
-		/* removing read callback (will pulling all output left manually) */
+		/* removing read callback (will be pulling all output left manually) */
 		if (gdb_id_out)
 		{
 			g_source_remove(gdb_id_out);
@@ -596,7 +596,7 @@ static gboolean on_read_from_gdb(GIOChannel * src, GIOCondition cond, gpointer d
 }
 
 /*
- * execute "command" asyncronously
+ * execute "command" asynchronously
  * after writing command to an input channel
  * connects reader to output channel and exits
  * after execution
@@ -609,12 +609,12 @@ static void exec_async_command(const gchar* command)
 
 	gdb_input_write_line(command);
 
-	/* connect read callback to the output chanel */
+	/* connect read callback to the output channel */
 	gdb_id_out = g_io_add_watch(gdb_ch_out, G_IO_IN, on_read_from_gdb, NULL);
 }
 
 /*
- * execute "command" syncronously
+ * execute "command" synchronously
  * i.e. reading output right
  * after execution
  */
@@ -748,7 +748,7 @@ static gboolean run(const gchar* file, const gchar* commandline, GList* env, GLi
 	/* set handler for gdb process exit event */
 	gdb_src_id = g_child_watch_add(gdb_pid, on_gdb_exit, NULL);
 
-	/* create GDB GIO chanels */
+	/* create GDB GIO channels */
 	gdb_ch_in = g_io_channel_unix_new(gdb_in);
 	gdb_ch_out = g_io_channel_unix_new(gdb_out);
 
@@ -785,7 +785,7 @@ static gboolean run(const gchar* file, const gchar* commandline, GList* env, GLi
 	g_free(command);
 	g_free(escaped);
 
-	/* setting asyncronous mode */
+	/* setting asynchronous mode */
 	commands = add_to_queue(commands, NULL, "-gdb-set target-async 1", _("Error configuring GDB"), FALSE);
 
 	/* setting null-stop array printing */
@@ -804,7 +804,7 @@ static gboolean run(const gchar* file, const gchar* commandline, GList* env, GLi
 	commands = add_to_queue(commands, NULL, command, NULL, FALSE);
 	g_free(command);
 
-	/* set passed evironment */
+	/* set passed environment */
 	iter = env;
 	while (iter)
 	{
@@ -868,7 +868,7 @@ static gboolean run(const gchar* file, const gchar* commandline, GList* env, GLi
 	commands = add_to_queue(commands, NULL, command, NULL, FALSE);
 	g_free(command);
 
-	/* connect read callback to the output chanel */
+	/* connect read callback to the output channel */
 	gdb_id_out = g_io_add_watch(gdb_ch_out, G_IO_IN, on_read_async_output, commands);
 
 	item = (queue_item*)commands->data;
@@ -1321,7 +1321,7 @@ static void update_watches(void)
 	}
 
 	/* create GDB variables, adding successfully created
-	variables to the list then passed for updatind */
+	variables to the list then passed for updating */
 	for (iter = watches; iter; iter = iter->next)
 	{
 		variable *var = (variable*)iter->data;

--- a/debugger/src/dconfig.c
+++ b/debugger/src/dconfig.c
@@ -72,7 +72,7 @@ static GCond cond;
 static GThread *saving_thread;
 
 /* flags that indicate that part of a config has been changed and
- * is going to be saved on the savng thread */
+ * is going to be saved on the saving thread */
 static gboolean debug_config_changed = FALSE;
 static gboolean panel_config_changed = FALSE;
 
@@ -522,7 +522,7 @@ int	config_get_right_selected_tab_index(void)
 }
 
 /*
- *	update GUI fron the store specified
+ *	update GUI from the store specified
  *  also handles default values insertion in a keyfile if debug section doesn't exist 
  */
 void config_set_debug_store(debug_store store)
@@ -587,7 +587,7 @@ void config_on_project_close(GObject *obj, gpointer user_data)
 	{
 		if (DBS_IDLE != debug_get_state())
 		{
-			/* stop a debugger and ait for it to be stopped */
+			/* stop a debugger and wait for it to be stopped */
 			debug_stop();
 			
 			while (DBS_IDLE != debug_get_state())
@@ -602,7 +602,7 @@ void config_on_project_close(GObject *obj, gpointer user_data)
 
 /*
  *	project save handler
- * 	handles ne project creation and updatng a project using project properties dialog 
+ * 	handles new project creation and updating a project using project properties dialog
  */
 void config_on_project_save(GObject *obj, GKeyFile *config, gpointer user_data)
 {

--- a/debugger/src/debug.c
+++ b/debugger/src/debug.c
@@ -22,7 +22,7 @@
 /*
  * 		Debug activities handlers (Run, Stop, etc)
  *		Manages GUI that is debug-state dependent.
- * 		Finaly, after checking current debug state - passes
+ * 		Finally, after checking current debug state - passes
  * 		command to the active debug module.
  * 		Also creates debug-related GUI (local, debug terminal pages)
  * 		and handles run-time watches and breakpoints changes.
@@ -76,7 +76,7 @@ extern GeanyData		*geany_data;
 
 /*
  *  calltip size  
- */ 
+ */
 #define CALLTIP_HEIGHT 20
 #define CALLTIP_WIDTH 200
 
@@ -96,9 +96,9 @@ extern dbg_module dbg_module_gdb;
 /* active debug module */
 dbg_module *active_module = NULL;
 
-/* Interrupt relateed data
- * Interrtion is requested when breakpoint is set/added/removed
- * asyncronously. Then debug_request_interrupt is called,
+/* Interrupt related data
+ * Interruption is requested when breakpoint is set/added/removed
+ * asynchronously. Then debug_request_interrupt is called,
  * supplied with interrupt reason (interrupt_flags),
  * breakpoint pointer (interrupt_data) and callback to call
  * after interruption
@@ -127,7 +127,7 @@ static GtkWidget *debugger_messages_textview = NULL;
 static GtkAdjustment *hadj = NULL;
 static GtkAdjustment *vadj = NULL;
 
-/* stack trace/watch/autos CtkTreeView widgets */
+/* stack trace/watch/autos GtkTreeView widgets */
 static GtkWidget *stree = NULL;
 static GtkWidget *wtree = NULL;
 static GtkWidget *atree = NULL;
@@ -141,7 +141,7 @@ static GtkWidget **sensitive_widget[] = {&stree, &wtree, &atree, NULL};
 
 /* 
  * current stack for holding
- * position of ffreames markers
+ * position of frames markers
  */
 static GList* stack = NULL;
 
@@ -219,7 +219,7 @@ static void add_stack_markers(void)
 }
 
 /* 
- * Handlers for GUI maked changes in watches
+ * Handlers for GUI-made changes in watches
  */
 
 /* 
@@ -364,7 +364,7 @@ static void on_watch_dragged_callback(GtkWidget *wgt, GdkDragContext *context, i
 	}
 	
 	/* if debugger is active (in stopped condition) - add to run-time watch list
-	 *  if not - just set new expession in the tree view */ 
+	 *  if not - just set new expression in the tree view */
 	if (DBS_STOPPED == debug_state)
 	{
 		variable *var = active_module->add_watch(expression);
@@ -401,7 +401,7 @@ static gboolean on_watch_key_pressed_callback(GtkWidget *widget, GdkEvent  *even
 	if (1 != gtk_tree_selection_count_selected_rows(selection) ||
 	    (rows && gtk_tree_path_compare((GtkTreePath*)rows->data, empty_path)))
 	{
-		/* path reference to select after deleteing finishes */
+		/* path reference to select after deleting finishes */
 		GtkTreeRowReference *reference_to_select = NULL;
 		GtkTreePath *path_to_select;
 
@@ -429,7 +429,7 @@ static gboolean on_watch_key_pressed_callback(GtkWidget *widget, GdkEvent  *even
 		{
 			GtkTreeRowReference *reference = (GtkTreeRowReference*)iter->data;
 			/* check for valid reference because two or more equal
-			refernces could be put in the list if several child items
+			references could be put in the list if several children items
 			of the same node were selected and the path for the
 			current reference was already deleted */
 			if (gtk_tree_row_reference_valid(reference))
@@ -540,7 +540,7 @@ static gboolean on_watch_button_pressed_callback(GtkWidget *treeview, GdkEventBu
 				gtk_tree_store_insert_before(wstore, &newvar, NULL, &empty);
 			
 				/* if debugger is active (in stopped condition) - add to run-time watch list
-				 *  if not - just set new expession in the tree view */ 
+				 *  if not - just set new expression in the tree view */
 				if (DBS_STOPPED == debug_state)
 				{
 					variable *var = active_module->add_watch(expression);
@@ -625,7 +625,7 @@ static void enable_sensitive_widgets(gboolean enable)
 }
 
 /* 
- * Debug state changed hanflers
+ * Debug state changed handlers
  */
 
 /* 
@@ -636,7 +636,7 @@ static void on_debugger_run (void)
 	/* update debug state */
 	debug_state = DBS_RUNNING;
 
-	/* if curren instruction marker was set previously - remove it */
+	/* if current instruction marker was set previously - remove it */
 	if (stack)
 	{
 		remove_stack_markers();
@@ -675,7 +675,7 @@ static void on_debugger_stopped (int thread_id)
 	if (calltips)
 		g_hash_table_remove_all(calltips);
 
-	/* if a stop was requested for asyncronous exiting -
+	/* if a stop was requested for asynchronous exiting -
 	 * stop debug module and exit */
 	if (exit_pending)
 	{
@@ -893,7 +893,7 @@ static void on_debugger_error (const gchar* message)
 }
 
 /* 
- * called from debugger module when a thead has been removed 
+ * called from debugger module when a thread has been removed 
  */
 static void on_thread_removed(int thread_id)
 {
@@ -901,7 +901,7 @@ static void on_thread_removed(int thread_id)
 }
 
 /* 
- * called from debugger module when a new thead has been added 
+ * called from debugger module when a new thread has been added 
  */
 static void on_thread_added (int thread_id)
 {
@@ -960,7 +960,7 @@ static void on_select_frame(int frame_number)
 }
 
 /*
- * called when a thread should been selected
+ * called when a thread has been selected
  */
 static void on_select_thread(int thread_id)
 {
@@ -1091,7 +1091,7 @@ void debug_init(void)
 	gtk_scrolled_window_add_with_viewport(GTK_SCROLLED_WINDOW(tab_messages), debugger_messages_textview);
 #endif
 	
-	/* create tex tags */
+	/* create text tags */
 	buffer = gtk_text_view_get_buffer(GTK_TEXT_VIEW(debugger_messages_textview));
 	gtk_text_buffer_create_tag(buffer, "black", "foreground", "#000000", NULL); 
 	gtk_text_buffer_create_tag(buffer, "grey", "foreground", "#AAAAAA", NULL); 
@@ -1133,7 +1133,7 @@ enum dbs debug_get_state(void)
 }
 
 /*
- * gets current stack frames lisy
+ * gets current stack frames list
  */
 GList* debug_get_stack(void)
 {
@@ -1175,7 +1175,7 @@ GList* debug_get_modules(void)
 }
 
 /*
- * checks whether currently active debug module supports asyncronous breaks
+ * checks whether currently active debug module supports asynchronous breaks
  */
 gboolean debug_supports_async_breaks(void)
 {
@@ -1210,7 +1210,7 @@ void debug_run(void)
 			/* set target page - readonly */
 			tpage_set_readonly(TRUE);
 
-			/* update debuf state */
+			/* update debug state */
 			debug_state = DBS_RUN_REQUESTED;
 		}
 
@@ -1310,7 +1310,7 @@ void debug_execute_until(const gchar *file, int line)
 /*
  * sets a break
  * arguments:
- *		bp - breakpoitn to set
+ *		bp - breakpoint to set
  * 		bsa - what to do with breakpoint (add/remove/change)
  */
 gboolean debug_set_break(breakpoint* bp, break_set_activity bsa)
@@ -1325,7 +1325,7 @@ gboolean debug_set_break(breakpoint* bp, break_set_activity bsa)
 /*
  * removes a break
  * arguments:
- *		bp - breakpoitn to set
+ *		bp - breakpoint to set
  */
 gboolean debug_remove_break(breakpoint* bp)
 {
@@ -1337,12 +1337,12 @@ gboolean debug_remove_break(breakpoint* bp)
 }
 
 /*
- * requests active debug module to interrupt fo further
+ * requests active debug module to interrupt for further
  * breakpoint modifications
  * arguments:
- *		cb - callback to call on interruption happents
+ *		cb - callback to call when the interruption happens
  * 		bp - breakpoint to deal with
- * 		flags - whar to do with breakpoint
+ * 		flags - what to do with breakpoint
  */
 void debug_request_interrupt(bs_callback cb, gpointer data)
 {
@@ -1361,7 +1361,7 @@ gchar* debug_error_message(void)
 }
 
 /*
- * evaluates expression in runtime and returns its value or NULL if unevaluatable
+ * evaluates expression in runtime and returns its value or NULL if non-evaluatable
  */
 gchar* debug_evaluate_expression(gchar *expression)
 {
@@ -1424,7 +1424,7 @@ gchar* debug_get_calltip_for_expression(gchar* expression)
 
 /*
  * check whether source for the current instruction
- * is avaiable
+ * is available
  */
 gboolean debug_current_instruction_have_sources(void)
 {

--- a/debugger/src/debug_module.h
+++ b/debugger/src/debug_module.h
@@ -71,7 +71,7 @@ typedef struct _variable {
 	GString *value;
 	/* flag indicating whether a variable has children */
 	gboolean has_children;
-	/* flag indicating whether getting variable value was successfull */
+	/* flag indicating whether getting variable value was successful */
 	gboolean evaluated;
 	/* variable type */
 	variable_type vt;
@@ -142,7 +142,7 @@ typedef struct _dbg_module {
 	
 } dbg_module;
 
-/* helping macroes to declare and define degub module */
+/* helping macros to declare and define debug module */
 #define DBG_MODULE_DECLARE(name) extern dbg_module dbg_module##name
 #define DBG_MODULE_DEFINE(name) dbg_module dbg_module_##name = { \
 	run, \

--- a/debugger/src/envtree.c
+++ b/debugger/src/envtree.c
@@ -61,11 +61,11 @@ static GtkTreeRowReference *empty_row = NULL;
 
 static GtkTreePath *being_edited_value = NULL;
 
-/* env variable name cloumn */
+/* env variable name column */
 static GtkTreeViewColumn *column_name = NULL;
 static GtkCellRenderer *renderer_name = NULL;
 
-/* env variable value cloumn */
+/* env variable value column */
 static GtkTreeViewColumn *column_value = NULL;
 static GtkCellRenderer *renderer_value = NULL;
 
@@ -86,7 +86,7 @@ static void add_empty_row(void)
 		VALUE, "",
 		-1);
 
-	/* remeber reference */
+	/* remember reference */
 	path = gtk_tree_model_get_path(GTK_TREE_MODEL(store), &empty);
 	empty_row = gtk_tree_row_reference_new(GTK_TREE_MODEL(store), path);
 	gtk_tree_path_free(path);
@@ -250,8 +250,8 @@ static void on_value_changed(GtkCellRendererText *renderer, gchar *path, gchar *
 	striped = g_strstrip(g_strdup(new_text));
 	if (!strlen(striped))
 	{
-		/* if new value is empty string, if it's a new row - do nothig
-		 otheerwise - offer to delete a variable */
+		/* if new value is empty string, if it's a new row - do nothing
+		 otherwise - offer to delete a variable */
 		if (empty)
 			gtk_list_store_set(store, &iter, NAME, "", -1);
 		else
@@ -307,7 +307,7 @@ static void on_value_editing_started(GtkCellRenderer *renderer, GtkCellEditable 
 }
 
 /*
- * env tree view value editing cancelled (Escape pressed)
+ * env tree view value editing canceled (Escape pressed)
  */
 static void on_value_editing_cancelled(GtkCellRenderer *renderer, gpointer user_data)
 {
@@ -337,7 +337,7 @@ static void on_value_editing_cancelled(GtkCellRenderer *renderer, gpointer user_
 }
 
 /*
- * env tree view name changed hadler 
+ * env tree view name changed handler
  */
 static void on_name_changed(GtkCellRendererText *renderer, gchar *path, gchar *new_text, gpointer user_data)
 {

--- a/debugger/src/gdb_mi.c
+++ b/debugger/src/gdb_mi.c
@@ -155,7 +155,7 @@ static gchar *parse_cstring(const gchar **p)
 						}
 						else
 						{
-							g_warning("Unkown escape \"\\%c\"", **p);
+							g_warning("Unknown escape \"\\%c\"", **p);
 							(*p)--; /* put the \ back */
 							c = **p;
 						}

--- a/debugger/src/markers.c
+++ b/debugger/src/markers.c
@@ -79,13 +79,13 @@ void markers_set_for_document(ScintillaObject *sci)
 	/* conditional breakpoint */
 	scintilla_send_message(sci, SCI_MARKERDEFINEPIXMAP, M_BP_CONDITIONAL, (long)breakpoint_condition_xpm);
 
-	/* currect instruction background */
+	/* current instruction background */
 	scintilla_send_message(sci, SCI_MARKERDEFINE, M_CI_BACKGROUND, SC_MARK_BACKGROUND);
 	scintilla_send_message(sci, SCI_MARKERSETBACK, M_CI_BACKGROUND, YELLOW);
 	scintilla_send_message(sci, SCI_MARKERSETFORE, M_CI_BACKGROUND, YELLOW);
 	scintilla_send_message(sci, SCI_MARKERSETALPHA, M_CI_BACKGROUND, 75);
 
-	/* currect instruction arrow */
+	/* current instruction arrow */
 	scintilla_send_message(sci, SCI_MARKERDEFINEPIXMAP, M_CI_ARROW, (long)frame_current_xpm);
 
 	/* frame marker current */

--- a/debugger/src/plugin.c
+++ b/debugger/src/plugin.c
@@ -98,7 +98,7 @@ static gboolean plugin_debugger_init(GeanyPlugin *plugin, G_GNUC_UNUSED gpointer
 	/* add target page */
 	tpage_init();
 	
-	/* init brekpoints */
+	/* init breakpoints */
 	breaks_init(editor_open_position);
 	
 	/* init markers */

--- a/debugger/src/vtree.c
+++ b/debugger/src/vtree.c
@@ -41,7 +41,7 @@
 #include "pixbuf.h"
 
 
-/* columns minumum width in characters */
+/* columns minimum width in characters */
 #define MIN_COLUMN_CHARS 20
 
 /*
@@ -74,7 +74,7 @@ static gboolean on_key_pressed(GtkWidget *widget, GdkEvent *event, gpointer user
 
 
 /*
- * value rendere function
+ * value renderer function
  */
 static void render_icon(GtkTreeViewColumn *tree_column,
 	 GtkCellRenderer *cell,
@@ -111,7 +111,7 @@ static void render_icon(GtkTreeViewColumn *tree_column,
 }
 
 /*
- * value rendere function
+ * value renderer function
  */
 static void render_value(GtkTreeViewColumn *tree_column,
 	 GtkCellRenderer *cell,
@@ -207,25 +207,25 @@ GtkWidget* vtree_create(watch_render_name on_render_name, watch_expression_chang
 	column = gtk_tree_view_column_new_with_attributes ("", renderer, "text", W_LAST_VISIBLE, NULL);
 	gtk_tree_view_append_column (GTK_TREE_VIEW (tree), column);
 
-	/* Internal (unvisible column) */
+	/* Internal (invisible column) */
 	renderer = gtk_cell_renderer_text_new ();
 	column = gtk_tree_view_column_new_with_attributes ("Internal", renderer, "text", W_INTERNAL, NULL);
 	gtk_tree_view_column_set_visible(column, FALSE);
 	gtk_tree_view_append_column (GTK_TREE_VIEW (tree), column);
 	
-	/* Path expression (unvisible column) */
+	/* Path expression (invisible column) */
 	renderer = gtk_cell_renderer_text_new ();
 	column = gtk_tree_view_column_new_with_attributes ("Expression", renderer, "text", W_EXPRESSION, NULL);
 	gtk_tree_view_column_set_visible(column, FALSE);
 	gtk_tree_view_append_column (GTK_TREE_VIEW (tree), column);
 
-	/* STUB (unvisible column) */
+	/* STUB (invisible column) */
 	renderer = gtk_cell_renderer_toggle_new ();
 	column = gtk_tree_view_column_new_with_attributes ("Need Update", renderer, "active", W_STUB, NULL);
 	gtk_tree_view_append_column (GTK_TREE_VIEW (tree), column);
 	gtk_tree_view_column_set_visible(column, FALSE);
 
-	/* Changed (unvisible column) */
+	/* Changed (invisible column) */
 	renderer = gtk_cell_renderer_toggle_new ();
 	column = gtk_tree_view_column_new_with_attributes ("Changed", renderer, "active", W_CHANGED, NULL);
 	gtk_tree_view_append_column (GTK_TREE_VIEW (tree), column);

--- a/debugger/src/watch_model.c
+++ b/debugger/src/watch_model.c
@@ -83,7 +83,7 @@ inline static void add_stub(GtkTreeStore *store, GtkTreeIter *parent)
 
 /*
  * insert all "vars" members to "parent" iterator in the "tree" as new children
- * mark_changed specifies whether to mark new items as beed changed
+ * mark_changed specifies whether to mark new items as being changed
  * expand specifies whether to expand to the added children
  */
 inline static void append_variables(GtkTreeView *tree, GtkTreeIter *parent, GList *vars,
@@ -166,7 +166,7 @@ inline static void append_variables(GtkTreeView *tree, GtkTreeIter *parent, GLis
 				gtk_tree_path_free(path);
 			}
 			
-			/* add stub if added child also have children */
+			/* add stub if added child also has children */
 			if (v->has_children)
 				add_stub(store, &child);
 		}
@@ -240,7 +240,7 @@ void expand_stub(GtkTreeView *tree, GtkTreeIter *parent, GList *vars)
 	/* remember stub iterator */
 	gtk_tree_model_iter_children(model, &stub, parent);
 
-	/* check whether arent has been changed */
+	/* check whether parent has been changed */
 	gtk_tree_model_get(model, parent,
 		W_CHANGED, &changed,
 		-1);
@@ -253,7 +253,7 @@ void expand_stub(GtkTreeView *tree, GtkTreeIter *parent, GList *vars)
 }
 
 /*
- * change watch specified by "iter" as dscribed in "var"
+ * change watch specified by "iter" as described in "var"
  */
 void change_watch(GtkTreeView *tree, GtkTreeIter *iter, gpointer var)
 {
@@ -265,7 +265,7 @@ void change_watch(GtkTreeView *tree, GtkTreeIter *iter, gpointer var)
 	/* update variable */
 	update_variable(store, iter, v, FALSE);
 
-	/* if item have children - remove them */ 		
+	/* if item has children - remove them */
 	if (gtk_tree_model_iter_has_child(model, iter))
 		remove_children(model, iter);
 	
@@ -330,7 +330,7 @@ void update_variables(GtkTreeView *tree, GtkTreeIter *parent, GList *vars)
 			/* 2. find this path is "vars" list */
 			var = lookup_variable(vars, name);
 
-			/* 3. check if we have found currect iterator */
+			/* 3. check if we have found current iterator */
 			if (!var)
 			{
 				/* if we haven't - remove current and try to move to the next one
@@ -419,7 +419,7 @@ void clear_watch_values(GtkTreeView *tree)
 	
 	do
 	{
-		/* if item have children - process them */ 		
+		/* if item has children - process them */
 		if (gtk_tree_model_iter_has_child(model, &child))
 			remove_children(model, &child);
 		

--- a/debugger/src/wtree.c
+++ b/debugger/src/wtree.c
@@ -199,7 +199,7 @@ void wtree_remove_all(void)
 }
 
 /*
- * add new watche to the tree view
+ * add new watch to the tree view
  */
 void wtree_add_watch(gchar *watch)
 {


### PR DESCRIPTION
This is an excellent and quite complex plugin. Fixing typos in the code comments helps new devs to get familiar with the plugin's design and logic. Well, it helped me at least...