### PR TITLE
Use standard gettext, following Geany core.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,7 +99,6 @@ jobs:
             gettext
             python-docutils
             # geany-plugins
-            intltool
             check
             cppcheck
             # debugger

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ cscope.files
 #-----------------------------------------------------------------------
 # / (root)
 #-----------------------------------------------------------------------
+/ABOUT-NLS
 /aclocal.m4
 /autom4te.cache
 /build/*.pyc
@@ -35,6 +36,7 @@ cscope.files
 /config.log
 /config.status
 /config.sub
+/config.rpath
 /configure
 /debian
 /depcomp
@@ -62,10 +64,8 @@ cscope.files
 /po/ChangeLog.save
 /po/*.gmo
 /po/*.header
-/po/.intltool-merge-cache
-/po/LINGUAS
 /po/Makefile.in.in
-/po/Makevars
+/po/Makevars.template
 /po/*.mo
 /po/*.pot
 /po/POTFILES
@@ -76,6 +76,7 @@ cscope.files
 /po/*.sed
 /po/*.sin
 /po/stamp-it
+/po/stamp-po
 
 #-----------------------------------------------------------------------
 # TeX

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,11 +1,16 @@
 #!/bin/sh -e
 
+srcdir=`dirname $0`
+test -z "$srcdir" && srcdir=.
+
 mkdir -p build/cache
-intltoolize -c -f
-autoreconf -vfi
+
+(cd $srcdir; autoreconf --install --verbose)
 
 if [ "$NOCONFIGURE" = 1 ]; then
     echo "Done. configure skipped."
     exit 0;
 fi
-exec ./configure "$@"
+
+echo "Running $srcdir/configure $@ ..."
+$srcdir/configure "$@" && echo "Now type 'make' to compile." || exit 1

--- a/build/common.m4
+++ b/build/common.m4
@@ -75,6 +75,7 @@ AC_DEFUN([GP_CHECK_MINGW],
 		*mingw*)
 			AC_DEFINE([WIN32], [1], [we are cross compiling for WIN32])
 			AM_CONDITIONAL([MINGW], true)
+			LIBS="$LIBS -liconv"
 			;;
 		*)
 			AM_CONDITIONAL([MINGW], false)

--- a/build/i18n.m4
+++ b/build/i18n.m4
@@ -1,16 +1,14 @@
 AC_DEFUN([GP_I18N],
 [
-    if test -z "$conf_dir" ; then
-        conf_dir="."
-    fi
-    ALL_LINGUAS=`cd "$conf_dir/po" 2>/dev/null && ls *.po 2>/dev/null | $AWK 'BEGIN { FS="."; ORS=" " } { print $[1] }'`
     GETTEXT_PACKAGE=geany-plugins
     AC_SUBST(GETTEXT_PACKAGE)
     AC_DEFINE_UNQUOTED(
-        [GETTEXT_PACKAGE],
+    o    [GETTEXT_PACKAGE],
         ["$GETTEXT_PACKAGE"],
         [The domain to use with gettext])
     LOCALEDIR="${datadir}/locale"
     AC_SUBST(LOCALEDIR)
-    AM_GLIB_GNU_GETTEXT
+
+    AM_GNU_GETTEXT_VERSION([0.19.8])
+    AM_GNU_GETTEXT([external])
 ])

--- a/configure.ac
+++ b/configure.ac
@@ -16,9 +16,11 @@ AM_PROG_CC_C_O
 AC_DISABLE_STATIC
 AC_PROG_LIBTOOL
 
-dnl i18n
-IT_PROG_INTLTOOL([0.35.0])
-GP_I18N
+dnl i18n, inline so autoreconf can detect gettext usage
+AM_GNU_GETTEXT_VERSION([0.19.8])
+AM_GNU_GETTEXT([external])
+AC_SUBST([GETTEXT_PACKAGE],[$PACKAGE])
+AC_DEFINE_UNQUOTED([GETTEXT_PACKAGE], ["$PACKAGE"], [Gettext package.])
 
 dnl common checks
 GP_CHECK_GEANY(1.29)

--- a/po/LINGUAS
+++ b/po/LINGUAS
@@ -1,0 +1,1 @@
+be ca da de el es fr gl it ja kk nl pt_BR pt ru tr uk zh_CN

--- a/po/Makevars
+++ b/po/Makevars
@@ -1,0 +1,82 @@
+# Makefile variables for PO directory in any package using GNU gettext.
+#
+# Copyright (C) 2003-2019 Free Software Foundation, Inc.
+# This file is free software; the Free Software Foundation gives
+# unlimited permission to use, copy, distribute, and modify it.
+
+# Usually the message domain is the same as the package name.
+DOMAIN = $(PACKAGE)
+
+# These two variables depend on the location of this directory.
+subdir = po
+top_builddir = ..
+
+# These options get passed to xgettext.
+XGETTEXT_OPTIONS = --keyword=_ --keyword=N_ --keyword=C_:1c,2 --keyword=NC_:1c,2 --from-code=UTF-8
+
+# This is the copyright holder that gets inserted into the header of the
+# $(DOMAIN).pot file.  Set this to the copyright holder of the surrounding
+# package.  (Note that the msgstr strings, extracted from the package's
+# sources, belong to the copyright holder of the package.)  Translators are
+# expected to transfer the copyright for their translations to this person
+# or entity, or to disclaim their copyright.  The empty string stands for
+# the public domain; in this case the translators are expected to disclaim
+# their copyright.
+COPYRIGHT_HOLDER = The Geany contributors
+
+# This tells whether or not to prepend "GNU " prefix to the package
+# name that gets inserted into the header of the $(DOMAIN).pot file.
+# Possible values are "yes", "no", or empty.  If it is empty, try to
+# detect it automatically by scanning the files in $(top_srcdir) for
+# "GNU packagename" string.
+PACKAGE_GNU = no
+
+# This is the email address or URL to which the translators shall report
+# bugs in the untranslated strings:
+# - Strings which are not entire sentences, see the maintainer guidelines
+#   in the GNU gettext documentation, section 'Preparing Strings'.
+# - Strings which use unclear terms or require additional context to be
+#   understood.
+# - Strings which make invalid assumptions about notation of date, time or
+#   money.
+# - Pluralisation problems.
+# - Incorrect English spelling.
+# - Incorrect formatting.
+# It can be your email address, or a mailing list address where translators
+# can write to without being subscribed, or the URL of a web page through
+# which the translators can contact you.
+MSGID_BUGS_ADDRESS = https://github.com/geany/geany/issues
+
+# This is the list of locale categories, beyond LC_MESSAGES, for which the
+# message catalogs shall be used.  It is usually empty.
+EXTRA_LOCALE_CATEGORIES =
+
+# This tells whether the $(DOMAIN).pot file contains messages with an 'msgctxt'
+# context.  Possible values are "yes" and "no".  Set this to yes if the
+# package uses functions taking also a message context, like pgettext(), or
+# if in $(XGETTEXT_OPTIONS) you define keywords with a context argument.
+USE_MSGCTXT = no
+
+# These options get passed to msgmerge.
+# Useful options are in particular:
+#   --previous            to keep previous msgids of translated messages,
+#   --quiet               to reduce the verbosity.
+MSGMERGE_OPTIONS =
+
+# These options get passed to msginit.
+# If you want to disable line wrapping when writing PO files, add
+# --no-wrap to MSGMERGE_OPTIONS, XGETTEXT_OPTIONS, and
+# MSGINIT_OPTIONS.
+MSGINIT_OPTIONS =
+
+# This tells whether or not to regenerate a PO file when $(DOMAIN).pot
+# has changed.  Possible values are "yes" and "no".  Set this to no if
+# the POT file is checked in the repository and the version control
+# program ignores timestamps.
+PO_DEPENDS_ON_POT = no
+
+# This tells whether or not to forcibly update $(DOMAIN).pot and
+# regenerate PO files on "make dist".  Possible values are "yes" and
+# "no".  Set this to no if the POT file and PO files are maintained
+# externally.
+DIST_DEPENDS_ON_UPDATE_PO = yes

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -213,7 +213,7 @@ geanyvc/src/utils.c
 geniuspaste/src/geniuspaste.c
 
 # GitChangeBar
-[type: gettext/glade]git-changebar/data/prefs.ui
+git-changebar/data/prefs.ui
 git-changebar/src/gcb-plugin.c
 
 # Keyrecord
@@ -247,14 +247,14 @@ overview/overview/overviewprefs.c
 overview/overview/overviewprefspanel.c
 overview/overview/overviewscintilla.c
 overview/overview/overviewui.c
-[type: gettext/glade]overview/data/prefs.ui
+overview/data/prefs.ui
 
 # Pairtaghighlighter
 pairtaghighlighter/src/pair_tag_highlighter.c
 
 # PoHelper
-[type: gettext/glade]pohelper/data/menus.ui
-[type: gettext/glade]pohelper/data/stats.ui
+pohelper/data/menus.ui
+pohelper/data/stats.ui
 pohelper/src/gph-plugin.c
 
 # Pretty-printer

--- a/po/be.po
+++ b/po/be.po
@@ -6,8 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Geany-Plugins 1.30\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-29 19:41+0200\n"
+"Report-Msgid-Bugs-To: https://github.com/geany/geany/issues\n"
+"POT-Creation-Date: 2022-06-28 07:39+0200\n"
 "PO-Revision-Date: 2009-06-11 10:15+0200\n"
 "Last-Translator: Yura Siamshka <yurand2@gmail.com>>\n"
 "Language-Team: Belarusian <geany-i18n@uvena.de>\n"
@@ -24,27 +24,27 @@ msgstr ""
 msgid "(Empty Line)"
 msgstr ""
 
-#: ../addons/src/ao_bookmarklist.c:315
+#: ../addons/src/ao_bookmarklist.c:331
 msgid "_Remove Bookmark"
 msgstr ""
 
 #. Translators: Number is meant at this point.
-#: ../addons/src/ao_bookmarklist.c:342
+#: ../addons/src/ao_bookmarklist.c:358
 msgid "No."
 msgstr ""
 
-#: ../addons/src/ao_bookmarklist.c:350 ../devhelp/src/dhp-object.c:494
+#: ../addons/src/ao_bookmarklist.c:366 ../devhelp/src/dhp-object.c:494
 #: ../devhelp/devhelp/dh-window.c:1142
 msgid "Contents"
 msgstr ""
 
-#: ../addons/src/ao_bookmarklist.c:383 ../treebrowser/src/treebrowser.c:666
+#: ../addons/src/ao_bookmarklist.c:399 ../treebrowser/src/treebrowser.c:666
 #: ../webhelper/src/gwh-plugin.c:328
 msgid "Bookmarks"
 msgstr ""
 
 #. complete update
-#: ../addons/src/ao_tasks.c:373 ../geanyvc/src/geanyvc.c:2679
+#: ../addons/src/ao_tasks.c:373 ../geanyvc/src/geanyvc.c:2730
 msgid "_Update"
 msgstr ""
 
@@ -165,10 +165,10 @@ msgstr ""
 #: ../addons/src/addons.c:364 ../autoclose/src/autoclose.c:920
 #: ../codenav/src/codenavigation.c:281 ../latex/src/latex.c:208
 #: ../latex/src/latex.c:293 ../geanyprj/src/geanyprj.c:176
-#: ../geanyvc/src/geanyvc.c:2079 ../geniuspaste/src/geniuspaste.c:336
+#: ../geanyvc/src/geanyvc.c:2130 ../geniuspaste/src/geniuspaste.c:336
 #: ../lineoperations/src/lo_prefs.c:58 ../sendmail/src/sendmail.c:128
 #: ../sendmail/src/sendmail.c:293 ../spellcheck/src/scplugin.c:124
-#: ../treebrowser/src/treebrowser.c:2102
+#: ../treebrowser/src/treebrowser.c:2106
 #: ../updatechecker/src/updatechecker.c:262
 msgid "Plugin configuration directory could not be created."
 msgstr ""
@@ -717,7 +717,7 @@ msgstr ""
 msgid "Error loading file"
 msgstr ""
 
-#. setting asyncronous mode
+#. setting asynchronous mode
 #. setting null-stop array printing
 #. enable pretty printing
 #: ../debugger/src/dbm_gdb.c:789 ../debugger/src/dbm_gdb.c:792
@@ -1110,7 +1110,7 @@ msgid "A developers' help browser for GNOME"
 msgstr ""
 
 #. Create the current file Submenu
-#: ../devhelp/devhelp/dh-window.c:759 ../geanyvc/src/geanyvc.c:2660
+#: ../devhelp/devhelp/dh-window.c:759 ../geanyvc/src/geanyvc.c:2711
 #, fuzzy
 msgid "_File"
 msgstr "Дадаць файл"
@@ -1145,12 +1145,12 @@ msgstr ""
 msgid "_Print…"
 msgstr ""
 
-#: ../devhelp/devhelp/dh-window.c:782 ../devhelp/devhelp/eggfindbar.c:342
+#: ../devhelp/devhelp/dh-window.c:782
 #, fuzzy
 msgid "Find Next"
 msgstr "Дадаць файл"
 
-#: ../devhelp/devhelp/dh-window.c:784 ../devhelp/devhelp/eggfindbar.c:329
+#: ../devhelp/devhelp/dh-window.c:784
 #, fuzzy
 msgid "Find Previous"
 msgstr "Знайсьці і праэкце"
@@ -1340,7 +1340,7 @@ msgid ""
 "contributing to this plugin?"
 msgstr ""
 
-#: ../geanydoc/src/geanydoc.c:159 ../geanyvc/src/geanyvc.c:442
+#: ../geanydoc/src/geanydoc.c:159 ../geanyvc/src/geanyvc.c:448
 msgid "Could not parse the output of command"
 msgstr "Немагчыма прааналізаваць вывад каманды"
 
@@ -3014,14 +3014,14 @@ msgid ""
 "not enough arguments for command \"%s\".\n"
 msgstr ""
 
-#: ../geanylua/glspi_sci.c:637 ../geanylua/glspi_app.c:406
+#: ../geanylua/glspi_sci.c:729 ../geanylua/glspi_app.c:406
 #, c-format
 msgid ""
 "Error in module \"%s\" at function %s():\n"
 "unknown command \"%s\" given for argument #1.\n"
 msgstr ""
 
-#: ../geanylua/glspi_sci.c:781
+#: ../geanylua/glspi_sci.c:924
 #, c-format
 msgid ""
 "Error in module \"%s\" at function %s():\n"
@@ -3029,7 +3029,7 @@ msgid ""
 " unknown flag \"%s\" for element #%d\n"
 msgstr ""
 
-#: ../geanylua/glspi_sci.c:785
+#: ../geanylua/glspi_sci.c:928
 msgid "<too large to display>"
 msgstr ""
 
@@ -3778,7 +3778,7 @@ msgid "New _Below"
 msgstr ""
 
 #: ../geanymacro/src/geanymacro.c:1824 ../geanymacro/src/geanymacro.c:2120
-#: ../treebrowser/src/treebrowser.c:1338 ../treebrowser/src/treebrowser.c:1340
+#: ../treebrowser/src/treebrowser.c:1342 ../treebrowser/src/treebrowser.c:1344
 #, fuzzy
 msgid "_Delete"
 msgstr "Выдаліць праэкт"
@@ -4149,8 +4149,8 @@ msgstr ""
 msgid "a key with fingerprint"
 msgstr ""
 
-#: ../geanypg/src/verify_aux.c:66 ../spellcheck/src/gui.c:610
-#: ../spellcheck/src/gui.c:621
+#: ../geanypg/src/verify_aux.c:66 ../spellcheck/src/gui.c:607
+#: ../spellcheck/src/gui.c:618
 msgid "unknown"
 msgstr ""
 
@@ -4451,49 +4451,49 @@ msgid ""
 "contributing to this plugin?"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:501
+#: ../geanyvc/src/geanyvc.c:507
 #, c-format
 msgid "geanyvc: s_spawn_sync error: %s"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:587
+#: ../geanyvc/src/geanyvc.c:593
 #, c-format
 msgid "File %s: action %s executed via %s."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:646 ../geanyvc/src/geanyvc.c:657
+#: ../geanyvc/src/geanyvc.c:633 ../geanyvc/src/geanyvc.c:643
 #, c-format
-msgid "geanyvc: vcdiff_file_activated: Unable to rename '%s' to '%s'"
+msgid "geanyvc: diff_external: Unable to rename '%s' to '%s'"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:683 ../geanyvc/src/geanyvc.c:733
+#: ../geanyvc/src/geanyvc.c:698 ../geanyvc/src/geanyvc.c:784
 msgid "No changes were made."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:760
+#: ../geanyvc/src/geanyvc.c:811
 msgid "No history available"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:953 ../geanyvc/src/geanyvc.c:961
+#: ../geanyvc/src/geanyvc.c:1004 ../geanyvc/src/geanyvc.c:1012
 #, c-format
 msgid "Do you really want to revert: %s?"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:969
+#: ../geanyvc/src/geanyvc.c:1020
 #, c-format
 msgid "Do you really want to add: %s?"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:976
+#: ../geanyvc/src/geanyvc.c:1027
 #, c-format
 msgid "Do you really want to remove: %s?"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:999
+#: ../geanyvc/src/geanyvc.c:1050
 msgid "Do you really want to update?"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1126
+#: ../geanyvc/src/geanyvc.c:1177
 msgid ""
 "The resulting differences cannot be displayed because the changes are too "
 "big to display here and would slow down the UI significantly.\n"
@@ -4502,327 +4502,327 @@ msgid ""
 "Geany directly by using the GeanyVC menu (Base Directory -> Diff)."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1280
+#: ../geanyvc/src/geanyvc.c:1331
 msgid "Commit Y/N"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1290
+#: ../geanyvc/src/geanyvc.c:1341
 msgid "Status"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1297
+#: ../geanyvc/src/geanyvc.c:1348
 msgid "Path"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1414
+#: ../geanyvc/src/geanyvc.c:1465
 msgid "Choose a previous commit message"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1476
+#: ../geanyvc/src/geanyvc.c:1527
 #, c-format
 msgid "Line: %d Column: %d"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1523
+#: ../geanyvc/src/geanyvc.c:1574
 msgid "Commit"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1564
+#: ../geanyvc/src/geanyvc.c:1615
 msgid "_De-/select all files"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1608
+#: ../geanyvc/src/geanyvc.c:1659
 msgid "<b>Commit message:</b>"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1632
+#: ../geanyvc/src/geanyvc.c:1683
 msgid "C_ommit"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1740
+#: ../geanyvc/src/geanyvc.c:1791
 msgid "Nothing to commit."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1788
+#: ../geanyvc/src/geanyvc.c:1839
 #, c-format
 msgid ""
 "Error initializing GeanyVC spell checking: %s. Check your configuration."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1823
+#: ../geanyvc/src/geanyvc.c:1874
 #, c-format
 msgid "Commit failed (status: %d, error: %s)."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1824
+#: ../geanyvc/src/geanyvc.c:1875
 msgid "Commit failed; see status in the Message window."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1829
+#: ../geanyvc/src/geanyvc.c:1880
 msgid "Changes committed."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2151
+#: ../geanyvc/src/geanyvc.c:2202
 msgid "Set Changed-flag for document tabs created by the plugin"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2154
+#: ../geanyvc/src/geanyvc.c:2205
 msgid ""
 "If this option is activated, every new by the VC-plugin created document tab "
 "will be marked as changed. Even this option is useful in some cases, it "
 "could cause a big number of annoying \"Do you want to save\"-dialogs."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2162
+#: ../geanyvc/src/geanyvc.c:2213
 msgid "Confirm adding new files to a VCS"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2165
+#: ../geanyvc/src/geanyvc.c:2216
 msgid "Shows a confirmation dialog on adding a new (created) file to VCS."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2171
+#: ../geanyvc/src/geanyvc.c:2222
 msgid "Maximize commit dialog"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2172
+#: ../geanyvc/src/geanyvc.c:2223
 msgid "Show commit dialog maximize."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2178
+#: ../geanyvc/src/geanyvc.c:2229
 msgid "Use external diff viewer"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2180
+#: ../geanyvc/src/geanyvc.c:2231
 msgid "Use external diff viewer for file diff."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2186
+#: ../geanyvc/src/geanyvc.c:2237
 msgid "Show VC entries at editor menu"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2188
+#: ../geanyvc/src/geanyvc.c:2239
 msgid "Show entries for VC functions inside editor menu"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2193
+#: ../geanyvc/src/geanyvc.c:2244
 msgid "Attach menu to menubar"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2195
+#: ../geanyvc/src/geanyvc.c:2246
 msgid ""
 "Whether menu for this plugin are getting placed either inside tools menu or "
 "directly inside Geany's menubar. Will take in account after next start of "
 "GeanyVC"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2203
+#: ../geanyvc/src/geanyvc.c:2254
 msgid "Enable CVS"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2208
+#: ../geanyvc/src/geanyvc.c:2259
 msgid "Enable GIT"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2213
+#: ../geanyvc/src/geanyvc.c:2264
 msgid "Enable Fossil"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2218
+#: ../geanyvc/src/geanyvc.c:2269
 msgid "Enable SVN"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2223
+#: ../geanyvc/src/geanyvc.c:2274
 msgid "Enable SVK"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2228
+#: ../geanyvc/src/geanyvc.c:2279
 msgid "Enable Bazaar"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2233
+#: ../geanyvc/src/geanyvc.c:2284
 msgid "Enable Mercurial"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2239
+#: ../geanyvc/src/geanyvc.c:2290
 msgid "Spellcheck language"
 msgstr ""
 
 #. Diff of current file
 #. Diff of the current dir
 #. Complete diff of base directory
-#: ../geanyvc/src/geanyvc.c:2368 ../geanyvc/src/geanyvc.c:2463
-#: ../geanyvc/src/geanyvc.c:2503
+#: ../geanyvc/src/geanyvc.c:2419 ../geanyvc/src/geanyvc.c:2514
+#: ../geanyvc/src/geanyvc.c:2554
 msgid "_Diff"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2371
+#: ../geanyvc/src/geanyvc.c:2422
 msgid "Make a diff from the current active file"
 msgstr ""
 
 #. Revert current file
 #. Revert current dir
 #. Revert everything
-#: ../geanyvc/src/geanyvc.c:2376 ../geanyvc/src/geanyvc.c:2472
-#: ../geanyvc/src/geanyvc.c:2511
+#: ../geanyvc/src/geanyvc.c:2427 ../geanyvc/src/geanyvc.c:2523
+#: ../geanyvc/src/geanyvc.c:2562
 msgid "_Revert"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2379
+#: ../geanyvc/src/geanyvc.c:2430
 msgid "Restore pristine working copy file (undo local edits)."
 msgstr ""
 
 #. Blame for current file
-#: ../geanyvc/src/geanyvc.c:2388
+#: ../geanyvc/src/geanyvc.c:2439
 msgid "_Blame"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2391
+#: ../geanyvc/src/geanyvc.c:2442
 msgid "Shows the changes made at one file per revision and author."
 msgstr ""
 
 #. History/log of current file
 #. History/log of the current dir
 #. Complete History/Log of base directory
-#: ../geanyvc/src/geanyvc.c:2398 ../geanyvc/src/geanyvc.c:2482
-#: ../geanyvc/src/geanyvc.c:2523
+#: ../geanyvc/src/geanyvc.c:2449 ../geanyvc/src/geanyvc.c:2533
+#: ../geanyvc/src/geanyvc.c:2574
 msgid "_History (log)"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2401
+#: ../geanyvc/src/geanyvc.c:2452
 msgid "Shows the log of the current file"
 msgstr ""
 
 #. base version of the current file
-#: ../geanyvc/src/geanyvc.c:2406
+#: ../geanyvc/src/geanyvc.c:2457
 msgid "_Original"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2409
+#: ../geanyvc/src/geanyvc.c:2460
 msgid "Shows the original of the current file"
 msgstr ""
 
 #. add current file
-#: ../geanyvc/src/geanyvc.c:2417
+#: ../geanyvc/src/geanyvc.c:2468
 msgid "_Add to Version Control"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2419
+#: ../geanyvc/src/geanyvc.c:2470
 msgid "Add file to repository."
 msgstr ""
 
 #. remove current file
-#: ../geanyvc/src/geanyvc.c:2425
+#: ../geanyvc/src/geanyvc.c:2476
 msgid "_Remove from Version Control"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2427
+#: ../geanyvc/src/geanyvc.c:2478
 msgid "Remove file from repository."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2460
+#: ../geanyvc/src/geanyvc.c:2511
 msgid "_Directory"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2466
+#: ../geanyvc/src/geanyvc.c:2517
 msgid "Make a diff from the directory of the current active file"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2475
+#: ../geanyvc/src/geanyvc.c:2526
 msgid "Restore original files in the current folder (undo local edits)."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2485
+#: ../geanyvc/src/geanyvc.c:2536
 msgid "Shows the log of the current directory"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2499
+#: ../geanyvc/src/geanyvc.c:2550
 msgid "_Base Directory"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2505
+#: ../geanyvc/src/geanyvc.c:2556
 msgid "Make a diff from the top VC directory"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2513
+#: ../geanyvc/src/geanyvc.c:2564
 msgid "Revert any local edits."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2526
+#: ../geanyvc/src/geanyvc.c:2577
 msgid "Shows the log of the top VC directory"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2543
+#: ../geanyvc/src/geanyvc.c:2594
 msgid "_VC file Actions"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2552
+#: ../geanyvc/src/geanyvc.c:2603
 msgid "VC _Commit..."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2596
+#: ../geanyvc/src/geanyvc.c:2647
 msgid "Show diff of file"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2598
+#: ../geanyvc/src/geanyvc.c:2649
 msgid "Show diff of directory"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2600
+#: ../geanyvc/src/geanyvc.c:2651
 msgid "Show diff of basedir"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2603
+#: ../geanyvc/src/geanyvc.c:2654
 msgid "Commit changes"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2605
+#: ../geanyvc/src/geanyvc.c:2656
 msgid "Show status"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2607
+#: ../geanyvc/src/geanyvc.c:2658
 msgid "Revert single file"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2609
+#: ../geanyvc/src/geanyvc.c:2660
 msgid "Revert directory"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2611
+#: ../geanyvc/src/geanyvc.c:2662
 msgid "Revert base directory"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2613
+#: ../geanyvc/src/geanyvc.c:2664
 msgid "Update file"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2643
+#: ../geanyvc/src/geanyvc.c:2694
 msgid "_VC"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2650
+#: ../geanyvc/src/geanyvc.c:2701
 msgid "_Version Control"
 msgstr ""
 
 #. Status of basedir
-#: ../geanyvc/src/geanyvc.c:2672
+#: ../geanyvc/src/geanyvc.c:2723
 msgid "_Status"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2674
+#: ../geanyvc/src/geanyvc.c:2725
 msgid "Show status."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2681
+#: ../geanyvc/src/geanyvc.c:2732
 msgid "Update from remote repository."
 msgstr ""
 
 #. Commit all changes
-#: ../geanyvc/src/geanyvc.c:2686
+#: ../geanyvc/src/geanyvc.c:2737
 msgid "_Commit..."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2688
+#: ../geanyvc/src/geanyvc.c:2739
 msgid "Commit changes."
 msgstr ""
 
@@ -4933,34 +4933,6 @@ msgstr ""
 
 #: ../geniuspaste/src/geniuspaste.c:959
 msgid "_Paste it!"
-msgstr ""
-
-#: ../git-changebar/data/prefs.ui.h:1
-msgid "_Monitor repository for changes"
-msgstr ""
-
-#: ../git-changebar/data/prefs.ui.h:2
-msgid ""
-"Whether to automatically update the diff in order to maintain it up to date "
-"when the underlying Git repository changes.  This should generally be "
-"enabled for optimal user experience."
-msgstr ""
-
-#: ../git-changebar/data/prefs.ui.h:3
-msgid "_Added lines:"
-msgstr ""
-
-#: ../git-changebar/data/prefs.ui.h:4
-msgid "_Changed lines:"
-msgstr ""
-
-#: ../git-changebar/data/prefs.ui.h:5
-#, fuzzy
-msgid "_Removed lines:"
-msgstr "Выдаліць файл"
-
-#: ../git-changebar/data/prefs.ui.h:6
-msgid "Colors"
 msgstr ""
 
 #: ../git-changebar/src/gcb-plugin.c:62
@@ -5144,8 +5116,8 @@ msgstr ""
 #: ../lipsum/src/lipsum.c:184 ../sendmail/src/sendmail.c:396
 #, c-format
 msgid ""
-"Your configuration directory has been successfully moved from \"%s\" to \"%s"
-"\"."
+"Your configuration directory has been successfully moved from \"%s\" to "
+"\"%s\"."
 msgstr ""
 
 #: ../lipsum/src/lipsum.c:199
@@ -5316,7 +5288,7 @@ msgstr ""
 msgid "Unable to read value for '%s' key: %s"
 msgstr ""
 
-#: ../multiterm/src/tab-label.vala:62 ../treebrowser/src/treebrowser.c:2132
+#: ../multiterm/src/tab-label.vala:62 ../treebrowser/src/treebrowser.c:2137
 msgid "Terminal"
 msgstr ""
 
@@ -5354,113 +5326,6 @@ msgstr ""
 msgid "Show Overview"
 msgstr ""
 
-#: ../overview/data/prefs.ui.h:1
-msgid ""
-"The amount to zoom the overview sidebar. This should probably negative if "
-"you want the sidebar zoomed out."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:2
-msgid "Zoom Level:"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:3
-msgid "The width of the overview sidebar."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:4
-msgid "Width:"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:5
-msgid ""
-"The number of lines to scroll at a time when scrolling the overview sidebar."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:6
-msgid "Scroll Lines:"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:7
-#, fuzzy
-msgid "Position on left"
-msgstr "Лакацыя:"
-
-#: ../overview/data/prefs.ui.h:8
-msgid ""
-"Position the overview bar on the left rather than the right (requires Geany "
-"1.25 or greater)."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:9
-msgid "Hide tooltip"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:10
-msgid ""
-"Hide the tooltip that is displayed when mousing over the overview that shows "
-"line, column and position information."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:11
-msgid "Hide editor scrollbar"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:12
-msgid ""
-"Whether to hide Geany's regular editor scrollbar while the overview bar is "
-"visible."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:13
-msgid "Disable overlay"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:14
-msgid ""
-"Turn off drawing overlay, which shows the region of the main editor view "
-"that is currently in view, ontop of the overview bar."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:15 ../scope/data/scope.glade.h:130
-#: ../scope/data/scope_gtk3.glade.h:130
-msgid "Options"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:16
-msgid ""
-"The color and opacity of the overlay drawn ontop of the overlay sidebar."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:17
-msgid "Color:"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:18
-msgid ""
-"The color and opacity of the border drawn around the revealed area in the "
-"overview sidebar. Set to the same as Overlay Color to disable."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:19
-msgid "Outline Color:"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:20
-msgid "Draw over visible area"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:21
-msgid ""
-"When checked it will draw the overlay ontop of the area that is visible in "
-"the main editor view, when unchecked, it will do the opposite and draw the "
-"overlay everywhere but the visible area, \"revealing\" the visible part."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:22
-msgid "Overlay"
-msgstr ""
-
 #: ../pairtaghighlighter/src/pair_tag_highlighter.c:43
 msgid "Pair Tag Highlighter"
 msgstr ""
@@ -5485,145 +5350,6 @@ msgstr ""
 #, fuzzy
 msgid "Select To Matching Tag"
 msgstr "Выдаліць праэкт"
-
-#: ../pohelper/data/menus.ui.h:1
-msgid "_Translation Helper"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:2
-msgid "_Previous String"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:3 ../pohelper/src/gph-plugin.c:1590
-msgid "Go to previous string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:4
-msgid "_Next String"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:5 ../pohelper/src/gph-plugin.c:1593
-msgid "Go to next string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:6
-msgid "Pre_vious Untranslated"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:7 ../pohelper/src/gph-plugin.c:1596
-msgid "Go to previous untranslated string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:8
-msgid "Next _Untranslated"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:9 ../pohelper/src/gph-plugin.c:1599
-msgid "Go to next untranslated string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:10
-msgid "Previous Fu_zzy"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:11 ../pohelper/src/gph-plugin.c:1602
-msgid "Go to previous fuzzily translated string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:12
-msgid "Next _Fuzzy"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:13 ../pohelper/src/gph-plugin.c:1605
-msgid "Go to next fuzzily translated string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:14
-msgid "Previous Untranslated or Fuzz_y"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:15 ../pohelper/src/gph-plugin.c:1608
-msgid "Go to previous untranslated or fuzzy string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:16
-msgid "Next Untranslated _or Fuzzy"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:17 ../pohelper/src/gph-plugin.c:1612
-msgid "Go to next untranslated or fuzzy string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:18 ../pohelper/src/gph-plugin.c:1623
-#, fuzzy
-msgid "Toggle current translation fuzziness"
-msgstr "Інтэрактыўная даведка"
-
-#: ../pohelper/data/menus.ui.h:19
-msgid "_Toggle Fuzziness"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:20
-msgid "Paste _Message as Translation"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:21
-msgid "Paste the original untranslated string to the translation"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:22 ../pohelper/src/gph-plugin.c:1620
-msgid "Reflow the current translation string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:23
-msgid "_Reflow Translation"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:24 ../pohelper/src/gph-plugin.c:1626
-msgid "Show statistics of the current document"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:25
-msgid "_Show stats"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:26
-msgid ""
-"Whether to update the translation headers (author, revision date, ...) upon "
-"file save"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:27
-msgid "Update _Headers Upon Save"
-msgstr ""
-
-#: ../pohelper/data/stats.ui.h:1
-msgid "Translation statistics"
-msgstr ""
-
-#: ../pohelper/data/stats.ui.h:2
-msgid "Choose a color for translated strings"
-msgstr ""
-
-#: ../pohelper/data/stats.ui.h:3
-msgid "Choose a color for fuzzily translated strings"
-msgstr ""
-
-#: ../pohelper/data/stats.ui.h:4
-msgid "Choose a color for untranslated strings"
-msgstr ""
-
-#: ../pohelper/data/stats.ui.h:5
-msgid "Translated:"
-msgstr ""
-
-#: ../pohelper/data/stats.ui.h:6
-msgid "Fuzzy:"
-msgstr ""
-
-#: ../pohelper/data/stats.ui.h:7
-msgid "Untranslated:"
-msgstr ""
 
 #: ../pohelper/src/gph-plugin.c:40
 msgid "Translation Helper"
@@ -5653,8 +5379,53 @@ msgstr ""
 msgid "%u (%.3g%%)"
 msgstr ""
 
+#: ../pohelper/src/gph-plugin.c:1590
+msgid "Go to previous string"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1593
+msgid "Go to next string"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1596
+msgid "Go to previous untranslated string"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1599
+msgid "Go to next untranslated string"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1602
+msgid "Go to previous fuzzily translated string"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1605
+msgid "Go to next fuzzily translated string"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1608
+msgid "Go to previous untranslated or fuzzy string"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1612
+msgid "Go to next untranslated or fuzzy string"
+msgstr ""
+
 #: ../pohelper/src/gph-plugin.c:1616
 msgid "Paste original untranslated string to translation"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1620
+msgid "Reflow the current translation string"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1623
+#, fuzzy
+msgid "Toggle current translation fuzziness"
+msgstr "Інтэрактыўная даведка"
+
+#: ../pohelper/src/gph-plugin.c:1626
+msgid "Show statistics of the current document"
 msgstr ""
 
 #: ../pohelper/src/gph-plugin.c:1833
@@ -5926,7 +5697,7 @@ msgid "Add"
 msgstr ""
 
 #: ../projectorganizer/src/prjorg-sidebar.c:390
-#: ../treebrowser/src/treebrowser.c:2356
+#: ../treebrowser/src/treebrowser.c:2361
 #, fuzzy
 msgid "New File"
 msgstr "Дадаць файл"
@@ -6554,6 +6325,10 @@ msgstr ""
 msgid "<b>Others</b>"
 msgstr ""
 
+#: ../scope/data/scope.glade.h:130 ../scope/data/scope_gtk3.glade.h:130
+msgid "Options"
+msgstr ""
+
 #: ../scope/data/scope.glade.h:131 ../scope/data/scope_gtk3.glade.h:131
 msgid "_Import"
 msgstr ""
@@ -7114,11 +6889,11 @@ msgid "Checks the spelling of the current document."
 msgstr ""
 
 #: ../spellcheck/src/scplugin.c:225
-msgid "Run Spell Check"
+msgid "Run spell check once"
 msgstr ""
 
-#: ../spellcheck/src/scplugin.c:228
-msgid "Toggle Check While Typing"
+#: ../spellcheck/src/scplugin.c:228 ../spellcheck/src/scplugin.c:333
+msgid "Toggle spell check"
 msgstr ""
 
 #. initialise the dialog
@@ -7145,10 +6920,6 @@ msgstr ""
 
 #: ../spellcheck/src/scplugin.c:325
 msgid "<b>Interface</b>"
-msgstr ""
-
-#: ../spellcheck/src/scplugin.c:333
-msgid "Check spelling while typing"
 msgstr ""
 
 #: ../spellcheck/src/scplugin.c:336
@@ -7181,52 +6952,52 @@ msgstr ""
 msgid "<b>Behavior</b>"
 msgstr ""
 
-#: ../spellcheck/src/gui.c:76
+#: ../spellcheck/src/gui.c:88
 msgid "Spell checking while typing is now enabled"
 msgstr ""
 
-#: ../spellcheck/src/gui.c:78
+#: ../spellcheck/src/gui.c:90
 msgid "Spell checking while typing is now disabled"
 msgstr ""
 
-#: ../spellcheck/src/gui.c:326
+#: ../spellcheck/src/gui.c:323
 msgid "More..."
 msgstr ""
 
-#: ../spellcheck/src/gui.c:347
+#: ../spellcheck/src/gui.c:344
 msgid "(No Suggestions)"
 msgstr ""
 
-#: ../spellcheck/src/gui.c:360
+#: ../spellcheck/src/gui.c:357
 #, c-format
 msgid "Add \"%s\" to Dictionary"
 msgstr ""
 
-#: ../spellcheck/src/gui.c:368
+#: ../spellcheck/src/gui.c:365
 msgid "Ignore All"
 msgstr ""
 
-#: ../spellcheck/src/gui.c:441
+#: ../spellcheck/src/gui.c:438
 msgid ""
 "Search term is too long to provide\n"
 "spelling suggestions in the editor menu."
 msgstr ""
 
-#: ../spellcheck/src/gui.c:447
+#: ../spellcheck/src/gui.c:444
 msgid "Perform Spell Check"
 msgstr ""
 
-#: ../spellcheck/src/gui.c:609
+#: ../spellcheck/src/gui.c:606
 #, c-format
 msgid "Default (%s)"
 msgstr ""
 
-#: ../spellcheck/src/gui.c:620
+#: ../spellcheck/src/gui.c:617
 #, c-format
-msgid "Toggle spell check while typing (current language: %s)"
+msgid "Toggle spell check (current language: %s)"
 msgstr ""
 
-#: ../spellcheck/src/gui.c:698
+#: ../spellcheck/src/gui.c:695
 msgid "Spelling Suggestions"
 msgstr ""
 
@@ -7319,157 +7090,157 @@ msgstr ""
 msgid "Could not execute configured external command '%s' (%s)."
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1089
+#: ../treebrowser/src/treebrowser.c:1093
 #, fuzzy
 msgid "NewDirectory"
 msgstr "Выдаліць праэкт"
 
-#: ../treebrowser/src/treebrowser.c:1091
+#: ../treebrowser/src/treebrowser.c:1095
 #, fuzzy
 msgid "NewFile"
 msgstr "Дадаць файл"
 
-#: ../treebrowser/src/treebrowser.c:1096
+#: ../treebrowser/src/treebrowser.c:1100
 #, c-format
 msgid ""
 "Target file '%s' exists.\n"
 "Do you really want to replace it with an empty file?"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1142
+#: ../treebrowser/src/treebrowser.c:1146
 #, c-format
 msgid "Do you really want to delete '%s' ?"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1255 ../treebrowser/src/treebrowser.c:1257
+#: ../treebrowser/src/treebrowser.c:1259 ../treebrowser/src/treebrowser.c:1261
 msgid "Go _Up"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1263 ../treebrowser/src/treebrowser.c:1265
+#: ../treebrowser/src/treebrowser.c:1267 ../treebrowser/src/treebrowser.c:1269
 msgid "Set _Path From Document"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1271 ../treebrowser/src/treebrowser.c:1273
+#: ../treebrowser/src/treebrowser.c:1275 ../treebrowser/src/treebrowser.c:1277
 msgid "_Open Externally"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1279
+#: ../treebrowser/src/treebrowser.c:1283
 msgid "Open _Terminal"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1284 ../treebrowser/src/treebrowser.c:1286
+#: ../treebrowser/src/treebrowser.c:1288 ../treebrowser/src/treebrowser.c:1290
 msgid "Set as _Root"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1293 ../treebrowser/src/treebrowser.c:1295
+#: ../treebrowser/src/treebrowser.c:1297 ../treebrowser/src/treebrowser.c:1299
 msgid "Refres_h"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1301 ../treebrowser/src/treebrowser.c:1303
+#: ../treebrowser/src/treebrowser.c:1305 ../treebrowser/src/treebrowser.c:1307
 #, fuzzy
 msgid "_Find in Files"
 msgstr "Знайсьці і праэкце"
 
-#: ../treebrowser/src/treebrowser.c:1313 ../treebrowser/src/treebrowser.c:1315
+#: ../treebrowser/src/treebrowser.c:1317 ../treebrowser/src/treebrowser.c:1319
 #, fuzzy
 msgid "N_ew Folder"
 msgstr "Выдаліць праэкт"
 
-#: ../treebrowser/src/treebrowser.c:1321 ../treebrowser/src/treebrowser.c:1323
+#: ../treebrowser/src/treebrowser.c:1325 ../treebrowser/src/treebrowser.c:1327
 #, fuzzy
 msgid "_New File"
 msgstr "Дадаць файл"
 
-#: ../treebrowser/src/treebrowser.c:1329 ../treebrowser/src/treebrowser.c:1331
+#: ../treebrowser/src/treebrowser.c:1333 ../treebrowser/src/treebrowser.c:1335
 msgid "Rena_me"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1350 ../treebrowser/src/treebrowser.c:1352
+#: ../treebrowser/src/treebrowser.c:1354 ../treebrowser/src/treebrowser.c:1356
 #, c-format
 msgid "Close: %s"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1359 ../treebrowser/src/treebrowser.c:1361
+#: ../treebrowser/src/treebrowser.c:1363 ../treebrowser/src/treebrowser.c:1365
 #, c-format
 msgid "Clo_se Child Documents "
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1368 ../treebrowser/src/treebrowser.c:1370
+#: ../treebrowser/src/treebrowser.c:1372 ../treebrowser/src/treebrowser.c:1374
 msgid "_Copy Full Path to Clipboard"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1381 ../treebrowser/src/treebrowser.c:1383
+#: ../treebrowser/src/treebrowser.c:1385 ../treebrowser/src/treebrowser.c:1387
 msgid "E_xpand All"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1389 ../treebrowser/src/treebrowser.c:1391
+#: ../treebrowser/src/treebrowser.c:1393 ../treebrowser/src/treebrowser.c:1395
 msgid "Coll_apse All"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1399
+#: ../treebrowser/src/treebrowser.c:1403
 msgid "Show Boo_kmarks"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1404
+#: ../treebrowser/src/treebrowser.c:1408
 #, fuzzy
 msgid "Sho_w Hidden Files"
 msgstr "Знайсьці і праэкце"
 
-#: ../treebrowser/src/treebrowser.c:1409
+#: ../treebrowser/src/treebrowser.c:1413
 msgid "Show Tool_bars"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1747
+#: ../treebrowser/src/treebrowser.c:1751
 #, c-format
 msgid "Target file '%s' exists, do you really want to replace it?"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1883
+#: ../treebrowser/src/treebrowser.c:1887
 msgid "Go up"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1893 ../treebrowser/src/treebrowser.c:2360
+#: ../treebrowser/src/treebrowser.c:1897 ../treebrowser/src/treebrowser.c:2365
 msgid "Refresh"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1903
+#: ../treebrowser/src/treebrowser.c:1907
 msgid "Home"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1913
+#: ../treebrowser/src/treebrowser.c:1917
 msgid "Set path from document"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1923
+#: ../treebrowser/src/treebrowser.c:1927
 #, fuzzy
 msgid "Track path"
 msgstr "Базавы шлях:"
 
-#: ../treebrowser/src/treebrowser.c:1933
+#: ../treebrowser/src/treebrowser.c:1937
 #, fuzzy
 msgid "Hide bars"
 msgstr "Схаваць сайдбар"
 
-#: ../treebrowser/src/treebrowser.c:1943
+#: ../treebrowser/src/treebrowser.c:1947
 msgid ""
 "Filter (*.c;*.h;*.cpp), and if you want temporary filter using the '!' "
 "reverse try for example this '!;*.c;*.h;*.cpp'"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1948
+#: ../treebrowser/src/treebrowser.c:1952
 msgid "Addressbar for example '/projects/my-project'"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1973
+#: ../treebrowser/src/treebrowser.c:1977
 msgid "Tree Browser"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2114
+#: ../treebrowser/src/treebrowser.c:2118
 msgid "External open command"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2124
-#, c-format
+#: ../treebrowser/src/treebrowser.c:2129
+#, no-c-format
 msgid ""
 "The command to execute when using \"Open with\". You can use %f and %d "
 "wildcards.\n"
@@ -7478,120 +7249,120 @@ msgid ""
 "filename"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2143
+#: ../treebrowser/src/treebrowser.c:2148
 msgid "The terminal to use with the command \"Open Terminal\""
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2149
+#: ../treebrowser/src/treebrowser.c:2154
 msgid "Toolbar"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2151
+#: ../treebrowser/src/treebrowser.c:2156
 msgid "Hidden"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2152
+#: ../treebrowser/src/treebrowser.c:2157
 msgid "Top"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2153
+#: ../treebrowser/src/treebrowser.c:2158
 msgid "Bottom"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2158
+#: ../treebrowser/src/treebrowser.c:2163
 msgid "If position is changed, the option require plugin restart."
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2162
+#: ../treebrowser/src/treebrowser.c:2167
 msgid "Show icons"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2164
+#: ../treebrowser/src/treebrowser.c:2169
 msgid "None"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2165
+#: ../treebrowser/src/treebrowser.c:2170
 #, fuzzy
 msgid "Base"
 msgstr "Базавы шлях:"
 
-#: ../treebrowser/src/treebrowser.c:2166
+#: ../treebrowser/src/treebrowser.c:2171
 msgid "Content-type"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2172
+#: ../treebrowser/src/treebrowser.c:2177
 msgid "Show hidden files"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2181
+#: ../treebrowser/src/treebrowser.c:2186
 msgid "On Windows, this just hide files that are prefixed with '.' (dot)"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2183
+#: ../treebrowser/src/treebrowser.c:2188
 msgid "Hide object files"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2192
+#: ../treebrowser/src/treebrowser.c:2197
 msgid ""
 "Don't show generated object files in the file browser, this includes *.o, *."
 "obj. *.so, *.dll, *.a, *.lib"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2194
+#: ../treebrowser/src/treebrowser.c:2199
 #, fuzzy
 msgid "Reverse filter"
 msgstr "Выдаліць файл"
 
-#: ../treebrowser/src/treebrowser.c:2203
+#: ../treebrowser/src/treebrowser.c:2208
 msgid "Follow current document"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2212
+#: ../treebrowser/src/treebrowser.c:2217
 msgid "Single click, open document and focus it"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2221
+#: ../treebrowser/src/treebrowser.c:2226
 msgid "Double click open directory"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2230
+#: ../treebrowser/src/treebrowser.c:2235
 msgid "On delete file, close it if is opened"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2239
+#: ../treebrowser/src/treebrowser.c:2244
 msgid "Focus editor on file open"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2248
+#: ../treebrowser/src/treebrowser.c:2253
 msgid "Show tree lines"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2257
+#: ../treebrowser/src/treebrowser.c:2262
 msgid "Show bookmarks"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2266
+#: ../treebrowser/src/treebrowser.c:2271
 msgid "Open new files"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2350
+#: ../treebrowser/src/treebrowser.c:2355
 msgid "Focus File List"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2352
+#: ../treebrowser/src/treebrowser.c:2357
 msgid "Focus Path Entry"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2354
+#: ../treebrowser/src/treebrowser.c:2359
 msgid "Rename Object"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2358
+#: ../treebrowser/src/treebrowser.c:2363
 #, fuzzy
 msgid "New Folder"
 msgstr "Выдаліць праэкт"
 
-#: ../treebrowser/src/treebrowser.c:2362
+#: ../treebrowser/src/treebrowser.c:2367
 #, fuzzy
 msgid "Track Current"
 msgstr "Базавы шлях:"
@@ -8270,13 +8041,6 @@ msgstr "Выдаліць праэкт"
 msgid "No workbench opened."
 msgstr ""
 
-#: ../workbench/src/sidebar.c:875
-#, fuzzy, c-format
-msgid "%s: %u Project"
-msgid_plural "%s: %u Projects"
-msgstr[0] "Праэкт"
-msgstr[1] "Праэкт"
-
 #: ../workbench/src/sidebar.c:886
 msgid ""
 "Add a project using the context menu\n"
@@ -8381,6 +8145,20 @@ msgstr ""
 #: ../xmlsnippets/src/plugin.c:45
 msgid "Autocompletes XML/HTML tags using snippets."
 msgstr ""
+
+#, fuzzy
+#~ msgid "_Removed lines:"
+#~ msgstr "Выдаліць файл"
+
+#, fuzzy
+#~ msgid "Position on left"
+#~ msgstr "Лакацыя:"
+
+#, fuzzy, c-format
+#~ msgid "%s: %u Project"
+#~ msgid_plural "%s: %u Projects"
+#~ msgstr[0] "Праэкт"
+#~ msgstr[1] "Праэкт"
 
 #, fuzzy
 #~ msgid "Create New File"

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,8 +7,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Geany-Plugins 1.30\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-29 19:41+0200\n"
+"Report-Msgid-Bugs-To: https://github.com/geany/geany/issues\n"
+"POT-Creation-Date: 2022-06-28 07:39+0200\n"
 "PO-Revision-Date: 2013-03-07 23:48+0100\n"
 "Last-Translator: Toni Garcia-Navarro <topi@elpiset.net>\n"
 "Language-Team: ca <topi@elpiset.net>\n"
@@ -22,27 +22,27 @@ msgstr ""
 msgid "(Empty Line)"
 msgstr "(Línia Buida)"
 
-#: ../addons/src/ao_bookmarklist.c:315
+#: ../addons/src/ao_bookmarklist.c:331
 msgid "_Remove Bookmark"
 msgstr "_Suprimeix l'adreça d'interès"
 
 #. Translators: Number is meant at this point.
-#: ../addons/src/ao_bookmarklist.c:342
+#: ../addons/src/ao_bookmarklist.c:358
 msgid "No."
 msgstr "No."
 
-#: ../addons/src/ao_bookmarklist.c:350 ../devhelp/src/dhp-object.c:494
+#: ../addons/src/ao_bookmarklist.c:366 ../devhelp/src/dhp-object.c:494
 #: ../devhelp/devhelp/dh-window.c:1142
 msgid "Contents"
 msgstr "Continguts"
 
-#: ../addons/src/ao_bookmarklist.c:383 ../treebrowser/src/treebrowser.c:666
+#: ../addons/src/ao_bookmarklist.c:399 ../treebrowser/src/treebrowser.c:666
 #: ../webhelper/src/gwh-plugin.c:328
 msgid "Bookmarks"
 msgstr "Marcadors"
 
 #. complete update
-#: ../addons/src/ao_tasks.c:373 ../geanyvc/src/geanyvc.c:2679
+#: ../addons/src/ao_tasks.c:373 ../geanyvc/src/geanyvc.c:2730
 msgid "_Update"
 msgstr "Act_ualitza"
 
@@ -163,10 +163,10 @@ msgstr "Comprova l'ortografia del document actual."
 #: ../addons/src/addons.c:364 ../autoclose/src/autoclose.c:920
 #: ../codenav/src/codenavigation.c:281 ../latex/src/latex.c:208
 #: ../latex/src/latex.c:293 ../geanyprj/src/geanyprj.c:176
-#: ../geanyvc/src/geanyvc.c:2079 ../geniuspaste/src/geniuspaste.c:336
+#: ../geanyvc/src/geanyvc.c:2130 ../geniuspaste/src/geniuspaste.c:336
 #: ../lineoperations/src/lo_prefs.c:58 ../sendmail/src/sendmail.c:128
 #: ../sendmail/src/sendmail.c:293 ../spellcheck/src/scplugin.c:124
-#: ../treebrowser/src/treebrowser.c:2102
+#: ../treebrowser/src/treebrowser.c:2106
 #: ../updatechecker/src/updatechecker.c:262
 msgid "Plugin configuration directory could not be created."
 msgstr "No s'ha pogut crear el directori de configuració de connectors."
@@ -709,7 +709,7 @@ msgstr ""
 msgid "Error loading file"
 msgstr "S'ha produït un error en carregar el fitxer"
 
-#. setting asyncronous mode
+#. setting asynchronous mode
 #. setting null-stop array printing
 #. enable pretty printing
 #: ../debugger/src/dbm_gdb.c:789 ../debugger/src/dbm_gdb.c:792
@@ -1100,7 +1100,7 @@ msgid "A developers' help browser for GNOME"
 msgstr "Un navegador d'ajuda per a desenvolupadors per al GNOME"
 
 #. Create the current file Submenu
-#: ../devhelp/devhelp/dh-window.c:759 ../geanyvc/src/geanyvc.c:2660
+#: ../devhelp/devhelp/dh-window.c:759 ../geanyvc/src/geanyvc.c:2711
 msgid "_File"
 msgstr "_Fitxer"
 
@@ -1134,11 +1134,11 @@ msgstr "_Pestanya Nova"
 msgid "_Print…"
 msgstr "Im_primir..."
 
-#: ../devhelp/devhelp/dh-window.c:782 ../devhelp/devhelp/eggfindbar.c:342
+#: ../devhelp/devhelp/dh-window.c:782
 msgid "Find Next"
 msgstr "Cerca el Següent"
 
-#: ../devhelp/devhelp/dh-window.c:784 ../devhelp/devhelp/eggfindbar.c:329
+#: ../devhelp/devhelp/dh-window.c:784
 msgid "Find Previous"
 msgstr "Cerca l'Anterior"
 
@@ -1331,7 +1331,7 @@ msgid ""
 "contributing to this plugin?"
 msgstr ""
 
-#: ../geanydoc/src/geanydoc.c:159 ../geanyvc/src/geanyvc.c:442
+#: ../geanydoc/src/geanydoc.c:159 ../geanyvc/src/geanyvc.c:448
 msgid "Could not parse the output of command"
 msgstr "No s'ha pogut llegir l'eixida de l'ordre"
 
@@ -1607,8 +1607,8 @@ msgstr "No s'ha pogut desar la configuració: %s"
 #, c-format
 msgid "Failed to find configuration file for file type \"%s\": %s"
 msgstr ""
-"No s'ha pogut trobar un fitxer de configuració per al tipus de fitxer \"%s"
-"\": %s"
+"No s'ha pogut trobar un fitxer de configuració per al tipus de fitxer "
+"\"%s\": %s"
 
 #: ../geanygendoc/src/ggd-plugin.c:329
 msgid ""
@@ -2981,14 +2981,14 @@ msgid ""
 "not enough arguments for command \"%s\".\n"
 msgstr ""
 
-#: ../geanylua/glspi_sci.c:637 ../geanylua/glspi_app.c:406
+#: ../geanylua/glspi_sci.c:729 ../geanylua/glspi_app.c:406
 #, c-format
 msgid ""
 "Error in module \"%s\" at function %s():\n"
 "unknown command \"%s\" given for argument #1.\n"
 msgstr ""
 
-#: ../geanylua/glspi_sci.c:781
+#: ../geanylua/glspi_sci.c:924
 #, c-format
 msgid ""
 "Error in module \"%s\" at function %s():\n"
@@ -2996,7 +2996,7 @@ msgid ""
 " unknown flag \"%s\" for element #%d\n"
 msgstr ""
 
-#: ../geanylua/glspi_sci.c:785
+#: ../geanylua/glspi_sci.c:928
 msgid "<too large to display>"
 msgstr ""
 
@@ -3722,7 +3722,7 @@ msgid "New _Below"
 msgstr ""
 
 #: ../geanymacro/src/geanymacro.c:1824 ../geanymacro/src/geanymacro.c:2120
-#: ../treebrowser/src/treebrowser.c:1338 ../treebrowser/src/treebrowser.c:1340
+#: ../treebrowser/src/treebrowser.c:1342 ../treebrowser/src/treebrowser.c:1344
 msgid "_Delete"
 msgstr "_Elimina"
 
@@ -4085,8 +4085,8 @@ msgstr ""
 msgid "a key with fingerprint"
 msgstr ""
 
-#: ../geanypg/src/verify_aux.c:66 ../spellcheck/src/gui.c:610
-#: ../spellcheck/src/gui.c:621
+#: ../geanypg/src/verify_aux.c:66 ../spellcheck/src/gui.c:607
+#: ../spellcheck/src/gui.c:618
 msgid "unknown"
 msgstr "desconegut"
 
@@ -4380,49 +4380,49 @@ msgid ""
 "contributing to this plugin?"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:501
+#: ../geanyvc/src/geanyvc.c:507
 #, c-format
 msgid "geanyvc: s_spawn_sync error: %s"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:587
+#: ../geanyvc/src/geanyvc.c:593
 #, c-format
 msgid "File %s: action %s executed via %s."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:646 ../geanyvc/src/geanyvc.c:657
-#, c-format
-msgid "geanyvc: vcdiff_file_activated: Unable to rename '%s' to '%s'"
-msgstr ""
+#: ../geanyvc/src/geanyvc.c:633 ../geanyvc/src/geanyvc.c:643
+#, fuzzy, c-format
+msgid "geanyvc: diff_external: Unable to rename '%s' to '%s'"
+msgstr "No s'ha pogut descomprimir el llibre '%s': %s"
 
-#: ../geanyvc/src/geanyvc.c:683 ../geanyvc/src/geanyvc.c:733
+#: ../geanyvc/src/geanyvc.c:698 ../geanyvc/src/geanyvc.c:784
 msgid "No changes were made."
 msgstr "No s'han fet canvis."
 
-#: ../geanyvc/src/geanyvc.c:760
+#: ../geanyvc/src/geanyvc.c:811
 msgid "No history available"
 msgstr "No hi ha cap historial disponible"
 
-#: ../geanyvc/src/geanyvc.c:953 ../geanyvc/src/geanyvc.c:961
+#: ../geanyvc/src/geanyvc.c:1004 ../geanyvc/src/geanyvc.c:1012
 #, c-format
 msgid "Do you really want to revert: %s?"
 msgstr "Esteu segurs de voler revertir: %s?"
 
-#: ../geanyvc/src/geanyvc.c:969
+#: ../geanyvc/src/geanyvc.c:1020
 #, c-format
 msgid "Do you really want to add: %s?"
 msgstr "Esteu segurs de voler afegir: %s?"
 
-#: ../geanyvc/src/geanyvc.c:976
+#: ../geanyvc/src/geanyvc.c:1027
 #, c-format
 msgid "Do you really want to remove: %s?"
 msgstr "Esteu segurs de voler eliminar: %s?"
 
-#: ../geanyvc/src/geanyvc.c:999
+#: ../geanyvc/src/geanyvc.c:1050
 msgid "Do you really want to update?"
 msgstr "Esteu segurs de voler actualitzar?"
 
-#: ../geanyvc/src/geanyvc.c:1126
+#: ../geanyvc/src/geanyvc.c:1177
 msgid ""
 "The resulting differences cannot be displayed because the changes are too "
 "big to display here and would slow down the UI significantly.\n"
@@ -4431,327 +4431,327 @@ msgid ""
 "Geany directly by using the GeanyVC menu (Base Directory -> Diff)."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1280
+#: ../geanyvc/src/geanyvc.c:1331
 msgid "Commit Y/N"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1290
+#: ../geanyvc/src/geanyvc.c:1341
 msgid "Status"
 msgstr "Estat"
 
-#: ../geanyvc/src/geanyvc.c:1297
+#: ../geanyvc/src/geanyvc.c:1348
 msgid "Path"
 msgstr "Directori base"
 
-#: ../geanyvc/src/geanyvc.c:1414
+#: ../geanyvc/src/geanyvc.c:1465
 msgid "Choose a previous commit message"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1476
+#: ../geanyvc/src/geanyvc.c:1527
 #, c-format
 msgid "Line: %d Column: %d"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1523
+#: ../geanyvc/src/geanyvc.c:1574
 msgid "Commit"
 msgstr "Confirmació"
 
-#: ../geanyvc/src/geanyvc.c:1564
+#: ../geanyvc/src/geanyvc.c:1615
 msgid "_De-/select all files"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1608
+#: ../geanyvc/src/geanyvc.c:1659
 msgid "<b>Commit message:</b>"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1632
+#: ../geanyvc/src/geanyvc.c:1683
 msgid "C_ommit"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1740
+#: ../geanyvc/src/geanyvc.c:1791
 msgid "Nothing to commit."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1788
+#: ../geanyvc/src/geanyvc.c:1839
 #, c-format
 msgid ""
 "Error initializing GeanyVC spell checking: %s. Check your configuration."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1823
+#: ../geanyvc/src/geanyvc.c:1874
 #, c-format
 msgid "Commit failed (status: %d, error: %s)."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1824
+#: ../geanyvc/src/geanyvc.c:1875
 msgid "Commit failed; see status in the Message window."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1829
+#: ../geanyvc/src/geanyvc.c:1880
 msgid "Changes committed."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2151
+#: ../geanyvc/src/geanyvc.c:2202
 msgid "Set Changed-flag for document tabs created by the plugin"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2154
+#: ../geanyvc/src/geanyvc.c:2205
 msgid ""
 "If this option is activated, every new by the VC-plugin created document tab "
 "will be marked as changed. Even this option is useful in some cases, it "
 "could cause a big number of annoying \"Do you want to save\"-dialogs."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2162
+#: ../geanyvc/src/geanyvc.c:2213
 msgid "Confirm adding new files to a VCS"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2165
+#: ../geanyvc/src/geanyvc.c:2216
 msgid "Shows a confirmation dialog on adding a new (created) file to VCS."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2171
+#: ../geanyvc/src/geanyvc.c:2222
 msgid "Maximize commit dialog"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2172
+#: ../geanyvc/src/geanyvc.c:2223
 msgid "Show commit dialog maximize."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2178
+#: ../geanyvc/src/geanyvc.c:2229
 msgid "Use external diff viewer"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2180
+#: ../geanyvc/src/geanyvc.c:2231
 msgid "Use external diff viewer for file diff."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2186
+#: ../geanyvc/src/geanyvc.c:2237
 msgid "Show VC entries at editor menu"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2188
+#: ../geanyvc/src/geanyvc.c:2239
 msgid "Show entries for VC functions inside editor menu"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2193
+#: ../geanyvc/src/geanyvc.c:2244
 msgid "Attach menu to menubar"
 msgstr "Annexar el menú a la barra d'eines"
 
-#: ../geanyvc/src/geanyvc.c:2195
+#: ../geanyvc/src/geanyvc.c:2246
 msgid ""
 "Whether menu for this plugin are getting placed either inside tools menu or "
 "directly inside Geany's menubar. Will take in account after next start of "
 "GeanyVC"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2203
+#: ../geanyvc/src/geanyvc.c:2254
 msgid "Enable CVS"
 msgstr "Activa CVS"
 
-#: ../geanyvc/src/geanyvc.c:2208
+#: ../geanyvc/src/geanyvc.c:2259
 msgid "Enable GIT"
 msgstr "Activa GIT"
 
-#: ../geanyvc/src/geanyvc.c:2213
+#: ../geanyvc/src/geanyvc.c:2264
 msgid "Enable Fossil"
 msgstr "Activa Fossil"
 
-#: ../geanyvc/src/geanyvc.c:2218
+#: ../geanyvc/src/geanyvc.c:2269
 msgid "Enable SVN"
 msgstr "Activa SVN"
 
-#: ../geanyvc/src/geanyvc.c:2223
+#: ../geanyvc/src/geanyvc.c:2274
 msgid "Enable SVK"
 msgstr "Activa SVK"
 
-#: ../geanyvc/src/geanyvc.c:2228
+#: ../geanyvc/src/geanyvc.c:2279
 msgid "Enable Bazaar"
 msgstr "Activa Bazaar"
 
-#: ../geanyvc/src/geanyvc.c:2233
+#: ../geanyvc/src/geanyvc.c:2284
 msgid "Enable Mercurial"
 msgstr "Activa Mercurial"
 
-#: ../geanyvc/src/geanyvc.c:2239
+#: ../geanyvc/src/geanyvc.c:2290
 msgid "Spellcheck language"
 msgstr ""
 
 #. Diff of current file
 #. Diff of the current dir
 #. Complete diff of base directory
-#: ../geanyvc/src/geanyvc.c:2368 ../geanyvc/src/geanyvc.c:2463
-#: ../geanyvc/src/geanyvc.c:2503
+#: ../geanyvc/src/geanyvc.c:2419 ../geanyvc/src/geanyvc.c:2514
+#: ../geanyvc/src/geanyvc.c:2554
 msgid "_Diff"
 msgstr "_Diferències"
 
-#: ../geanyvc/src/geanyvc.c:2371
+#: ../geanyvc/src/geanyvc.c:2422
 msgid "Make a diff from the current active file"
 msgstr ""
 
 #. Revert current file
 #. Revert current dir
 #. Revert everything
-#: ../geanyvc/src/geanyvc.c:2376 ../geanyvc/src/geanyvc.c:2472
-#: ../geanyvc/src/geanyvc.c:2511
+#: ../geanyvc/src/geanyvc.c:2427 ../geanyvc/src/geanyvc.c:2523
+#: ../geanyvc/src/geanyvc.c:2562
 msgid "_Revert"
 msgstr "_Reverteix"
 
-#: ../geanyvc/src/geanyvc.c:2379
+#: ../geanyvc/src/geanyvc.c:2430
 msgid "Restore pristine working copy file (undo local edits)."
 msgstr ""
 
 #. Blame for current file
-#: ../geanyvc/src/geanyvc.c:2388
+#: ../geanyvc/src/geanyvc.c:2439
 msgid "_Blame"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2391
+#: ../geanyvc/src/geanyvc.c:2442
 msgid "Shows the changes made at one file per revision and author."
 msgstr ""
 
 #. History/log of current file
 #. History/log of the current dir
 #. Complete History/Log of base directory
-#: ../geanyvc/src/geanyvc.c:2398 ../geanyvc/src/geanyvc.c:2482
-#: ../geanyvc/src/geanyvc.c:2523
+#: ../geanyvc/src/geanyvc.c:2449 ../geanyvc/src/geanyvc.c:2533
+#: ../geanyvc/src/geanyvc.c:2574
 msgid "_History (log)"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2401
+#: ../geanyvc/src/geanyvc.c:2452
 msgid "Shows the log of the current file"
 msgstr ""
 
 #. base version of the current file
-#: ../geanyvc/src/geanyvc.c:2406
+#: ../geanyvc/src/geanyvc.c:2457
 msgid "_Original"
 msgstr "_Original"
 
-#: ../geanyvc/src/geanyvc.c:2409
+#: ../geanyvc/src/geanyvc.c:2460
 msgid "Shows the original of the current file"
 msgstr ""
 
 #. add current file
-#: ../geanyvc/src/geanyvc.c:2417
+#: ../geanyvc/src/geanyvc.c:2468
 msgid "_Add to Version Control"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2419
+#: ../geanyvc/src/geanyvc.c:2470
 msgid "Add file to repository."
 msgstr "Afegeix el fitxer al repositori."
 
 #. remove current file
-#: ../geanyvc/src/geanyvc.c:2425
+#: ../geanyvc/src/geanyvc.c:2476
 msgid "_Remove from Version Control"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2427
+#: ../geanyvc/src/geanyvc.c:2478
 msgid "Remove file from repository."
 msgstr "Elimina el fitxer del repositori."
 
-#: ../geanyvc/src/geanyvc.c:2460
+#: ../geanyvc/src/geanyvc.c:2511
 msgid "_Directory"
 msgstr "_Directori"
 
-#: ../geanyvc/src/geanyvc.c:2466
+#: ../geanyvc/src/geanyvc.c:2517
 msgid "Make a diff from the directory of the current active file"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2475
+#: ../geanyvc/src/geanyvc.c:2526
 msgid "Restore original files in the current folder (undo local edits)."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2485
+#: ../geanyvc/src/geanyvc.c:2536
 msgid "Shows the log of the current directory"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2499
+#: ../geanyvc/src/geanyvc.c:2550
 msgid "_Base Directory"
 msgstr "Directori _Base"
 
-#: ../geanyvc/src/geanyvc.c:2505
+#: ../geanyvc/src/geanyvc.c:2556
 msgid "Make a diff from the top VC directory"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2513
+#: ../geanyvc/src/geanyvc.c:2564
 msgid "Revert any local edits."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2526
+#: ../geanyvc/src/geanyvc.c:2577
 msgid "Shows the log of the top VC directory"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2543
+#: ../geanyvc/src/geanyvc.c:2594
 msgid "_VC file Actions"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2552
+#: ../geanyvc/src/geanyvc.c:2603
 msgid "VC _Commit..."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2596
+#: ../geanyvc/src/geanyvc.c:2647
 msgid "Show diff of file"
 msgstr "Mostra diferències entre fitxers"
 
-#: ../geanyvc/src/geanyvc.c:2598
+#: ../geanyvc/src/geanyvc.c:2649
 msgid "Show diff of directory"
 msgstr "Mostra diferències entre directoris"
 
-#: ../geanyvc/src/geanyvc.c:2600
+#: ../geanyvc/src/geanyvc.c:2651
 msgid "Show diff of basedir"
 msgstr "Mostra diferències entre directoris base"
 
-#: ../geanyvc/src/geanyvc.c:2603
+#: ../geanyvc/src/geanyvc.c:2654
 msgid "Commit changes"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2605
+#: ../geanyvc/src/geanyvc.c:2656
 msgid "Show status"
 msgstr "Mostra l'estat"
 
-#: ../geanyvc/src/geanyvc.c:2607
+#: ../geanyvc/src/geanyvc.c:2658
 msgid "Revert single file"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2609
+#: ../geanyvc/src/geanyvc.c:2660
 msgid "Revert directory"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2611
+#: ../geanyvc/src/geanyvc.c:2662
 msgid "Revert base directory"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2613
+#: ../geanyvc/src/geanyvc.c:2664
 msgid "Update file"
 msgstr "Actualitza el fitxer"
 
-#: ../geanyvc/src/geanyvc.c:2643
+#: ../geanyvc/src/geanyvc.c:2694
 msgid "_VC"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2650
+#: ../geanyvc/src/geanyvc.c:2701
 msgid "_Version Control"
 msgstr "Control de _Versions"
 
 #. Status of basedir
-#: ../geanyvc/src/geanyvc.c:2672
+#: ../geanyvc/src/geanyvc.c:2723
 msgid "_Status"
 msgstr "_Estat"
 
-#: ../geanyvc/src/geanyvc.c:2674
+#: ../geanyvc/src/geanyvc.c:2725
 msgid "Show status."
 msgstr "Mostra l'estat."
 
-#: ../geanyvc/src/geanyvc.c:2681
+#: ../geanyvc/src/geanyvc.c:2732
 msgid "Update from remote repository."
 msgstr "Actualitza des dels repositoris."
 
 #. Commit all changes
-#: ../geanyvc/src/geanyvc.c:2686
+#: ../geanyvc/src/geanyvc.c:2737
 msgid "_Commit..."
 msgstr "Publica els _canvis..."
 
-#: ../geanyvc/src/geanyvc.c:2688
+#: ../geanyvc/src/geanyvc.c:2739
 msgid "Commit changes."
 msgstr "Publica els canvis."
 
@@ -4812,8 +4812,8 @@ msgstr ""
 #, fuzzy
 msgid "Check the pastebin configuration and retry."
 msgstr ""
-"No s'ha pogut trobar un fitxer de configuració per al tipus de fitxer \"%s"
-"\": %s"
+"No s'ha pogut trobar un fitxer de configuració per al tipus de fitxer "
+"\"%s\": %s"
 
 #: ../geniuspaste/src/geniuspaste.c:844
 #, fuzzy
@@ -4868,35 +4868,6 @@ msgstr ""
 msgid "_Paste it!"
 msgstr ""
 
-#: ../git-changebar/data/prefs.ui.h:1
-msgid "_Monitor repository for changes"
-msgstr ""
-
-#: ../git-changebar/data/prefs.ui.h:2
-msgid ""
-"Whether to automatically update the diff in order to maintain it up to date "
-"when the underlying Git repository changes.  This should generally be "
-"enabled for optimal user experience."
-msgstr ""
-
-#: ../git-changebar/data/prefs.ui.h:3
-msgid "_Added lines:"
-msgstr ""
-
-#: ../git-changebar/data/prefs.ui.h:4
-msgid "_Changed lines:"
-msgstr ""
-
-#: ../git-changebar/data/prefs.ui.h:5
-#, fuzzy
-msgid "_Removed lines:"
-msgstr "Elimina un Fitxer"
-
-#: ../git-changebar/data/prefs.ui.h:6
-#, fuzzy
-msgid "Colors"
-msgstr "Color del Fons:"
-
 #: ../git-changebar/src/gcb-plugin.c:62
 msgid "Git Change Bar"
 msgstr ""
@@ -4914,8 +4885,8 @@ msgstr "No s'ha pogut carregar la configuració: %s"
 #, fuzzy, c-format
 msgid "Failed to create configuration directory \"%s\": %s"
 msgstr ""
-"No s'ha pogut trobar un fitxer de configuració per al tipus de fitxer \"%s"
-"\": %s"
+"No s'ha pogut trobar un fitxer de configuració per al tipus de fitxer "
+"\"%s\": %s"
 
 #: ../git-changebar/src/gcb-plugin.c:1418 ../pohelper/src/gph-plugin.c:1689
 #, fuzzy, c-format
@@ -5086,8 +5057,8 @@ msgstr ""
 #: ../lipsum/src/lipsum.c:184 ../sendmail/src/sendmail.c:396
 #, c-format
 msgid ""
-"Your configuration directory has been successfully moved from \"%s\" to \"%s"
-"\"."
+"Your configuration directory has been successfully moved from \"%s\" to "
+"\"%s\"."
 msgstr ""
 
 #: ../lipsum/src/lipsum.c:199
@@ -5261,7 +5232,7 @@ msgstr "No s'ha pogut escriure la configuració per defecte: %s"
 msgid "Unable to read value for '%s' key: %s"
 msgstr "No s'ha pogut crear el directori de configuració '%s'"
 
-#: ../multiterm/src/tab-label.vala:62 ../treebrowser/src/treebrowser.c:2132
+#: ../multiterm/src/tab-label.vala:62 ../treebrowser/src/treebrowser.c:2137
 #, fuzzy
 msgid "Terminal"
 msgstr "Finalitza"
@@ -5302,116 +5273,6 @@ msgstr ""
 msgid "Show Overview"
 msgstr "Mostra el terminal"
 
-#: ../overview/data/prefs.ui.h:1
-msgid ""
-"The amount to zoom the overview sidebar. This should probably negative if "
-"you want the sidebar zoomed out."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:2
-msgid "Zoom Level:"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:3
-msgid "The width of the overview sidebar."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:4
-msgid "Width:"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:5
-msgid ""
-"The number of lines to scroll at a time when scrolling the overview sidebar."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:6
-msgid "Scroll Lines:"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:7
-#, fuzzy
-msgid "Position on left"
-msgstr "Posició:"
-
-#: ../overview/data/prefs.ui.h:8
-msgid ""
-"Position the overview bar on the left rather than the right (requires Geany "
-"1.25 or greater)."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:9
-#, fuzzy
-msgid "Hide tooltip"
-msgstr "Mostra _consells"
-
-#: ../overview/data/prefs.ui.h:10
-msgid ""
-"Hide the tooltip that is displayed when mousing over the overview that shows "
-"line, column and position information."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:11
-msgid "Hide editor scrollbar"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:12
-msgid ""
-"Whether to hide Geany's regular editor scrollbar while the overview bar is "
-"visible."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:13
-msgid "Disable overlay"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:14
-msgid ""
-"Turn off drawing overlay, which shows the region of the main editor view "
-"that is currently in view, ontop of the overview bar."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:15 ../scope/data/scope.glade.h:130
-#: ../scope/data/scope_gtk3.glade.h:130
-msgid "Options"
-msgstr "Opcions"
-
-#: ../overview/data/prefs.ui.h:16
-msgid ""
-"The color and opacity of the overlay drawn ontop of the overlay sidebar."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:17
-#, fuzzy
-msgid "Color:"
-msgstr "Color del Fons:"
-
-#: ../overview/data/prefs.ui.h:18
-msgid ""
-"The color and opacity of the border drawn around the revealed area in the "
-"overview sidebar. Set to the same as Overlay Color to disable."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:19
-#, fuzzy
-msgid "Outline Color:"
-msgstr "Selecciona un Color"
-
-#: ../overview/data/prefs.ui.h:20
-msgid "Draw over visible area"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:21
-msgid ""
-"When checked it will draw the overlay ontop of the area that is visible in "
-"the main editor view, when unchecked, it will do the opposite and draw the "
-"overlay everywhere but the visible area, \"revealing\" the visible part."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:22
-msgid "Overlay"
-msgstr ""
-
 #: ../pairtaghighlighter/src/pair_tag_highlighter.c:43
 msgid "Pair Tag Highlighter"
 msgstr ""
@@ -5439,149 +5300,6 @@ msgstr "Vés al Parèntesi _Corresponent"
 #, fuzzy
 msgid "Select To Matching Tag"
 msgstr "Vés al Parèntesi _Corresponent"
-
-#: ../pohelper/data/menus.ui.h:1
-msgid "_Translation Helper"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:2
-msgid "_Previous String"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:3 ../pohelper/src/gph-plugin.c:1590
-#, fuzzy
-msgid "Go to previous string"
-msgstr "Vés a la pàgina anterior"
-
-#: ../pohelper/data/menus.ui.h:4
-msgid "_Next String"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:5 ../pohelper/src/gph-plugin.c:1593
-#, fuzzy
-msgid "Go to next string"
-msgstr "Vés a la pàgina següent"
-
-#: ../pohelper/data/menus.ui.h:6
-msgid "Pre_vious Untranslated"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:7 ../pohelper/src/gph-plugin.c:1596
-msgid "Go to previous untranslated string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:8
-msgid "Next _Untranslated"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:9 ../pohelper/src/gph-plugin.c:1599
-msgid "Go to next untranslated string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:10
-msgid "Previous Fu_zzy"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:11 ../pohelper/src/gph-plugin.c:1602
-msgid "Go to previous fuzzily translated string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:12
-msgid "Next _Fuzzy"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:13 ../pohelper/src/gph-plugin.c:1605
-msgid "Go to next fuzzily translated string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:14
-msgid "Previous Untranslated or Fuzz_y"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:15 ../pohelper/src/gph-plugin.c:1608
-msgid "Go to previous untranslated or fuzzy string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:16
-msgid "Next Untranslated _or Fuzzy"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:17 ../pohelper/src/gph-plugin.c:1612
-msgid "Go to next untranslated or fuzzy string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:18 ../pohelper/src/gph-plugin.c:1623
-msgid "Toggle current translation fuzziness"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:19
-msgid "_Toggle Fuzziness"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:20
-msgid "Paste _Message as Translation"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:21
-msgid "Paste the original untranslated string to the translation"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:22 ../pohelper/src/gph-plugin.c:1620
-msgid "Reflow the current translation string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:23
-msgid "_Reflow Translation"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:24 ../pohelper/src/gph-plugin.c:1626
-#, fuzzy
-msgid "Show statistics of the current document"
-msgstr "Comprova l'ortografia del document actual."
-
-#: ../pohelper/data/menus.ui.h:25
-#, fuzzy
-msgid "_Show stats"
-msgstr "Mostra l'estat"
-
-#: ../pohelper/data/menus.ui.h:26
-msgid ""
-"Whether to update the translation headers (author, revision date, ...) upon "
-"file save"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:27
-msgid "Update _Headers Upon Save"
-msgstr ""
-
-#: ../pohelper/data/stats.ui.h:1
-msgid "Translation statistics"
-msgstr ""
-
-#: ../pohelper/data/stats.ui.h:2
-msgid "Choose a color for translated strings"
-msgstr ""
-
-#: ../pohelper/data/stats.ui.h:3
-msgid "Choose a color for fuzzily translated strings"
-msgstr ""
-
-#: ../pohelper/data/stats.ui.h:4
-msgid "Choose a color for untranslated strings"
-msgstr ""
-
-#: ../pohelper/data/stats.ui.h:5
-#, fuzzy
-msgid "Translated:"
-msgstr "Plantilla:"
-
-#: ../pohelper/data/stats.ui.h:6
-msgid "Fuzzy:"
-msgstr ""
-
-#: ../pohelper/data/stats.ui.h:7
-msgid "Untranslated:"
-msgstr ""
 
 #: ../pohelper/src/gph-plugin.c:40
 msgid "Translation Helper"
@@ -5611,9 +5329,56 @@ msgstr ""
 msgid "%u (%.3g%%)"
 msgstr ""
 
+#: ../pohelper/src/gph-plugin.c:1590
+#, fuzzy
+msgid "Go to previous string"
+msgstr "Vés a la pàgina anterior"
+
+#: ../pohelper/src/gph-plugin.c:1593
+#, fuzzy
+msgid "Go to next string"
+msgstr "Vés a la pàgina següent"
+
+#: ../pohelper/src/gph-plugin.c:1596
+msgid "Go to previous untranslated string"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1599
+msgid "Go to next untranslated string"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1602
+msgid "Go to previous fuzzily translated string"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1605
+msgid "Go to next fuzzily translated string"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1608
+msgid "Go to previous untranslated or fuzzy string"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1612
+msgid "Go to next untranslated or fuzzy string"
+msgstr ""
+
 #: ../pohelper/src/gph-plugin.c:1616
 msgid "Paste original untranslated string to translation"
 msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1620
+msgid "Reflow the current translation string"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1623
+msgid "Toggle current translation fuzziness"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1626
+#, fuzzy
+msgid "Show statistics of the current document"
+msgstr "Comprova l'ortografia del document actual."
 
 #: ../pohelper/src/gph-plugin.c:1833
 #, c-format
@@ -5887,7 +5652,7 @@ msgid "Add"
 msgstr "Afegits"
 
 #: ../projectorganizer/src/prjorg-sidebar.c:390
-#: ../treebrowser/src/treebrowser.c:2356
+#: ../treebrowser/src/treebrowser.c:2361
 #, fuzzy
 msgid "New File"
 msgstr "NouFitxer"
@@ -6518,6 +6283,10 @@ msgstr "Mostra _consells"
 msgid "<b>Others</b>"
 msgstr "<B>Altres</b>"
 
+#: ../scope/data/scope.glade.h:130 ../scope/data/scope_gtk3.glade.h:130
+msgid "Options"
+msgstr "Opcions"
+
 #: ../scope/data/scope.glade.h:131 ../scope/data/scope_gtk3.glade.h:131
 msgid "_Import"
 msgstr "_Importa"
@@ -7083,12 +6852,14 @@ msgid "Checks the spelling of the current document."
 msgstr "Comprova l'ortografia del document actual."
 
 #: ../spellcheck/src/scplugin.c:225
-msgid "Run Spell Check"
+#, fuzzy
+msgid "Run spell check once"
 msgstr "Executa la Comprovació Ortogràfica"
 
-#: ../spellcheck/src/scplugin.c:228
-msgid "Toggle Check While Typing"
-msgstr ""
+#: ../spellcheck/src/scplugin.c:228 ../spellcheck/src/scplugin.c:333
+#, fuzzy
+msgid "Toggle spell check"
+msgstr "Verifica l'Ortografia"
 
 #. initialise the dialog
 #: ../spellcheck/src/scplugin.c:239
@@ -7116,10 +6887,6 @@ msgstr ""
 #, fuzzy
 msgid "<b>Interface</b>"
 msgstr "<b>Inspecciona</b>"
-
-#: ../spellcheck/src/scplugin.c:333
-msgid "Check spelling while typing"
-msgstr "Verifica l'ortografia a mesura que escric"
 
 #: ../spellcheck/src/scplugin.c:336
 #, fuzzy
@@ -7153,52 +6920,52 @@ msgstr ""
 msgid "<b>Behavior</b>"
 msgstr "<B>Altres</b>"
 
-#: ../spellcheck/src/gui.c:76
+#: ../spellcheck/src/gui.c:88
 msgid "Spell checking while typing is now enabled"
 msgstr ""
 
-#: ../spellcheck/src/gui.c:78
+#: ../spellcheck/src/gui.c:90
 msgid "Spell checking while typing is now disabled"
 msgstr ""
 
-#: ../spellcheck/src/gui.c:326
+#: ../spellcheck/src/gui.c:323
 msgid "More..."
 msgstr "Més..."
 
-#: ../spellcheck/src/gui.c:347
+#: ../spellcheck/src/gui.c:344
 msgid "(No Suggestions)"
 msgstr "(No hi ha suggerències)"
 
-#: ../spellcheck/src/gui.c:360
+#: ../spellcheck/src/gui.c:357
 #, c-format
 msgid "Add \"%s\" to Dictionary"
 msgstr "Afegeix \"%s\" al Diccionari"
 
-#: ../spellcheck/src/gui.c:368
+#: ../spellcheck/src/gui.c:365
 msgid "Ignore All"
 msgstr "Ignora-ho Tot"
 
-#: ../spellcheck/src/gui.c:441
+#: ../spellcheck/src/gui.c:438
 msgid ""
 "Search term is too long to provide\n"
 "spelling suggestions in the editor menu."
 msgstr ""
 
-#: ../spellcheck/src/gui.c:447
+#: ../spellcheck/src/gui.c:444
 msgid "Perform Spell Check"
 msgstr "Realitza la Comprovació Ortogràfica"
 
-#: ../spellcheck/src/gui.c:609
+#: ../spellcheck/src/gui.c:606
 #, c-format
 msgid "Default (%s)"
 msgstr "Predeterminat (%s)"
 
-#: ../spellcheck/src/gui.c:620
+#: ../spellcheck/src/gui.c:617
 #, c-format
-msgid "Toggle spell check while typing (current language: %s)"
+msgid "Toggle spell check (current language: %s)"
 msgstr ""
 
-#: ../spellcheck/src/gui.c:698
+#: ../spellcheck/src/gui.c:695
 msgid "Spelling Suggestions"
 msgstr "Suggeriments d'Ortografia"
 
@@ -7291,165 +7058,165 @@ msgstr "(Buit)"
 msgid "Could not execute configured external command '%s' (%s)."
 msgstr "No s'ha pogut executar l'ordre externa '%s' (%s)."
 
-#: ../treebrowser/src/treebrowser.c:1089
+#: ../treebrowser/src/treebrowser.c:1093
 msgid "NewDirectory"
 msgstr "NouDirectori"
 
-#: ../treebrowser/src/treebrowser.c:1091
+#: ../treebrowser/src/treebrowser.c:1095
 msgid "NewFile"
 msgstr "NouFitxer"
 
-#: ../treebrowser/src/treebrowser.c:1096
+#: ../treebrowser/src/treebrowser.c:1100
 #, fuzzy, c-format
 msgid ""
 "Target file '%s' exists.\n"
 "Do you really want to replace it with an empty file?"
 msgstr "Ja existeix un fitxer anomenat \"%s\", voleu reemplaçar-lo?"
 
-#: ../treebrowser/src/treebrowser.c:1142
+#: ../treebrowser/src/treebrowser.c:1146
 #, c-format
 msgid "Do you really want to delete '%s' ?"
 msgstr "Esteu segurs de voler eliminar '%s'?"
 
-#: ../treebrowser/src/treebrowser.c:1255 ../treebrowser/src/treebrowser.c:1257
+#: ../treebrowser/src/treebrowser.c:1259 ../treebrowser/src/treebrowser.c:1261
 #, fuzzy
 msgid "Go _Up"
 msgstr "Mou Am_unt"
 
-#: ../treebrowser/src/treebrowser.c:1263 ../treebrowser/src/treebrowser.c:1265
+#: ../treebrowser/src/treebrowser.c:1267 ../treebrowser/src/treebrowser.c:1269
 #, fuzzy
 msgid "Set _Path From Document"
 msgstr "Especifica el directori pel document"
 
-#: ../treebrowser/src/treebrowser.c:1271 ../treebrowser/src/treebrowser.c:1273
+#: ../treebrowser/src/treebrowser.c:1275 ../treebrowser/src/treebrowser.c:1277
 #, fuzzy
 msgid "_Open Externally"
 msgstr "Obre externament"
 
-#: ../treebrowser/src/treebrowser.c:1279
+#: ../treebrowser/src/treebrowser.c:1283
 #, fuzzy
 msgid "Open _Terminal"
 msgstr "Obre el terminal"
 
-#: ../treebrowser/src/treebrowser.c:1284 ../treebrowser/src/treebrowser.c:1286
+#: ../treebrowser/src/treebrowser.c:1288 ../treebrowser/src/treebrowser.c:1290
 #, fuzzy
 msgid "Set as _Root"
 msgstr "Instal·la com a superusuari"
 
-#: ../treebrowser/src/treebrowser.c:1293 ../treebrowser/src/treebrowser.c:1295
+#: ../treebrowser/src/treebrowser.c:1297 ../treebrowser/src/treebrowser.c:1299
 #, fuzzy
 msgid "Refres_h"
 msgstr "Actualitza"
 
-#: ../treebrowser/src/treebrowser.c:1301 ../treebrowser/src/treebrowser.c:1303
+#: ../treebrowser/src/treebrowser.c:1305 ../treebrowser/src/treebrowser.c:1307
 #, fuzzy
 msgid "_Find in Files"
 msgstr "Cerca en els Fitxers"
 
-#: ../treebrowser/src/treebrowser.c:1313 ../treebrowser/src/treebrowser.c:1315
+#: ../treebrowser/src/treebrowser.c:1317 ../treebrowser/src/treebrowser.c:1319
 #, fuzzy
 msgid "N_ew Folder"
 msgstr "Selecciona Directory"
 
-#: ../treebrowser/src/treebrowser.c:1321 ../treebrowser/src/treebrowser.c:1323
+#: ../treebrowser/src/treebrowser.c:1325 ../treebrowser/src/treebrowser.c:1327
 #, fuzzy
 msgid "_New File"
 msgstr "NouFitxer"
 
-#: ../treebrowser/src/treebrowser.c:1329 ../treebrowser/src/treebrowser.c:1331
+#: ../treebrowser/src/treebrowser.c:1333 ../treebrowser/src/treebrowser.c:1335
 #, fuzzy
 msgid "Rena_me"
 msgstr "Reanomena"
 
-#: ../treebrowser/src/treebrowser.c:1350 ../treebrowser/src/treebrowser.c:1352
+#: ../treebrowser/src/treebrowser.c:1354 ../treebrowser/src/treebrowser.c:1356
 #, c-format
 msgid "Close: %s"
 msgstr "Tanca: %s"
 
-#: ../treebrowser/src/treebrowser.c:1359 ../treebrowser/src/treebrowser.c:1361
+#: ../treebrowser/src/treebrowser.c:1363 ../treebrowser/src/treebrowser.c:1365
 #, fuzzy, c-format
 msgid "Clo_se Child Documents "
 msgstr "Tanca els Documents Fills"
 
-#: ../treebrowser/src/treebrowser.c:1368 ../treebrowser/src/treebrowser.c:1370
+#: ../treebrowser/src/treebrowser.c:1372 ../treebrowser/src/treebrowser.c:1374
 #, fuzzy
 msgid "_Copy Full Path to Clipboard"
 msgstr "Copia la ruta completa al porta-retalls"
 
-#: ../treebrowser/src/treebrowser.c:1381 ../treebrowser/src/treebrowser.c:1383
+#: ../treebrowser/src/treebrowser.c:1385 ../treebrowser/src/treebrowser.c:1387
 #, fuzzy
 msgid "E_xpand All"
 msgstr "Expandeix-ho Tot"
 
-#: ../treebrowser/src/treebrowser.c:1389 ../treebrowser/src/treebrowser.c:1391
+#: ../treebrowser/src/treebrowser.c:1393 ../treebrowser/src/treebrowser.c:1395
 #, fuzzy
 msgid "Coll_apse All"
 msgstr "Tanca-ho Tot"
 
-#: ../treebrowser/src/treebrowser.c:1399
+#: ../treebrowser/src/treebrowser.c:1403
 #, fuzzy
 msgid "Show Boo_kmarks"
 msgstr "Mostra les adreces d'interès"
 
-#: ../treebrowser/src/treebrowser.c:1404
+#: ../treebrowser/src/treebrowser.c:1408
 #, fuzzy
 msgid "Sho_w Hidden Files"
 msgstr "Mostra els fitxers ocults"
 
-#: ../treebrowser/src/treebrowser.c:1409
+#: ../treebrowser/src/treebrowser.c:1413
 #, fuzzy
 msgid "Show Tool_bars"
 msgstr "Mostra les barres d'eines"
 
-#: ../treebrowser/src/treebrowser.c:1747
+#: ../treebrowser/src/treebrowser.c:1751
 #, c-format
 msgid "Target file '%s' exists, do you really want to replace it?"
 msgstr "Ja existeix un fitxer anomenat \"%s\", voleu reemplaçar-lo?"
 
-#: ../treebrowser/src/treebrowser.c:1883
+#: ../treebrowser/src/treebrowser.c:1887
 msgid "Go up"
 msgstr "Vés cap a dalt"
 
-#: ../treebrowser/src/treebrowser.c:1893 ../treebrowser/src/treebrowser.c:2360
+#: ../treebrowser/src/treebrowser.c:1897 ../treebrowser/src/treebrowser.c:2365
 msgid "Refresh"
 msgstr "Actualitza"
 
-#: ../treebrowser/src/treebrowser.c:1903
+#: ../treebrowser/src/treebrowser.c:1907
 msgid "Home"
 msgstr "Inici"
 
-#: ../treebrowser/src/treebrowser.c:1913
+#: ../treebrowser/src/treebrowser.c:1917
 msgid "Set path from document"
 msgstr "Especifica el directori pel document"
 
-#: ../treebrowser/src/treebrowser.c:1923
+#: ../treebrowser/src/treebrowser.c:1927
 msgid "Track path"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1933
+#: ../treebrowser/src/treebrowser.c:1937
 msgid "Hide bars"
 msgstr "Amaga les barres"
 
-#: ../treebrowser/src/treebrowser.c:1943
+#: ../treebrowser/src/treebrowser.c:1947
 msgid ""
 "Filter (*.c;*.h;*.cpp), and if you want temporary filter using the '!' "
 "reverse try for example this '!;*.c;*.h;*.cpp'"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1948
+#: ../treebrowser/src/treebrowser.c:1952
 msgid "Addressbar for example '/projects/my-project'"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1973
+#: ../treebrowser/src/treebrowser.c:1977
 msgid "Tree Browser"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2114
+#: ../treebrowser/src/treebrowser.c:2118
 msgid "External open command"
 msgstr "Ordre externa per obrir"
 
-#: ../treebrowser/src/treebrowser.c:2124
-#, c-format
+#: ../treebrowser/src/treebrowser.c:2129
+#, no-c-format
 msgid ""
 "The command to execute when using \"Open with\". You can use %f and %d "
 "wildcards.\n"
@@ -7462,119 +7229,119 @@ msgstr ""
 "%f serà substituit amb el nom del fitxer, incloent la ruta completa\n"
 "%d serà substituit amb la ruta completa, sense el nom del fitxer"
 
-#: ../treebrowser/src/treebrowser.c:2143
+#: ../treebrowser/src/treebrowser.c:2148
 msgid "The terminal to use with the command \"Open Terminal\""
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2149
+#: ../treebrowser/src/treebrowser.c:2154
 msgid "Toolbar"
 msgstr "Barra d'Eines"
 
-#: ../treebrowser/src/treebrowser.c:2151
+#: ../treebrowser/src/treebrowser.c:2156
 msgid "Hidden"
 msgstr "Ocult"
 
-#: ../treebrowser/src/treebrowser.c:2152
+#: ../treebrowser/src/treebrowser.c:2157
 msgid "Top"
 msgstr "Part superior"
 
-#: ../treebrowser/src/treebrowser.c:2153
+#: ../treebrowser/src/treebrowser.c:2158
 msgid "Bottom"
 msgstr "Part inferior"
 
-#: ../treebrowser/src/treebrowser.c:2158
+#: ../treebrowser/src/treebrowser.c:2163
 msgid "If position is changed, the option require plugin restart."
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2162
+#: ../treebrowser/src/treebrowser.c:2167
 msgid "Show icons"
 msgstr "Mostra les icones"
 
-#: ../treebrowser/src/treebrowser.c:2164
+#: ../treebrowser/src/treebrowser.c:2169
 msgid "None"
 msgstr "Cap"
 
-#: ../treebrowser/src/treebrowser.c:2165
+#: ../treebrowser/src/treebrowser.c:2170
 msgid "Base"
 msgstr "Base"
 
-#: ../treebrowser/src/treebrowser.c:2166
+#: ../treebrowser/src/treebrowser.c:2171
 msgid "Content-type"
 msgstr "Tipus de continguts"
 
-#: ../treebrowser/src/treebrowser.c:2172
+#: ../treebrowser/src/treebrowser.c:2177
 msgid "Show hidden files"
 msgstr "Mostra els fitxers ocults"
 
-#: ../treebrowser/src/treebrowser.c:2181
+#: ../treebrowser/src/treebrowser.c:2186
 msgid "On Windows, this just hide files that are prefixed with '.' (dot)"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2183
+#: ../treebrowser/src/treebrowser.c:2188
 msgid "Hide object files"
 msgstr "Amaga els fitxers objecte"
 
-#: ../treebrowser/src/treebrowser.c:2192
+#: ../treebrowser/src/treebrowser.c:2197
 msgid ""
 "Don't show generated object files in the file browser, this includes *.o, *."
 "obj. *.so, *.dll, *.a, *.lib"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2194
+#: ../treebrowser/src/treebrowser.c:2199
 msgid "Reverse filter"
 msgstr "Inverteix el filtre"
 
-#: ../treebrowser/src/treebrowser.c:2203
+#: ../treebrowser/src/treebrowser.c:2208
 msgid "Follow current document"
 msgstr "Segueix el document actual"
 
-#: ../treebrowser/src/treebrowser.c:2212
+#: ../treebrowser/src/treebrowser.c:2217
 msgid "Single click, open document and focus it"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2221
+#: ../treebrowser/src/treebrowser.c:2226
 msgid "Double click open directory"
 msgstr "Doble clic obre els directoris"
 
-#: ../treebrowser/src/treebrowser.c:2230
+#: ../treebrowser/src/treebrowser.c:2235
 msgid "On delete file, close it if is opened"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2239
+#: ../treebrowser/src/treebrowser.c:2244
 msgid "Focus editor on file open"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2248
+#: ../treebrowser/src/treebrowser.c:2253
 msgid "Show tree lines"
 msgstr "Mostra les línies de l'arbre"
 
-#: ../treebrowser/src/treebrowser.c:2257
+#: ../treebrowser/src/treebrowser.c:2262
 msgid "Show bookmarks"
 msgstr "Mostra les adreces d'interès"
 
-#: ../treebrowser/src/treebrowser.c:2266
+#: ../treebrowser/src/treebrowser.c:2271
 #, fuzzy
 msgid "Open new files"
 msgstr "Obre un Fitxer"
 
-#: ../treebrowser/src/treebrowser.c:2350
+#: ../treebrowser/src/treebrowser.c:2355
 msgid "Focus File List"
 msgstr "Enfoca la Llista de Fitxers"
 
-#: ../treebrowser/src/treebrowser.c:2352
+#: ../treebrowser/src/treebrowser.c:2357
 msgid "Focus Path Entry"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2354
+#: ../treebrowser/src/treebrowser.c:2359
 msgid "Rename Object"
 msgstr "Reanomena Objecte"
 
-#: ../treebrowser/src/treebrowser.c:2358
+#: ../treebrowser/src/treebrowser.c:2363
 #, fuzzy
 msgid "New Folder"
 msgstr "Selecciona Directory"
 
-#: ../treebrowser/src/treebrowser.c:2362
+#: ../treebrowser/src/treebrowser.c:2367
 msgid "Track Current"
 msgstr ""
 
@@ -8273,13 +8040,6 @@ msgstr "NouDirectori"
 msgid "No workbench opened."
 msgstr ""
 
-#: ../workbench/src/sidebar.c:875
-#, fuzzy, c-format
-msgid "%s: %u Project"
-msgid_plural "%s: %u Projects"
-msgstr[0] "Projecte"
-msgstr[1] "Projecte"
-
 #: ../workbench/src/sidebar.c:886
 msgid ""
 "Add a project using the context menu\n"
@@ -8303,8 +8063,8 @@ msgstr ""
 #, fuzzy, c-format
 msgid "Could not setup file monitoring for directory: \"%s\". Error: %s"
 msgstr ""
-"No s'ha pogut trobar un fitxer de configuració per al tipus de fitxer \"%s"
-"\": %s"
+"No s'ha pogut trobar un fitxer de configuració per al tipus de fitxer "
+"\"%s\": %s"
 
 #: ../workbench/src/wb_project.c:466
 #, fuzzy, c-format
@@ -8389,6 +8149,47 @@ msgstr ""
 #: ../xmlsnippets/src/plugin.c:45
 msgid "Autocompletes XML/HTML tags using snippets."
 msgstr ""
+
+#, fuzzy
+#~ msgid "_Removed lines:"
+#~ msgstr "Elimina un Fitxer"
+
+#, fuzzy
+#~ msgid "Colors"
+#~ msgstr "Color del Fons:"
+
+#, fuzzy
+#~ msgid "Position on left"
+#~ msgstr "Posició:"
+
+#, fuzzy
+#~ msgid "Hide tooltip"
+#~ msgstr "Mostra _consells"
+
+#, fuzzy
+#~ msgid "Color:"
+#~ msgstr "Color del Fons:"
+
+#, fuzzy
+#~ msgid "Outline Color:"
+#~ msgstr "Selecciona un Color"
+
+#, fuzzy
+#~ msgid "_Show stats"
+#~ msgstr "Mostra l'estat"
+
+#, fuzzy
+#~ msgid "Translated:"
+#~ msgstr "Plantilla:"
+
+#~ msgid "Check spelling while typing"
+#~ msgstr "Verifica l'ortografia a mesura que escric"
+
+#, fuzzy, c-format
+#~ msgid "%s: %u Project"
+#~ msgid_plural "%s: %u Projects"
+#~ msgstr[0] "Projecte"
+#~ msgstr[1] "Projecte"
 
 #~ msgid "GeanyLaTeX"
 #~ msgstr "GeanyLaTeX"

--- a/po/da.po
+++ b/po/da.po
@@ -5,8 +5,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: geany-plugins 1.38\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-29 03:19+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/geany/geany/issues\n"
+"POT-Creation-Date: 2022-06-28 07:39+0200\n"
 "PO-Revision-Date: 2021-09-29 03:19+0000\n"
 "Last-Translator: \n"
 "Language-Team: Danish\n"
@@ -20,27 +20,27 @@ msgstr ""
 msgid "(Empty Line)"
 msgstr ""
 
-#: ../addons/src/ao_bookmarklist.c:315
+#: ../addons/src/ao_bookmarklist.c:331
 msgid "_Remove Bookmark"
 msgstr ""
 
 #. Translators: Number is meant at this point.
-#: ../addons/src/ao_bookmarklist.c:342
+#: ../addons/src/ao_bookmarklist.c:358
 msgid "No."
 msgstr ""
 
-#: ../addons/src/ao_bookmarklist.c:350 ../devhelp/src/dhp-object.c:494
+#: ../addons/src/ao_bookmarklist.c:366 ../devhelp/src/dhp-object.c:494
 #: ../devhelp/devhelp/dh-window.c:1142
 msgid "Contents"
 msgstr ""
 
-#: ../addons/src/ao_bookmarklist.c:383 ../treebrowser/src/treebrowser.c:666
+#: ../addons/src/ao_bookmarklist.c:399 ../treebrowser/src/treebrowser.c:666
 #: ../webhelper/src/gwh-plugin.c:328
 msgid "Bookmarks"
 msgstr ""
 
 #. complete update
-#: ../addons/src/ao_tasks.c:373 ../geanyvc/src/geanyvc.c:2653
+#: ../addons/src/ao_tasks.c:373 ../geanyvc/src/geanyvc.c:2730
 msgid "_Update"
 msgstr ""
 
@@ -160,10 +160,10 @@ msgstr ""
 #: ../addons/src/addons.c:364 ../autoclose/src/autoclose.c:920
 #: ../codenav/src/codenavigation.c:281 ../latex/src/latex.c:208
 #: ../latex/src/latex.c:293 ../geanyprj/src/geanyprj.c:176
-#: ../geanyvc/src/geanyvc.c:2053 ../geniuspaste/src/geniuspaste.c:336
+#: ../geanyvc/src/geanyvc.c:2130 ../geniuspaste/src/geniuspaste.c:336
 #: ../lineoperations/src/lo_prefs.c:58 ../sendmail/src/sendmail.c:128
 #: ../sendmail/src/sendmail.c:293 ../spellcheck/src/scplugin.c:124
-#: ../treebrowser/src/treebrowser.c:2102
+#: ../treebrowser/src/treebrowser.c:2106
 #: ../updatechecker/src/updatechecker.c:262
 msgid "Plugin configuration directory could not be created."
 msgstr ""
@@ -702,7 +702,7 @@ msgstr ""
 msgid "Error loading file"
 msgstr ""
 
-#. setting asyncronous mode
+#. setting asynchronous mode
 #. setting null-stop array printing
 #. enable pretty printing
 #: ../debugger/src/dbm_gdb.c:789 ../debugger/src/dbm_gdb.c:792
@@ -1092,7 +1092,7 @@ msgid "A developers' help browser for GNOME"
 msgstr ""
 
 #. Create the current file Submenu
-#: ../devhelp/devhelp/dh-window.c:759 ../geanyvc/src/geanyvc.c:2634
+#: ../devhelp/devhelp/dh-window.c:759 ../geanyvc/src/geanyvc.c:2711
 msgid "_File"
 msgstr ""
 
@@ -1126,11 +1126,11 @@ msgstr ""
 msgid "_Print…"
 msgstr ""
 
-#: ../devhelp/devhelp/dh-window.c:782 ../devhelp/devhelp/eggfindbar.c:342
+#: ../devhelp/devhelp/dh-window.c:782
 msgid "Find Next"
 msgstr ""
 
-#: ../devhelp/devhelp/dh-window.c:784 ../devhelp/devhelp/eggfindbar.c:329
+#: ../devhelp/devhelp/dh-window.c:784
 msgid "Find Previous"
 msgstr ""
 
@@ -1315,7 +1315,7 @@ msgid ""
 "contributing to this plugin?"
 msgstr ""
 
-#: ../geanydoc/src/geanydoc.c:159 ../geanyvc/src/geanyvc.c:442
+#: ../geanydoc/src/geanydoc.c:159 ../geanyvc/src/geanyvc.c:448
 msgid "Could not parse the output of command"
 msgstr ""
 
@@ -2959,14 +2959,14 @@ msgid ""
 "not enough arguments for command \"%s\".\n"
 msgstr ""
 
-#: ../geanylua/glspi_sci.c:637 ../geanylua/glspi_app.c:406
+#: ../geanylua/glspi_sci.c:729 ../geanylua/glspi_app.c:406
 #, c-format
 msgid ""
 "Error in module \"%s\" at function %s():\n"
 "unknown command \"%s\" given for argument #1.\n"
 msgstr ""
 
-#: ../geanylua/glspi_sci.c:781
+#: ../geanylua/glspi_sci.c:924
 #, c-format
 msgid ""
 "Error in module \"%s\" at function %s():\n"
@@ -2974,7 +2974,7 @@ msgid ""
 " unknown flag \"%s\" for element #%d\n"
 msgstr ""
 
-#: ../geanylua/glspi_sci.c:785
+#: ../geanylua/glspi_sci.c:928
 msgid "<too large to display>"
 msgstr ""
 
@@ -3695,7 +3695,7 @@ msgid "New _Below"
 msgstr ""
 
 #: ../geanymacro/src/geanymacro.c:1824 ../geanymacro/src/geanymacro.c:2120
-#: ../treebrowser/src/treebrowser.c:1338 ../treebrowser/src/treebrowser.c:1340
+#: ../treebrowser/src/treebrowser.c:1342 ../treebrowser/src/treebrowser.c:1344
 msgid "_Delete"
 msgstr ""
 
@@ -4058,8 +4058,8 @@ msgstr ""
 msgid "a key with fingerprint"
 msgstr ""
 
-#: ../geanypg/src/verify_aux.c:66 ../spellcheck/src/gui.c:610
-#: ../spellcheck/src/gui.c:621
+#: ../geanypg/src/verify_aux.c:66 ../spellcheck/src/gui.c:607
+#: ../spellcheck/src/gui.c:618
 msgid "unknown"
 msgstr ""
 
@@ -4350,49 +4350,49 @@ msgid ""
 "contributing to this plugin?"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:501
+#: ../geanyvc/src/geanyvc.c:507
 #, c-format
 msgid "geanyvc: s_spawn_sync error: %s"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:587
+#: ../geanyvc/src/geanyvc.c:593
 #, c-format
 msgid "File %s: action %s executed via %s."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:640 ../geanyvc/src/geanyvc.c:651
+#: ../geanyvc/src/geanyvc.c:633 ../geanyvc/src/geanyvc.c:643
 #, c-format
-msgid "geanyvc: vcdiff_file_activated: Unable to rename '%s' to '%s'"
+msgid "geanyvc: diff_external: Unable to rename '%s' to '%s'"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:677 ../geanyvc/src/geanyvc.c:727
+#: ../geanyvc/src/geanyvc.c:698 ../geanyvc/src/geanyvc.c:784
 msgid "No changes were made."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:754
+#: ../geanyvc/src/geanyvc.c:811
 msgid "No history available"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:947 ../geanyvc/src/geanyvc.c:955
+#: ../geanyvc/src/geanyvc.c:1004 ../geanyvc/src/geanyvc.c:1012
 #, c-format
 msgid "Do you really want to revert: %s?"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:963
+#: ../geanyvc/src/geanyvc.c:1020
 #, c-format
 msgid "Do you really want to add: %s?"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:970
+#: ../geanyvc/src/geanyvc.c:1027
 #, c-format
 msgid "Do you really want to remove: %s?"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:993
+#: ../geanyvc/src/geanyvc.c:1050
 msgid "Do you really want to update?"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1120
+#: ../geanyvc/src/geanyvc.c:1177
 msgid ""
 "The resulting differences cannot be displayed because the changes are too "
 "big to display here and would slow down the UI significantly.\n"
@@ -4401,314 +4401,327 @@ msgid ""
 "Geany directly by using the GeanyVC menu (Base Directory -> Diff)."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1274
+#: ../geanyvc/src/geanyvc.c:1331
 msgid "Commit Y/N"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1284
+#: ../geanyvc/src/geanyvc.c:1341
 msgid "Status"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1291
+#: ../geanyvc/src/geanyvc.c:1348
 msgid "Path"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1408
+#: ../geanyvc/src/geanyvc.c:1465
 msgid "Choose a previous commit message"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1470
+#: ../geanyvc/src/geanyvc.c:1527
 #, c-format
 msgid "Line: %d Column: %d"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1517
+#: ../geanyvc/src/geanyvc.c:1574
 msgid "Commit"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1558
+#: ../geanyvc/src/geanyvc.c:1615
 msgid "_De-/select all files"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1602
+#: ../geanyvc/src/geanyvc.c:1659
 msgid "<b>Commit message:</b>"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1626
+#: ../geanyvc/src/geanyvc.c:1683
 msgid "C_ommit"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1734
+#: ../geanyvc/src/geanyvc.c:1791
 msgid "Nothing to commit."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1782
+#: ../geanyvc/src/geanyvc.c:1839
 #, c-format
 msgid ""
 "Error initializing GeanyVC spell checking: %s. Check your configuration."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2125
+#: ../geanyvc/src/geanyvc.c:1874
+#, c-format
+msgid "Commit failed (status: %d, error: %s)."
+msgstr ""
+
+#: ../geanyvc/src/geanyvc.c:1875
+msgid "Commit failed; see status in the Message window."
+msgstr ""
+
+#: ../geanyvc/src/geanyvc.c:1880
+msgid "Changes committed."
+msgstr ""
+
+#: ../geanyvc/src/geanyvc.c:2202
 msgid "Set Changed-flag for document tabs created by the plugin"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2128
+#: ../geanyvc/src/geanyvc.c:2205
 msgid ""
 "If this option is activated, every new by the VC-plugin created document tab "
 "will be marked as changed. Even this option is useful in some cases, it "
 "could cause a big number of annoying \"Do you want to save\"-dialogs."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2136
+#: ../geanyvc/src/geanyvc.c:2213
 msgid "Confirm adding new files to a VCS"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2139
+#: ../geanyvc/src/geanyvc.c:2216
 msgid "Shows a confirmation dialog on adding a new (created) file to VCS."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2145
+#: ../geanyvc/src/geanyvc.c:2222
 msgid "Maximize commit dialog"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2146
+#: ../geanyvc/src/geanyvc.c:2223
 msgid "Show commit dialog maximize."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2152
+#: ../geanyvc/src/geanyvc.c:2229
 msgid "Use external diff viewer"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2154
+#: ../geanyvc/src/geanyvc.c:2231
 msgid "Use external diff viewer for file diff."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2160
+#: ../geanyvc/src/geanyvc.c:2237
 msgid "Show VC entries at editor menu"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2162
+#: ../geanyvc/src/geanyvc.c:2239
 msgid "Show entries for VC functions inside editor menu"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2167
+#: ../geanyvc/src/geanyvc.c:2244
 msgid "Attach menu to menubar"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2169
+#: ../geanyvc/src/geanyvc.c:2246
 msgid ""
 "Whether menu for this plugin are getting placed either inside tools menu or "
 "directly inside Geany's menubar. Will take in account after next start of "
 "GeanyVC"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2177
+#: ../geanyvc/src/geanyvc.c:2254
 msgid "Enable CVS"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2182
+#: ../geanyvc/src/geanyvc.c:2259
 msgid "Enable GIT"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2187
+#: ../geanyvc/src/geanyvc.c:2264
 msgid "Enable Fossil"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2192
+#: ../geanyvc/src/geanyvc.c:2269
 msgid "Enable SVN"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2197
+#: ../geanyvc/src/geanyvc.c:2274
 msgid "Enable SVK"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2202
+#: ../geanyvc/src/geanyvc.c:2279
 msgid "Enable Bazaar"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2207
+#: ../geanyvc/src/geanyvc.c:2284
 msgid "Enable Mercurial"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2213
+#: ../geanyvc/src/geanyvc.c:2290
 msgid "Spellcheck language"
 msgstr ""
 
 #. Diff of current file
 #. Diff of the current dir
 #. Complete diff of base directory
-#: ../geanyvc/src/geanyvc.c:2342 ../geanyvc/src/geanyvc.c:2437
-#: ../geanyvc/src/geanyvc.c:2477
+#: ../geanyvc/src/geanyvc.c:2419 ../geanyvc/src/geanyvc.c:2514
+#: ../geanyvc/src/geanyvc.c:2554
 msgid "_Diff"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2345
+#: ../geanyvc/src/geanyvc.c:2422
 msgid "Make a diff from the current active file"
 msgstr ""
 
 #. Revert current file
 #. Revert current dir
 #. Revert everything
-#: ../geanyvc/src/geanyvc.c:2350 ../geanyvc/src/geanyvc.c:2446
-#: ../geanyvc/src/geanyvc.c:2485
+#: ../geanyvc/src/geanyvc.c:2427 ../geanyvc/src/geanyvc.c:2523
+#: ../geanyvc/src/geanyvc.c:2562
 msgid "_Revert"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2353
+#: ../geanyvc/src/geanyvc.c:2430
 msgid "Restore pristine working copy file (undo local edits)."
 msgstr ""
 
 #. Blame for current file
-#: ../geanyvc/src/geanyvc.c:2362
+#: ../geanyvc/src/geanyvc.c:2439
 msgid "_Blame"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2365
+#: ../geanyvc/src/geanyvc.c:2442
 msgid "Shows the changes made at one file per revision and author."
 msgstr ""
 
 #. History/log of current file
 #. History/log of the current dir
 #. Complete History/Log of base directory
-#: ../geanyvc/src/geanyvc.c:2372 ../geanyvc/src/geanyvc.c:2456
-#: ../geanyvc/src/geanyvc.c:2497
+#: ../geanyvc/src/geanyvc.c:2449 ../geanyvc/src/geanyvc.c:2533
+#: ../geanyvc/src/geanyvc.c:2574
 msgid "_History (log)"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2375
+#: ../geanyvc/src/geanyvc.c:2452
 msgid "Shows the log of the current file"
 msgstr ""
 
 #. base version of the current file
-#: ../geanyvc/src/geanyvc.c:2380
+#: ../geanyvc/src/geanyvc.c:2457
 msgid "_Original"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2383
+#: ../geanyvc/src/geanyvc.c:2460
 msgid "Shows the original of the current file"
 msgstr ""
 
 #. add current file
-#: ../geanyvc/src/geanyvc.c:2391
+#: ../geanyvc/src/geanyvc.c:2468
 msgid "_Add to Version Control"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2393
+#: ../geanyvc/src/geanyvc.c:2470
 msgid "Add file to repository."
 msgstr ""
 
 #. remove current file
-#: ../geanyvc/src/geanyvc.c:2399
+#: ../geanyvc/src/geanyvc.c:2476
 msgid "_Remove from Version Control"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2401
+#: ../geanyvc/src/geanyvc.c:2478
 msgid "Remove file from repository."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2434
+#: ../geanyvc/src/geanyvc.c:2511
 msgid "_Directory"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2440
+#: ../geanyvc/src/geanyvc.c:2517
 msgid "Make a diff from the directory of the current active file"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2449
+#: ../geanyvc/src/geanyvc.c:2526
 msgid "Restore original files in the current folder (undo local edits)."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2459
+#: ../geanyvc/src/geanyvc.c:2536
 msgid "Shows the log of the current directory"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2473
+#: ../geanyvc/src/geanyvc.c:2550
 msgid "_Base Directory"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2479
+#: ../geanyvc/src/geanyvc.c:2556
 msgid "Make a diff from the top VC directory"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2487
+#: ../geanyvc/src/geanyvc.c:2564
 msgid "Revert any local edits."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2500
+#: ../geanyvc/src/geanyvc.c:2577
 msgid "Shows the log of the top VC directory"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2517
+#: ../geanyvc/src/geanyvc.c:2594
 msgid "_VC file Actions"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2526
+#: ../geanyvc/src/geanyvc.c:2603
 msgid "VC _Commit..."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2570
+#: ../geanyvc/src/geanyvc.c:2647
 msgid "Show diff of file"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2572
+#: ../geanyvc/src/geanyvc.c:2649
 msgid "Show diff of directory"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2574
+#: ../geanyvc/src/geanyvc.c:2651
 msgid "Show diff of basedir"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2577
+#: ../geanyvc/src/geanyvc.c:2654
 msgid "Commit changes"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2579
+#: ../geanyvc/src/geanyvc.c:2656
 msgid "Show status"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2581
+#: ../geanyvc/src/geanyvc.c:2658
 msgid "Revert single file"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2583
+#: ../geanyvc/src/geanyvc.c:2660
 msgid "Revert directory"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2585
+#: ../geanyvc/src/geanyvc.c:2662
 msgid "Revert base directory"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2587
+#: ../geanyvc/src/geanyvc.c:2664
 msgid "Update file"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2617
+#: ../geanyvc/src/geanyvc.c:2694
 msgid "_VC"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2624
+#: ../geanyvc/src/geanyvc.c:2701
 msgid "_Version Control"
 msgstr ""
 
 #. Status of basedir
-#: ../geanyvc/src/geanyvc.c:2646
+#: ../geanyvc/src/geanyvc.c:2723
 msgid "_Status"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2648
+#: ../geanyvc/src/geanyvc.c:2725
 msgid "Show status."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2655
+#: ../geanyvc/src/geanyvc.c:2732
 msgid "Update from remote repository."
 msgstr ""
 
 #. Commit all changes
-#: ../geanyvc/src/geanyvc.c:2660
+#: ../geanyvc/src/geanyvc.c:2737
 msgid "_Commit..."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2662
+#: ../geanyvc/src/geanyvc.c:2739
 msgid "Commit changes."
 msgstr ""
 
@@ -4818,33 +4831,6 @@ msgstr ""
 
 #: ../geniuspaste/src/geniuspaste.c:959
 msgid "_Paste it!"
-msgstr ""
-
-#: ../git-changebar/data/prefs.ui.h:1
-msgid "_Monitor repository for changes"
-msgstr ""
-
-#: ../git-changebar/data/prefs.ui.h:2
-msgid ""
-"Whether to automatically update the diff in order to maintain it up to date "
-"when the underlying Git repository changes.  This should generally be "
-"enabled for optimal user experience."
-msgstr ""
-
-#: ../git-changebar/data/prefs.ui.h:3
-msgid "_Added lines:"
-msgstr ""
-
-#: ../git-changebar/data/prefs.ui.h:4
-msgid "_Changed lines:"
-msgstr ""
-
-#: ../git-changebar/data/prefs.ui.h:5
-msgid "_Removed lines:"
-msgstr ""
-
-#: ../git-changebar/data/prefs.ui.h:6
-msgid "Colors"
 msgstr ""
 
 #: ../git-changebar/src/gcb-plugin.c:62
@@ -5023,8 +5009,8 @@ msgstr ""
 #: ../lipsum/src/lipsum.c:184 ../sendmail/src/sendmail.c:396
 #, c-format
 msgid ""
-"Your configuration directory has been successfully moved from \"%s\" to \"%s"
-"\"."
+"Your configuration directory has been successfully moved from \"%s\" to "
+"\"%s\"."
 msgstr ""
 
 #: ../lipsum/src/lipsum.c:199
@@ -5187,7 +5173,7 @@ msgstr ""
 msgid "Unable to read value for '%s' key: %s"
 msgstr ""
 
-#: ../multiterm/src/tab-label.vala:62 ../treebrowser/src/treebrowser.c:2132
+#: ../multiterm/src/tab-label.vala:62 ../treebrowser/src/treebrowser.c:2137
 msgid "Terminal"
 msgstr ""
 
@@ -5225,112 +5211,6 @@ msgstr ""
 msgid "Show Overview"
 msgstr ""
 
-#: ../overview/data/prefs.ui.h:1
-msgid ""
-"The amount to zoom the overview sidebar. This should probably negative if "
-"you want the sidebar zoomed out."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:2
-msgid "Zoom Level:"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:3
-msgid "The width of the overview sidebar."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:4
-msgid "Width:"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:5
-msgid ""
-"The number of lines to scroll at a time when scrolling the overview sidebar."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:6
-msgid "Scroll Lines:"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:7
-msgid "Position on left"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:8
-msgid ""
-"Position the overview bar on the left rather than the right (requires Geany "
-"1.25 or greater)."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:9
-msgid "Hide tooltip"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:10
-msgid ""
-"Hide the tooltip that is displayed when mousing over the overview that shows "
-"line, column and position information."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:11
-msgid "Hide editor scrollbar"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:12
-msgid ""
-"Whether to hide Geany's regular editor scrollbar while the overview bar is "
-"visible."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:13
-msgid "Disable overlay"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:14
-msgid ""
-"Turn off drawing overlay, which shows the region of the main editor view "
-"that is currently in view, ontop of the overview bar."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:15 ../scope/data/scope.glade.h:130
-#: ../scope/data/scope_gtk3.glade.h:130
-msgid "Options"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:16
-msgid ""
-"The color and opacity of the overlay drawn ontop of the overlay sidebar."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:17
-msgid "Color:"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:18
-msgid ""
-"The color and opacity of the border drawn around the revealed area in the "
-"overview sidebar. Set to the same as Overlay Color to disable."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:19
-msgid "Outline Color:"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:20
-msgid "Draw over visible area"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:21
-msgid ""
-"When checked it will draw the overlay ontop of the area that is visible in "
-"the main editor view, when unchecked, it will do the opposite and draw the "
-"overlay everywhere but the visible area, \"revealing\" the visible part."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:22
-msgid "Overlay"
-msgstr ""
-
 #: ../pairtaghighlighter/src/pair_tag_highlighter.c:43
 msgid "Pair Tag Highlighter"
 msgstr ""
@@ -5353,144 +5233,6 @@ msgstr ""
 
 #: ../pairtaghighlighter/src/pair_tag_highlighter.c:504
 msgid "Select To Matching Tag"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:1
-msgid "_Translation Helper"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:2
-msgid "_Previous String"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:3 ../pohelper/src/gph-plugin.c:1590
-msgid "Go to previous string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:4
-msgid "_Next String"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:5 ../pohelper/src/gph-plugin.c:1593
-msgid "Go to next string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:6
-msgid "Pre_vious Untranslated"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:7 ../pohelper/src/gph-plugin.c:1596
-msgid "Go to previous untranslated string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:8
-msgid "Next _Untranslated"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:9 ../pohelper/src/gph-plugin.c:1599
-msgid "Go to next untranslated string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:10
-msgid "Previous Fu_zzy"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:11 ../pohelper/src/gph-plugin.c:1602
-msgid "Go to previous fuzzily translated string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:12
-msgid "Next _Fuzzy"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:13 ../pohelper/src/gph-plugin.c:1605
-msgid "Go to next fuzzily translated string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:14
-msgid "Previous Untranslated or Fuzz_y"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:15 ../pohelper/src/gph-plugin.c:1608
-msgid "Go to previous untranslated or fuzzy string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:16
-msgid "Next Untranslated _or Fuzzy"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:17 ../pohelper/src/gph-plugin.c:1612
-msgid "Go to next untranslated or fuzzy string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:18 ../pohelper/src/gph-plugin.c:1623
-msgid "Toggle current translation fuzziness"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:19
-msgid "_Toggle Fuzziness"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:20
-msgid "Paste _Message as Translation"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:21
-msgid "Paste the original untranslated string to the translation"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:22 ../pohelper/src/gph-plugin.c:1620
-msgid "Reflow the current translation string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:23
-msgid "_Reflow Translation"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:24 ../pohelper/src/gph-plugin.c:1626
-msgid "Show statistics of the current document"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:25
-msgid "_Show stats"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:26
-msgid ""
-"Whether to update the translation headers (author, revision date, ...) upon "
-"file save"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:27
-msgid "Update _Headers Upon Save"
-msgstr ""
-
-#: ../pohelper/data/stats.ui.h:1
-msgid "Translation statistics"
-msgstr ""
-
-#: ../pohelper/data/stats.ui.h:2
-msgid "Choose a color for translated strings"
-msgstr ""
-
-#: ../pohelper/data/stats.ui.h:3
-msgid "Choose a color for fuzzily translated strings"
-msgstr ""
-
-#: ../pohelper/data/stats.ui.h:4
-msgid "Choose a color for untranslated strings"
-msgstr ""
-
-#: ../pohelper/data/stats.ui.h:5
-msgid "Translated:"
-msgstr ""
-
-#: ../pohelper/data/stats.ui.h:6
-msgid "Fuzzy:"
-msgstr ""
-
-#: ../pohelper/data/stats.ui.h:7
-msgid "Untranslated:"
 msgstr ""
 
 #: ../pohelper/src/gph-plugin.c:40
@@ -5521,8 +5263,52 @@ msgstr ""
 msgid "%u (%.3g%%)"
 msgstr ""
 
+#: ../pohelper/src/gph-plugin.c:1590
+msgid "Go to previous string"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1593
+msgid "Go to next string"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1596
+msgid "Go to previous untranslated string"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1599
+msgid "Go to next untranslated string"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1602
+msgid "Go to previous fuzzily translated string"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1605
+msgid "Go to next fuzzily translated string"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1608
+msgid "Go to previous untranslated or fuzzy string"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1612
+msgid "Go to next untranslated or fuzzy string"
+msgstr ""
+
 #: ../pohelper/src/gph-plugin.c:1616
 msgid "Paste original untranslated string to translation"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1620
+msgid "Reflow the current translation string"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1623
+msgid "Toggle current translation fuzziness"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1626
+msgid "Show statistics of the current document"
 msgstr ""
 
 #: ../pohelper/src/gph-plugin.c:1833
@@ -5783,7 +5569,7 @@ msgid "Add"
 msgstr ""
 
 #: ../projectorganizer/src/prjorg-sidebar.c:390
-#: ../treebrowser/src/treebrowser.c:2356
+#: ../treebrowser/src/treebrowser.c:2361
 msgid "New File"
 msgstr ""
 
@@ -6393,6 +6179,10 @@ msgstr ""
 msgid "<b>Others</b>"
 msgstr ""
 
+#: ../scope/data/scope.glade.h:130 ../scope/data/scope_gtk3.glade.h:130
+msgid "Options"
+msgstr ""
+
 #: ../scope/data/scope.glade.h:131 ../scope/data/scope_gtk3.glade.h:131
 msgid "_Import"
 msgstr ""
@@ -6947,11 +6737,11 @@ msgid "Checks the spelling of the current document."
 msgstr ""
 
 #: ../spellcheck/src/scplugin.c:225
-msgid "Run Spell Check"
+msgid "Run spell check once"
 msgstr ""
 
-#: ../spellcheck/src/scplugin.c:228
-msgid "Toggle Check While Typing"
+#: ../spellcheck/src/scplugin.c:228 ../spellcheck/src/scplugin.c:333
+msgid "Toggle spell check"
 msgstr ""
 
 #. initialise the dialog
@@ -6977,10 +6767,6 @@ msgstr ""
 
 #: ../spellcheck/src/scplugin.c:325
 msgid "<b>Interface</b>"
-msgstr ""
-
-#: ../spellcheck/src/scplugin.c:333
-msgid "Check spelling while typing"
 msgstr ""
 
 #: ../spellcheck/src/scplugin.c:336
@@ -7013,52 +6799,52 @@ msgstr ""
 msgid "<b>Behavior</b>"
 msgstr ""
 
-#: ../spellcheck/src/gui.c:76
+#: ../spellcheck/src/gui.c:88
 msgid "Spell checking while typing is now enabled"
 msgstr ""
 
-#: ../spellcheck/src/gui.c:78
+#: ../spellcheck/src/gui.c:90
 msgid "Spell checking while typing is now disabled"
 msgstr ""
 
-#: ../spellcheck/src/gui.c:326
+#: ../spellcheck/src/gui.c:323
 msgid "More..."
 msgstr ""
 
-#: ../spellcheck/src/gui.c:347
+#: ../spellcheck/src/gui.c:344
 msgid "(No Suggestions)"
 msgstr ""
 
-#: ../spellcheck/src/gui.c:360
+#: ../spellcheck/src/gui.c:357
 #, c-format
 msgid "Add \"%s\" to Dictionary"
 msgstr ""
 
-#: ../spellcheck/src/gui.c:368
+#: ../spellcheck/src/gui.c:365
 msgid "Ignore All"
 msgstr ""
 
-#: ../spellcheck/src/gui.c:441
+#: ../spellcheck/src/gui.c:438
 msgid ""
 "Search term is too long to provide\n"
 "spelling suggestions in the editor menu."
 msgstr ""
 
-#: ../spellcheck/src/gui.c:447
+#: ../spellcheck/src/gui.c:444
 msgid "Perform Spell Check"
 msgstr ""
 
-#: ../spellcheck/src/gui.c:609
+#: ../spellcheck/src/gui.c:606
 #, c-format
 msgid "Default (%s)"
 msgstr ""
 
-#: ../spellcheck/src/gui.c:620
+#: ../spellcheck/src/gui.c:617
 #, c-format
-msgid "Toggle spell check while typing (current language: %s)"
+msgid "Toggle spell check (current language: %s)"
 msgstr ""
 
-#: ../spellcheck/src/gui.c:698
+#: ../spellcheck/src/gui.c:695
 msgid "Spelling Suggestions"
 msgstr ""
 
@@ -7151,149 +6937,149 @@ msgstr ""
 msgid "Could not execute configured external command '%s' (%s)."
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1089
+#: ../treebrowser/src/treebrowser.c:1093
 msgid "NewDirectory"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1091
+#: ../treebrowser/src/treebrowser.c:1095
 msgid "NewFile"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1096
+#: ../treebrowser/src/treebrowser.c:1100
 #, c-format
 msgid ""
 "Target file '%s' exists.\n"
 "Do you really want to replace it with an empty file?"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1142
+#: ../treebrowser/src/treebrowser.c:1146
 #, c-format
 msgid "Do you really want to delete '%s' ?"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1255 ../treebrowser/src/treebrowser.c:1257
+#: ../treebrowser/src/treebrowser.c:1259 ../treebrowser/src/treebrowser.c:1261
 msgid "Go _Up"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1263 ../treebrowser/src/treebrowser.c:1265
+#: ../treebrowser/src/treebrowser.c:1267 ../treebrowser/src/treebrowser.c:1269
 msgid "Set _Path From Document"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1271 ../treebrowser/src/treebrowser.c:1273
+#: ../treebrowser/src/treebrowser.c:1275 ../treebrowser/src/treebrowser.c:1277
 msgid "_Open Externally"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1279
+#: ../treebrowser/src/treebrowser.c:1283
 msgid "Open _Terminal"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1284 ../treebrowser/src/treebrowser.c:1286
+#: ../treebrowser/src/treebrowser.c:1288 ../treebrowser/src/treebrowser.c:1290
 msgid "Set as _Root"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1293 ../treebrowser/src/treebrowser.c:1295
+#: ../treebrowser/src/treebrowser.c:1297 ../treebrowser/src/treebrowser.c:1299
 msgid "Refres_h"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1301 ../treebrowser/src/treebrowser.c:1303
+#: ../treebrowser/src/treebrowser.c:1305 ../treebrowser/src/treebrowser.c:1307
 msgid "_Find in Files"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1313 ../treebrowser/src/treebrowser.c:1315
+#: ../treebrowser/src/treebrowser.c:1317 ../treebrowser/src/treebrowser.c:1319
 msgid "N_ew Folder"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1321 ../treebrowser/src/treebrowser.c:1323
+#: ../treebrowser/src/treebrowser.c:1325 ../treebrowser/src/treebrowser.c:1327
 msgid "_New File"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1329 ../treebrowser/src/treebrowser.c:1331
+#: ../treebrowser/src/treebrowser.c:1333 ../treebrowser/src/treebrowser.c:1335
 msgid "Rena_me"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1350 ../treebrowser/src/treebrowser.c:1352
+#: ../treebrowser/src/treebrowser.c:1354 ../treebrowser/src/treebrowser.c:1356
 #, c-format
 msgid "Close: %s"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1359 ../treebrowser/src/treebrowser.c:1361
+#: ../treebrowser/src/treebrowser.c:1363 ../treebrowser/src/treebrowser.c:1365
 #, c-format
 msgid "Clo_se Child Documents "
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1368 ../treebrowser/src/treebrowser.c:1370
+#: ../treebrowser/src/treebrowser.c:1372 ../treebrowser/src/treebrowser.c:1374
 msgid "_Copy Full Path to Clipboard"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1381 ../treebrowser/src/treebrowser.c:1383
+#: ../treebrowser/src/treebrowser.c:1385 ../treebrowser/src/treebrowser.c:1387
 msgid "E_xpand All"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1389 ../treebrowser/src/treebrowser.c:1391
+#: ../treebrowser/src/treebrowser.c:1393 ../treebrowser/src/treebrowser.c:1395
 msgid "Coll_apse All"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1399
+#: ../treebrowser/src/treebrowser.c:1403
 msgid "Show Boo_kmarks"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1404
+#: ../treebrowser/src/treebrowser.c:1408
 msgid "Sho_w Hidden Files"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1409
+#: ../treebrowser/src/treebrowser.c:1413
 msgid "Show Tool_bars"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1747
+#: ../treebrowser/src/treebrowser.c:1751
 #, c-format
 msgid "Target file '%s' exists, do you really want to replace it?"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1883
+#: ../treebrowser/src/treebrowser.c:1887
 msgid "Go up"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1893 ../treebrowser/src/treebrowser.c:2360
+#: ../treebrowser/src/treebrowser.c:1897 ../treebrowser/src/treebrowser.c:2365
 msgid "Refresh"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1903
+#: ../treebrowser/src/treebrowser.c:1907
 msgid "Home"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1913
+#: ../treebrowser/src/treebrowser.c:1917
 msgid "Set path from document"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1923
+#: ../treebrowser/src/treebrowser.c:1927
 msgid "Track path"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1933
+#: ../treebrowser/src/treebrowser.c:1937
 msgid "Hide bars"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1943
+#: ../treebrowser/src/treebrowser.c:1947
 msgid ""
 "Filter (*.c;*.h;*.cpp), and if you want temporary filter using the '!' "
 "reverse try for example this '!;*.c;*.h;*.cpp'"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1948
+#: ../treebrowser/src/treebrowser.c:1952
 msgid "Addressbar for example '/projects/my-project'"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1973
+#: ../treebrowser/src/treebrowser.c:1977
 msgid "Tree Browser"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2114
+#: ../treebrowser/src/treebrowser.c:2118
 msgid "External open command"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2124
-#, c-format
+#: ../treebrowser/src/treebrowser.c:2129
+#, no-c-format
 msgid ""
 "The command to execute when using \"Open with\". You can use %f and %d "
 "wildcards.\n"
@@ -7302,117 +7088,117 @@ msgid ""
 "filename"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2143
+#: ../treebrowser/src/treebrowser.c:2148
 msgid "The terminal to use with the command \"Open Terminal\""
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2149
+#: ../treebrowser/src/treebrowser.c:2154
 msgid "Toolbar"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2151
+#: ../treebrowser/src/treebrowser.c:2156
 msgid "Hidden"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2152
+#: ../treebrowser/src/treebrowser.c:2157
 msgid "Top"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2153
+#: ../treebrowser/src/treebrowser.c:2158
 msgid "Bottom"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2158
+#: ../treebrowser/src/treebrowser.c:2163
 msgid "If position is changed, the option require plugin restart."
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2162
+#: ../treebrowser/src/treebrowser.c:2167
 msgid "Show icons"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2164
+#: ../treebrowser/src/treebrowser.c:2169
 msgid "None"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2165
+#: ../treebrowser/src/treebrowser.c:2170
 msgid "Base"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2166
+#: ../treebrowser/src/treebrowser.c:2171
 msgid "Content-type"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2172
+#: ../treebrowser/src/treebrowser.c:2177
 msgid "Show hidden files"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2181
+#: ../treebrowser/src/treebrowser.c:2186
 msgid "On Windows, this just hide files that are prefixed with '.' (dot)"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2183
+#: ../treebrowser/src/treebrowser.c:2188
 msgid "Hide object files"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2192
+#: ../treebrowser/src/treebrowser.c:2197
 msgid ""
 "Don't show generated object files in the file browser, this includes *.o, *."
 "obj. *.so, *.dll, *.a, *.lib"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2194
+#: ../treebrowser/src/treebrowser.c:2199
 msgid "Reverse filter"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2203
+#: ../treebrowser/src/treebrowser.c:2208
 msgid "Follow current document"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2212
+#: ../treebrowser/src/treebrowser.c:2217
 msgid "Single click, open document and focus it"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2221
+#: ../treebrowser/src/treebrowser.c:2226
 msgid "Double click open directory"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2230
+#: ../treebrowser/src/treebrowser.c:2235
 msgid "On delete file, close it if is opened"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2239
+#: ../treebrowser/src/treebrowser.c:2244
 msgid "Focus editor on file open"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2248
+#: ../treebrowser/src/treebrowser.c:2253
 msgid "Show tree lines"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2257
+#: ../treebrowser/src/treebrowser.c:2262
 msgid "Show bookmarks"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2266
+#: ../treebrowser/src/treebrowser.c:2271
 msgid "Open new files"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2350
+#: ../treebrowser/src/treebrowser.c:2355
 msgid "Focus File List"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2352
+#: ../treebrowser/src/treebrowser.c:2357
 msgid "Focus Path Entry"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2354
+#: ../treebrowser/src/treebrowser.c:2359
 msgid "Rename Object"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2358
+#: ../treebrowser/src/treebrowser.c:2363
 msgid "New Folder"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2362
+#: ../treebrowser/src/treebrowser.c:2367
 msgid "Track Current"
 msgstr ""
 
@@ -8060,13 +7846,6 @@ msgstr ""
 #: ../workbench/src/sidebar.c:857 ../workbench/src/sidebar.c:1384
 msgid "No workbench opened."
 msgstr ""
-
-#: ../workbench/src/sidebar.c:875
-#, c-format
-msgid "%s: %u Project"
-msgid_plural "%s: %u Projects"
-msgstr[0] ""
-msgstr[1] ""
 
 #: ../workbench/src/sidebar.c:886
 msgid ""

--- a/po/de.po
+++ b/po/de.po
@@ -15,8 +15,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Geany-Plugins 1.35\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-29 19:41+0200\n"
+"Report-Msgid-Bugs-To: https://github.com/geany/geany/issues\n"
+"POT-Creation-Date: 2022-06-28 07:39+0200\n"
 "PO-Revision-Date: 2016-08-08 22:38+0200\n"
 "Last-Translator: Dominic Hopf <dmaphy@googlemail.com>\n"
 "Language-Team: German <geany-i18n@uvena.de>\n"
@@ -32,27 +32,27 @@ msgstr ""
 msgid "(Empty Line)"
 msgstr "(Leere Zeile)"
 
-#: ../addons/src/ao_bookmarklist.c:315
+#: ../addons/src/ao_bookmarklist.c:331
 msgid "_Remove Bookmark"
 msgstr "_Lesezeichen entfernen"
 
 #. Translators: Number is meant at this point.
-#: ../addons/src/ao_bookmarklist.c:342
+#: ../addons/src/ao_bookmarklist.c:358
 msgid "No."
 msgstr "Nr."
 
-#: ../addons/src/ao_bookmarklist.c:350 ../devhelp/src/dhp-object.c:494
+#: ../addons/src/ao_bookmarklist.c:366 ../devhelp/src/dhp-object.c:494
 #: ../devhelp/devhelp/dh-window.c:1142
 msgid "Contents"
 msgstr "Inhalte"
 
-#: ../addons/src/ao_bookmarklist.c:383 ../treebrowser/src/treebrowser.c:666
+#: ../addons/src/ao_bookmarklist.c:399 ../treebrowser/src/treebrowser.c:666
 #: ../webhelper/src/gwh-plugin.c:328
 msgid "Bookmarks"
 msgstr "Lesezeichen"
 
 #. complete update
-#: ../addons/src/ao_tasks.c:373 ../geanyvc/src/geanyvc.c:2679
+#: ../addons/src/ao_tasks.c:373 ../geanyvc/src/geanyvc.c:2730
 msgid "_Update"
 msgstr "_Aktualisieren"
 
@@ -174,10 +174,10 @@ msgstr "Kopiert den Pfad des aktuellen Dokumentes in die Zwischenablage."
 #: ../addons/src/addons.c:364 ../autoclose/src/autoclose.c:920
 #: ../codenav/src/codenavigation.c:281 ../latex/src/latex.c:208
 #: ../latex/src/latex.c:293 ../geanyprj/src/geanyprj.c:176
-#: ../geanyvc/src/geanyvc.c:2079 ../geniuspaste/src/geniuspaste.c:336
+#: ../geanyvc/src/geanyvc.c:2130 ../geniuspaste/src/geniuspaste.c:336
 #: ../lineoperations/src/lo_prefs.c:58 ../sendmail/src/sendmail.c:128
 #: ../sendmail/src/sendmail.c:293 ../spellcheck/src/scplugin.c:124
-#: ../treebrowser/src/treebrowser.c:2102
+#: ../treebrowser/src/treebrowser.c:2106
 #: ../updatechecker/src/updatechecker.c:262
 msgid "Plugin configuration directory could not be created."
 msgstr ""
@@ -783,7 +783,7 @@ msgstr "~\"Zieldatei laden.\\n\""
 msgid "Error loading file"
 msgstr "Fehler beim Laden der Datei"
 
-#. setting asyncronous mode
+#. setting asynchronous mode
 #. setting null-stop array printing
 #. enable pretty printing
 #: ../debugger/src/dbm_gdb.c:789 ../debugger/src/dbm_gdb.c:792
@@ -1190,7 +1190,7 @@ msgid "A developers' help browser for GNOME"
 msgstr "Ein Hilfebrowser für Entwickler unter GNOME"
 
 #. Create the current file Submenu
-#: ../devhelp/devhelp/dh-window.c:759 ../geanyvc/src/geanyvc.c:2660
+#: ../devhelp/devhelp/dh-window.c:759 ../geanyvc/src/geanyvc.c:2711
 msgid "_File"
 msgstr "_Datei"
 
@@ -1224,11 +1224,11 @@ msgstr "Neuer Rei_ter"
 msgid "_Print…"
 msgstr "_Drucken…"
 
-#: ../devhelp/devhelp/dh-window.c:782 ../devhelp/devhelp/eggfindbar.c:342
+#: ../devhelp/devhelp/dh-window.c:782
 msgid "Find Next"
 msgstr "Nächstes suchen"
 
-#: ../devhelp/devhelp/dh-window.c:784 ../devhelp/devhelp/eggfindbar.c:329
+#: ../devhelp/devhelp/dh-window.c:784
 msgid "Find Previous"
 msgstr "Vorheriges suchen"
 
@@ -1420,7 +1420,7 @@ msgstr ""
 "auf. \n"
 "Dieses Plugin hat im Moment keinen Maintainer. Möchtest Du vielleicht helfen?"
 
-#: ../geanydoc/src/geanydoc.c:159 ../geanyvc/src/geanyvc.c:442
+#: ../geanydoc/src/geanydoc.c:159 ../geanyvc/src/geanyvc.c:448
 msgid "Could not parse the output of command"
 msgstr "Konnte die Ausgabe des Befehls nicht verarbeiten."
 
@@ -3144,7 +3144,7 @@ msgstr ""
 "Fehler in Modul »%s« in Funktion %s():\n"
 "Nicht genügend Argumente für den Befehl »%s«.\n"
 
-#: ../geanylua/glspi_sci.c:637 ../geanylua/glspi_app.c:406
+#: ../geanylua/glspi_sci.c:729 ../geanylua/glspi_app.c:406
 #, c-format
 msgid ""
 "Error in module \"%s\" at function %s():\n"
@@ -3153,7 +3153,7 @@ msgstr ""
 "Fehler in Modul »%s« in Funktion %s():\n"
 "Unbekannter Befehl »%s« für das Argument #1.\n"
 
-#: ../geanylua/glspi_sci.c:781
+#: ../geanylua/glspi_sci.c:924
 #, c-format
 msgid ""
 "Error in module \"%s\" at function %s():\n"
@@ -3164,7 +3164,7 @@ msgstr ""
 "Falsche Tabelle in Argument #%d:\n"
 "Unbekannter Parameter »%s« für Element #%d\n"
 
-#: ../geanylua/glspi_sci.c:785
+#: ../geanylua/glspi_sci.c:928
 msgid "<too large to display>"
 msgstr "<zu groß zum Anzeigen>"
 
@@ -3957,7 +3957,7 @@ msgid "New _Below"
 msgstr "Neu d_arunter"
 
 #: ../geanymacro/src/geanymacro.c:1824 ../geanymacro/src/geanymacro.c:2120
-#: ../treebrowser/src/treebrowser.c:1338 ../treebrowser/src/treebrowser.c:1340
+#: ../treebrowser/src/treebrowser.c:1342 ../treebrowser/src/treebrowser.c:1344
 msgid "_Delete"
 msgstr "_Löschen"
 
@@ -4378,8 +4378,8 @@ msgstr ""
 msgid "a key with fingerprint"
 msgstr "ein Schlüssel mit Fingerabdruck"
 
-#: ../geanypg/src/verify_aux.c:66 ../spellcheck/src/gui.c:610
-#: ../spellcheck/src/gui.c:621
+#: ../geanypg/src/verify_aux.c:66 ../spellcheck/src/gui.c:607
+#: ../spellcheck/src/gui.c:618
 msgid "unknown"
 msgstr "Unbekannt"
 
@@ -4692,49 +4692,49 @@ msgstr ""
 "Schnittstelle für verschiedene Softwareversionskontrollsysteme.\n"
 "Dieses Plugin hat im Moment keinen Maintainer. Möchtest Du vielleicht helfen?"
 
-#: ../geanyvc/src/geanyvc.c:501
+#: ../geanyvc/src/geanyvc.c:507
 #, c-format
 msgid "geanyvc: s_spawn_sync error: %s"
 msgstr "geanyvc: s_spawn_sync error: %s"
 
-#: ../geanyvc/src/geanyvc.c:587
+#: ../geanyvc/src/geanyvc.c:593
 #, c-format
 msgid "File %s: action %s executed via %s."
 msgstr "Datei %s: Aktion %s wurde über %s ausgeführt."
 
-#: ../geanyvc/src/geanyvc.c:646 ../geanyvc/src/geanyvc.c:657
-#, c-format
-msgid "geanyvc: vcdiff_file_activated: Unable to rename '%s' to '%s'"
+#: ../geanyvc/src/geanyvc.c:633 ../geanyvc/src/geanyvc.c:643
+#, fuzzy, c-format
+msgid "geanyvc: diff_external: Unable to rename '%s' to '%s'"
 msgstr "geanyvc: vcdiff_file_activated: Kann »%s« nicht in »%s« umbenennen."
 
-#: ../geanyvc/src/geanyvc.c:683 ../geanyvc/src/geanyvc.c:733
+#: ../geanyvc/src/geanyvc.c:698 ../geanyvc/src/geanyvc.c:784
 msgid "No changes were made."
 msgstr "Es wurden keine Änderungen vorgenommen."
 
-#: ../geanyvc/src/geanyvc.c:760
+#: ../geanyvc/src/geanyvc.c:811
 msgid "No history available"
 msgstr "Keine Historie verfügbar"
 
-#: ../geanyvc/src/geanyvc.c:953 ../geanyvc/src/geanyvc.c:961
+#: ../geanyvc/src/geanyvc.c:1004 ../geanyvc/src/geanyvc.c:1012
 #, c-format
 msgid "Do you really want to revert: %s?"
 msgstr "Möchten Sie wirklich »%s« zurücksetzen?"
 
-#: ../geanyvc/src/geanyvc.c:969
+#: ../geanyvc/src/geanyvc.c:1020
 #, c-format
 msgid "Do you really want to add: %s?"
 msgstr "Möchten Sie wirklich »%s« hinzufügen?"
 
-#: ../geanyvc/src/geanyvc.c:976
+#: ../geanyvc/src/geanyvc.c:1027
 #, c-format
 msgid "Do you really want to remove: %s?"
 msgstr "Möchten Sie wirklich »%s« entfernen?"
 
-#: ../geanyvc/src/geanyvc.c:999
+#: ../geanyvc/src/geanyvc.c:1050
 msgid "Do you really want to update?"
 msgstr "Möchten Sie wirklich »%s« aktualisieren?"
 
-#: ../geanyvc/src/geanyvc.c:1126
+#: ../geanyvc/src/geanyvc.c:1177
 msgid ""
 "The resulting differences cannot be displayed because the changes are too "
 "big to display here and would slow down the UI significantly.\n"
@@ -4747,48 +4747,48 @@ msgstr ""
 "Um sich dennoch die Änderungen anzeigen zu lassen, benutzen Sie einfach die "
 "Diff-Funktion aus dem GeanyVC-Unterpunktes innerhalb des Werkzeuge-Menüs."
 
-#: ../geanyvc/src/geanyvc.c:1280
+#: ../geanyvc/src/geanyvc.c:1331
 msgid "Commit Y/N"
 msgstr "Eintragen"
 
-#: ../geanyvc/src/geanyvc.c:1290
+#: ../geanyvc/src/geanyvc.c:1341
 msgid "Status"
 msgstr "Status"
 
-#: ../geanyvc/src/geanyvc.c:1297
+#: ../geanyvc/src/geanyvc.c:1348
 msgid "Path"
 msgstr "Pfad"
 
-#: ../geanyvc/src/geanyvc.c:1414
+#: ../geanyvc/src/geanyvc.c:1465
 msgid "Choose a previous commit message"
 msgstr "Eine vorhergegangene Commit-Beschreibung auswählen"
 
-#: ../geanyvc/src/geanyvc.c:1476
+#: ../geanyvc/src/geanyvc.c:1527
 #, c-format
 msgid "Line: %d Column: %d"
 msgstr "Zeile: %d Spalte: %d"
 
-#: ../geanyvc/src/geanyvc.c:1523
+#: ../geanyvc/src/geanyvc.c:1574
 msgid "Commit"
 msgstr "Eintragen (commit)"
 
-#: ../geanyvc/src/geanyvc.c:1564
+#: ../geanyvc/src/geanyvc.c:1615
 msgid "_De-/select all files"
 msgstr "Alle _Dateien aus- bzw. abwählen"
 
-#: ../geanyvc/src/geanyvc.c:1608
+#: ../geanyvc/src/geanyvc.c:1659
 msgid "<b>Commit message:</b>"
 msgstr "<b>Commitnachricht:</b>"
 
-#: ../geanyvc/src/geanyvc.c:1632
+#: ../geanyvc/src/geanyvc.c:1683
 msgid "C_ommit"
 msgstr "Ein_tragen"
 
-#: ../geanyvc/src/geanyvc.c:1740
+#: ../geanyvc/src/geanyvc.c:1791
 msgid "Nothing to commit."
 msgstr "Nichts zum Eintragen."
 
-#: ../geanyvc/src/geanyvc.c:1788
+#: ../geanyvc/src/geanyvc.c:1839
 #, c-format
 msgid ""
 "Error initializing GeanyVC spell checking: %s. Check your configuration."
@@ -4796,26 +4796,26 @@ msgstr ""
 "Fehler beim Initialisieren der Rechtschreibprüfung: %s. Überprüfen Sie Ihre "
 "Konfiguration!"
 
-#: ../geanyvc/src/geanyvc.c:1823
+#: ../geanyvc/src/geanyvc.c:1874
 #, c-format
 msgid "Commit failed (status: %d, error: %s)."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1824
+#: ../geanyvc/src/geanyvc.c:1875
 #, fuzzy
 msgid "Commit failed; see status in the Message window."
 msgstr "Verfügbare Aufgaben im Meldungsfenster anzeigen"
 
-#: ../geanyvc/src/geanyvc.c:1829
+#: ../geanyvc/src/geanyvc.c:1880
 #, fuzzy
 msgid "Changes committed."
 msgstr "Nichts zum Eintragen."
 
-#: ../geanyvc/src/geanyvc.c:2151
+#: ../geanyvc/src/geanyvc.c:2202
 msgid "Set Changed-flag for document tabs created by the plugin"
 msgstr "Vom Plugin erstellte Dokumente als geändert markieren"
 
-#: ../geanyvc/src/geanyvc.c:2154
+#: ../geanyvc/src/geanyvc.c:2205
 msgid ""
 "If this option is activated, every new by the VC-plugin created document tab "
 "will be marked as changed. Even this option is useful in some cases, it "
@@ -4826,45 +4826,45 @@ msgstr ""
 "der Speichern-Dialog geöffnet wird. Auch wenn diese Option von Zeit zu Zeit "
 "sehr nützlich sein kann, kann sie ab und an einfach nur stören."
 
-#: ../geanyvc/src/geanyvc.c:2162
+#: ../geanyvc/src/geanyvc.c:2213
 msgid "Confirm adding new files to a VCS"
 msgstr "Hinzufügen von Dateien zur Versionsverwaltung immer bestätigen"
 
-#: ../geanyvc/src/geanyvc.c:2165
+#: ../geanyvc/src/geanyvc.c:2216
 msgid "Shows a confirmation dialog on adding a new (created) file to VCS."
 msgstr ""
 "Zeigt einen Bestätigungsdialog beim Hinzufügen von Dateien zu einem "
 "Versionsverwaltungssystem."
 
-#: ../geanyvc/src/geanyvc.c:2171
+#: ../geanyvc/src/geanyvc.c:2222
 msgid "Maximize commit dialog"
 msgstr "Commit-Dialog maximieren"
 
-#: ../geanyvc/src/geanyvc.c:2172
+#: ../geanyvc/src/geanyvc.c:2223
 msgid "Show commit dialog maximize."
 msgstr "Commit-Dialog beim Anzeigen maximieren"
 
-#: ../geanyvc/src/geanyvc.c:2178
+#: ../geanyvc/src/geanyvc.c:2229
 msgid "Use external diff viewer"
 msgstr "Externes Diff-Programm"
 
-#: ../geanyvc/src/geanyvc.c:2180
+#: ../geanyvc/src/geanyvc.c:2231
 msgid "Use external diff viewer for file diff."
 msgstr "Externes Diff-Programm zum Vergleich von zwei Dateien"
 
-#: ../geanyvc/src/geanyvc.c:2186
+#: ../geanyvc/src/geanyvc.c:2237
 msgid "Show VC entries at editor menu"
 msgstr "Funktionen über das Editormenü verfügbar machen"
 
-#: ../geanyvc/src/geanyvc.c:2188
+#: ../geanyvc/src/geanyvc.c:2239
 msgid "Show entries for VC functions inside editor menu"
 msgstr "Einträge für das Plugin im Editormenü anzeigen"
 
-#: ../geanyvc/src/geanyvc.c:2193
+#: ../geanyvc/src/geanyvc.c:2244
 msgid "Attach menu to menubar"
 msgstr "Menü an Menüleiste anhängen"
 
-#: ../geanyvc/src/geanyvc.c:2195
+#: ../geanyvc/src/geanyvc.c:2246
 msgid ""
 "Whether menu for this plugin are getting placed either inside tools menu or "
 "directly inside Geany's menubar. Will take in account after next start of "
@@ -4874,217 +4874,217 @@ msgstr ""
 "Menüleiste von Geany angezeigt werden. Dies wird erst nach einen Neustart "
 "von GeanyVC funktionieren"
 
-#: ../geanyvc/src/geanyvc.c:2203
+#: ../geanyvc/src/geanyvc.c:2254
 msgid "Enable CVS"
 msgstr "CVS aktivieren"
 
-#: ../geanyvc/src/geanyvc.c:2208
+#: ../geanyvc/src/geanyvc.c:2259
 msgid "Enable GIT"
 msgstr "GIT aktivieren"
 
-#: ../geanyvc/src/geanyvc.c:2213
+#: ../geanyvc/src/geanyvc.c:2264
 msgid "Enable Fossil"
 msgstr "Fossil aktivieren"
 
-#: ../geanyvc/src/geanyvc.c:2218
+#: ../geanyvc/src/geanyvc.c:2269
 msgid "Enable SVN"
 msgstr "SVN aktivieren"
 
-#: ../geanyvc/src/geanyvc.c:2223
+#: ../geanyvc/src/geanyvc.c:2274
 msgid "Enable SVK"
 msgstr "SVK aktivieren"
 
-#: ../geanyvc/src/geanyvc.c:2228
+#: ../geanyvc/src/geanyvc.c:2279
 msgid "Enable Bazaar"
 msgstr "Bazaar aktivieren"
 
-#: ../geanyvc/src/geanyvc.c:2233
+#: ../geanyvc/src/geanyvc.c:2284
 msgid "Enable Mercurial"
 msgstr "Mercurial aktivieren"
 
-#: ../geanyvc/src/geanyvc.c:2239
+#: ../geanyvc/src/geanyvc.c:2290
 msgid "Spellcheck language"
 msgstr "Sprache:"
 
 #. Diff of current file
 #. Diff of the current dir
 #. Complete diff of base directory
-#: ../geanyvc/src/geanyvc.c:2368 ../geanyvc/src/geanyvc.c:2463
-#: ../geanyvc/src/geanyvc.c:2503
+#: ../geanyvc/src/geanyvc.c:2419 ../geanyvc/src/geanyvc.c:2514
+#: ../geanyvc/src/geanyvc.c:2554
 msgid "_Diff"
 msgstr "_Unterschiede anzeigen (diff)"
 
-#: ../geanyvc/src/geanyvc.c:2371
+#: ../geanyvc/src/geanyvc.c:2422
 msgid "Make a diff from the current active file"
 msgstr "Erstellt ein Diff für die aktuelle Datei."
 
 #. Revert current file
 #. Revert current dir
 #. Revert everything
-#: ../geanyvc/src/geanyvc.c:2376 ../geanyvc/src/geanyvc.c:2472
-#: ../geanyvc/src/geanyvc.c:2511
+#: ../geanyvc/src/geanyvc.c:2427 ../geanyvc/src/geanyvc.c:2523
+#: ../geanyvc/src/geanyvc.c:2562
 msgid "_Revert"
 msgstr "_Zurücksetzen (revert)"
 
-#: ../geanyvc/src/geanyvc.c:2379
+#: ../geanyvc/src/geanyvc.c:2430
 msgid "Restore pristine working copy file (undo local edits)."
 msgstr ""
 "Stellt den ursprünglichen Zustand der Datei wieder her (verwirft lokale "
 "Änderungen)."
 
 #. Blame for current file
-#: ../geanyvc/src/geanyvc.c:2388
+#: ../geanyvc/src/geanyvc.c:2439
 msgid "_Blame"
 msgstr "Ä_nderungsverfolgung (blame)"
 
-#: ../geanyvc/src/geanyvc.c:2391
+#: ../geanyvc/src/geanyvc.c:2442
 msgid "Shows the changes made at one file per revision and author."
 msgstr "Zeigt alle Änderungen einer Datei nach Autor und Revision."
 
 #. History/log of current file
 #. History/log of the current dir
 #. Complete History/Log of base directory
-#: ../geanyvc/src/geanyvc.c:2398 ../geanyvc/src/geanyvc.c:2482
-#: ../geanyvc/src/geanyvc.c:2523
+#: ../geanyvc/src/geanyvc.c:2449 ../geanyvc/src/geanyvc.c:2533
+#: ../geanyvc/src/geanyvc.c:2574
 msgid "_History (log)"
 msgstr "_Versionsgeschichte (log)"
 
-#: ../geanyvc/src/geanyvc.c:2401
+#: ../geanyvc/src/geanyvc.c:2452
 msgid "Shows the log of the current file"
 msgstr "Zeigt die Versionsgeschichte der aktuellen Datei an."
 
 #. base version of the current file
-#: ../geanyvc/src/geanyvc.c:2406
+#: ../geanyvc/src/geanyvc.c:2457
 msgid "_Original"
 msgstr "_Original"
 
-#: ../geanyvc/src/geanyvc.c:2409
+#: ../geanyvc/src/geanyvc.c:2460
 msgid "Shows the original of the current file"
 msgstr "Zeigt die unveränderte Datei an"
 
 #. add current file
-#: ../geanyvc/src/geanyvc.c:2417
+#: ../geanyvc/src/geanyvc.c:2468
 msgid "_Add to Version Control"
 msgstr "Zur _Versionskontrolle hinzufügen"
 
-#: ../geanyvc/src/geanyvc.c:2419
+#: ../geanyvc/src/geanyvc.c:2470
 msgid "Add file to repository."
 msgstr "Fügt eine Datei zur Versionskontrolle hin_zu."
 
 #. remove current file
-#: ../geanyvc/src/geanyvc.c:2425
+#: ../geanyvc/src/geanyvc.c:2476
 msgid "_Remove from Version Control"
 msgstr "Aus Versionskontrolle _entfernen"
 
-#: ../geanyvc/src/geanyvc.c:2427
+#: ../geanyvc/src/geanyvc.c:2478
 msgid "Remove file from repository."
 msgstr "Entfernt eine Datei aus Versionskontrolle und Repository."
 
-#: ../geanyvc/src/geanyvc.c:2460
+#: ../geanyvc/src/geanyvc.c:2511
 msgid "_Directory"
 msgstr "_Verzeichnis"
 
-#: ../geanyvc/src/geanyvc.c:2466
+#: ../geanyvc/src/geanyvc.c:2517
 msgid "Make a diff from the directory of the current active file"
 msgstr "Erstellt ein Diff für das Verzeichnis der aktuellen Datei."
 
-#: ../geanyvc/src/geanyvc.c:2475
+#: ../geanyvc/src/geanyvc.c:2526
 msgid "Restore original files in the current folder (undo local edits)."
 msgstr ""
 "Stellt den ursprünglichen Zustand der Datei wieder her (verwirft lokale "
 "Änderungen)."
 
-#: ../geanyvc/src/geanyvc.c:2485
+#: ../geanyvc/src/geanyvc.c:2536
 msgid "Shows the log of the current directory"
 msgstr "Zeigt die Versionsgeschichte für das aktuelle Verzeichnis."
 
-#: ../geanyvc/src/geanyvc.c:2499
+#: ../geanyvc/src/geanyvc.c:2550
 msgid "_Base Directory"
 msgstr "_Basisordner"
 
-#: ../geanyvc/src/geanyvc.c:2505
+#: ../geanyvc/src/geanyvc.c:2556
 msgid "Make a diff from the top VC directory"
 msgstr "Erstellt ein Diff für die gesamte Arbeitskopie"
 
-#: ../geanyvc/src/geanyvc.c:2513
+#: ../geanyvc/src/geanyvc.c:2564
 msgid "Revert any local edits."
 msgstr "Alle lokalen Änderungen zurücksetzen"
 
-#: ../geanyvc/src/geanyvc.c:2526
+#: ../geanyvc/src/geanyvc.c:2577
 msgid "Shows the log of the top VC directory"
 msgstr "Zeigt die Versionsgeschichte für die gesamte Arbeitskopie"
 
-#: ../geanyvc/src/geanyvc.c:2543
+#: ../geanyvc/src/geanyvc.c:2594
 msgid "_VC file Actions"
 msgstr "_VC Dateioperationen"
 
-#: ../geanyvc/src/geanyvc.c:2552
+#: ../geanyvc/src/geanyvc.c:2603
 msgid "VC _Commit..."
 msgstr "VC ein_tragen (commit)..."
 
-#: ../geanyvc/src/geanyvc.c:2596
+#: ../geanyvc/src/geanyvc.c:2647
 msgid "Show diff of file"
 msgstr "Diff von der aktuellen Datei"
 
-#: ../geanyvc/src/geanyvc.c:2598
+#: ../geanyvc/src/geanyvc.c:2649
 msgid "Show diff of directory"
 msgstr "Zeigt Veränderung des Verzeichnisses an (diff)"
 
-#: ../geanyvc/src/geanyvc.c:2600
+#: ../geanyvc/src/geanyvc.c:2651
 msgid "Show diff of basedir"
 msgstr "Diff vom Grundverzeichnis"
 
-#: ../geanyvc/src/geanyvc.c:2603
+#: ../geanyvc/src/geanyvc.c:2654
 msgid "Commit changes"
 msgstr "Änderungen eintragen"
 
-#: ../geanyvc/src/geanyvc.c:2605
+#: ../geanyvc/src/geanyvc.c:2656
 msgid "Show status"
 msgstr "Status der Arbeitskopie anzeigen"
 
-#: ../geanyvc/src/geanyvc.c:2607
+#: ../geanyvc/src/geanyvc.c:2658
 msgid "Revert single file"
 msgstr "Datei zurücksetzen (revert)"
 
-#: ../geanyvc/src/geanyvc.c:2609
+#: ../geanyvc/src/geanyvc.c:2660
 msgid "Revert directory"
 msgstr "Verzeichnis zurücksetzen (revert)"
 
-#: ../geanyvc/src/geanyvc.c:2611
+#: ../geanyvc/src/geanyvc.c:2662
 msgid "Revert base directory"
 msgstr "Alle Änderungen verwerfen"
 
-#: ../geanyvc/src/geanyvc.c:2613
+#: ../geanyvc/src/geanyvc.c:2664
 msgid "Update file"
 msgstr "Datei aktualisieren"
 
-#: ../geanyvc/src/geanyvc.c:2643
+#: ../geanyvc/src/geanyvc.c:2694
 msgid "_VC"
 msgstr "_VC"
 
-#: ../geanyvc/src/geanyvc.c:2650
+#: ../geanyvc/src/geanyvc.c:2701
 msgid "_Version Control"
 msgstr "_Versionskontrolle"
 
 #. Status of basedir
-#: ../geanyvc/src/geanyvc.c:2672
+#: ../geanyvc/src/geanyvc.c:2723
 msgid "_Status"
 msgstr "_Status"
 
-#: ../geanyvc/src/geanyvc.c:2674
+#: ../geanyvc/src/geanyvc.c:2725
 msgid "Show status."
 msgstr "Zeigt den Status der Arbeitskopie."
 
-#: ../geanyvc/src/geanyvc.c:2681
+#: ../geanyvc/src/geanyvc.c:2732
 msgid "Update from remote repository."
 msgstr "Aus dem Repositorium aktualisieren"
 
 #. Commit all changes
-#: ../geanyvc/src/geanyvc.c:2686
+#: ../geanyvc/src/geanyvc.c:2737
 msgid "_Commit..."
 msgstr "Ein_tragen (commit)..."
 
-#: ../geanyvc/src/geanyvc.c:2688
+#: ../geanyvc/src/geanyvc.c:2739
 msgid "Commit changes."
 msgstr "Änderungen eintragen."
 
@@ -5186,8 +5186,8 @@ msgid ""
 "Your paste can be found here:\n"
 "<a href=\"%s\" title=\"Click to open the paste in your browser\">%s</a>"
 msgstr ""
-"Der gesendete Inhalt kann jetzt hier betrachtet werden: <a href=\"%s\" title="
-"\"Klicken, um im Browser betrachtet zu werden\">%s</a>"
+"Der gesendete Inhalt kann jetzt hier betrachtet werden: <a href=\"%s\" "
+"title=\"Klicken, um im Browser betrachtet zu werden\">%s</a>"
 
 #: ../geniuspaste/src/geniuspaste.c:881
 msgid "There are no opened documents. Open one and retry.\n"
@@ -5214,37 +5214,6 @@ msgstr "Code-Ablage in einem neuen Reiter im Browser zeigen"
 #: ../geniuspaste/src/geniuspaste.c:959
 msgid "_Paste it!"
 msgstr "Zu _Pastebin senden"
-
-#: ../git-changebar/data/prefs.ui.h:1
-msgid "_Monitor repository for changes"
-msgstr "Repository auf Änderungen _überwachen"
-
-#: ../git-changebar/data/prefs.ui.h:2
-msgid ""
-"Whether to automatically update the diff in order to maintain it up to date "
-"when the underlying Git repository changes.  This should generally be "
-"enabled for optimal user experience."
-msgstr ""
-"Legt fest, ob die Diffs automatische aktualisiert werden und sie so immer "
-"auf dem aktuellen Stand gehalten werden sollen. Insbesondere dann, wenn das "
-"zu Grunde liegende git-Repository geändert wurde. In den meisten Fällen "
-"sollte diese Option aktiviert sein."
-
-#: ../git-changebar/data/prefs.ui.h:3
-msgid "_Added lines:"
-msgstr "_Hinzugefügte Zeilen:"
-
-#: ../git-changebar/data/prefs.ui.h:4
-msgid "_Changed lines:"
-msgstr "_Geänderte Zeilen:"
-
-#: ../git-changebar/data/prefs.ui.h:5
-msgid "_Removed lines:"
-msgstr "_Entfernte Zeilen:"
-
-#: ../git-changebar/data/prefs.ui.h:6
-msgid "Colors"
-msgstr "Farben:"
 
 #: ../git-changebar/src/gcb-plugin.c:62
 msgid "Git Change Bar"
@@ -5437,8 +5406,8 @@ msgstr ""
 #: ../lipsum/src/lipsum.c:184 ../sendmail/src/sendmail.c:396
 #, c-format
 msgid ""
-"Your configuration directory has been successfully moved from \"%s\" to \"%s"
-"\"."
+"Your configuration directory has been successfully moved from \"%s\" to "
+"\"%s\"."
 msgstr ""
 "Das Konfigurationsverzeichnis wurde erfolgreich von »%s« nach »%s« "
 "verschoben."
@@ -5606,7 +5575,7 @@ msgstr "Konnte Standardkonfiguration nicht schreiben: %s"
 msgid "Unable to read value for '%s' key: %s"
 msgstr "Konnte Wert für »%s«, Schlüssel »%s« nicht lesen"
 
-#: ../multiterm/src/tab-label.vala:62 ../treebrowser/src/treebrowser.c:2132
+#: ../multiterm/src/tab-label.vala:62 ../treebrowser/src/treebrowser.c:2137
 msgid "Terminal"
 msgstr "Terminal"
 
@@ -5644,133 +5613,6 @@ msgstr "Zeile <b>%d</b>, Spalte <b>%d</b>, Position <b>%d</b>"
 msgid "Show Overview"
 msgstr "Überblick anzeigen"
 
-#: ../overview/data/prefs.ui.h:1
-msgid ""
-"The amount to zoom the overview sidebar. This should probably negative if "
-"you want the sidebar zoomed out."
-msgstr ""
-"Legt fest, wie stark die Seitenleiste von »Overview« vergrößert/verkleinert "
-"werden soll. Negative Werte sorgen für eine größere Übersicht."
-
-#: ../overview/data/prefs.ui.h:2
-msgid "Zoom Level:"
-msgstr "Zoom-Stufe:"
-
-#: ../overview/data/prefs.ui.h:3
-msgid "The width of the overview sidebar."
-msgstr "Die Breite der Überblick-Fensters"
-
-#: ../overview/data/prefs.ui.h:4
-msgid "Width:"
-msgstr "Breite:"
-
-#: ../overview/data/prefs.ui.h:5
-msgid ""
-"The number of lines to scroll at a time when scrolling the overview sidebar."
-msgstr ""
-"Legt die Anzahl der Zeilen fest, die beim Scrollen in der Seitenleiste "
-"zurückgelegt werden sollen."
-
-#: ../overview/data/prefs.ui.h:6
-msgid "Scroll Lines:"
-msgstr "Scrollgeschwindigkeit:"
-
-#: ../overview/data/prefs.ui.h:7
-msgid "Position on left"
-msgstr "Links positionieren"
-
-#: ../overview/data/prefs.ui.h:8
-msgid ""
-"Position the overview bar on the left rather than the right (requires Geany "
-"1.25 or greater)."
-msgstr ""
-"Diese Option positioniert die Seitenleiste des Plugins an der linken Seite "
-"von Geany. Dies funktioniert nur in Geany-Versionen >= 1.25."
-
-#: ../overview/data/prefs.ui.h:9
-msgid "Hide tooltip"
-msgstr "Tooltips verstecken."
-
-#: ../overview/data/prefs.ui.h:10
-msgid ""
-"Hide the tooltip that is displayed when mousing over the overview that shows "
-"line, column and position information."
-msgstr ""
-"Versteckt die zusätzlichen Informationen, die beim mit der Maus "
-"überstreichen angezeigt werden (Zeile, Spalte etc.)"
-
-#: ../overview/data/prefs.ui.h:11
-msgid "Hide editor scrollbar"
-msgstr "Normale Bildlaufleiste verstecken"
-
-#: ../overview/data/prefs.ui.h:12
-msgid ""
-"Whether to hide Geany's regular editor scrollbar while the overview bar is "
-"visible."
-msgstr ""
-"Mit dieser Option kann Geanys normale Bildlaufleiste versteckt werden, so "
-"dass, wenn das Plugin aktiv ist, allein über die Vorschau im Dokument "
-"navigiert werden kann."
-
-#: ../overview/data/prefs.ui.h:13
-msgid "Disable overlay"
-msgstr "Bildausschnittsmarkierung deaktivieren"
-
-#: ../overview/data/prefs.ui.h:14
-msgid ""
-"Turn off drawing overlay, which shows the region of the main editor view "
-"that is currently in view, ontop of the overview bar."
-msgstr ""
-"Diese Option legt fest, ob der aktuelle Bildschirmausschnitt aus dem "
-"normalen Editorfenster in der Vorschau angezeigt werden soll."
-
-#: ../overview/data/prefs.ui.h:15 ../scope/data/scope.glade.h:130
-#: ../scope/data/scope_gtk3.glade.h:130
-msgid "Options"
-msgstr "Optionen"
-
-#: ../overview/data/prefs.ui.h:16
-msgid ""
-"The color and opacity of the overlay drawn ontop of the overlay sidebar."
-msgstr ""
-"Konfiguriert die Farbe und Sättigung der Bildausschnittsmarkierung in der "
-"Seitenleiste des Plugins."
-
-#: ../overview/data/prefs.ui.h:17
-msgid "Color:"
-msgstr "Farbe:"
-
-#: ../overview/data/prefs.ui.h:18
-msgid ""
-"The color and opacity of the border drawn around the revealed area in the "
-"overview sidebar. Set to the same as Overlay Color to disable."
-msgstr ""
-"Konfiguriert die Farbe und Sättigung rund um das aktive Gebiet des "
-"Dokumentes. Zum Deaktivieren einfach auf die gleiche Farbe wie die der "
-"Bildausschnittsmarkierung stellen"
-
-#: ../overview/data/prefs.ui.h:19
-msgid "Outline Color:"
-msgstr "Farbe Außenlinie"
-
-#: ../overview/data/prefs.ui.h:20
-msgid "Draw over visible area"
-msgstr "Über sichtbares Gebiet zeichnen"
-
-#: ../overview/data/prefs.ui.h:21
-msgid ""
-"When checked it will draw the overlay ontop of the area that is visible in "
-"the main editor view, when unchecked, it will do the opposite and draw the "
-"overlay everywhere but the visible area, \"revealing\" the visible part."
-msgstr ""
-"Wenn diese Option aktiv ist, wird die Bildausschnittsmarkierung nur über den "
-"aktiven Bereich gelegt. Ist die Option deaktiviert, wird alles was nicht "
-"sichtbar ist mit einer Markierung versehen. "
-
-#: ../overview/data/prefs.ui.h:22
-msgid "Overlay"
-msgstr "Überlagerung"
-
 #: ../pairtaghighlighter/src/pair_tag_highlighter.c:43
 msgid "Pair Tag Highlighter"
 msgstr "PairTagHighlighter"
@@ -5794,148 +5636,6 @@ msgstr "Zum korrospondierenden Tag springen"
 #: ../pairtaghighlighter/src/pair_tag_highlighter.c:504
 msgid "Select To Matching Tag"
 msgstr "Bis zur korrospondierenden _Tag auswählen"
-
-#: ../pohelper/data/menus.ui.h:1
-msgid "_Translation Helper"
-msgstr "_Übersetzungshelfer"
-
-#: ../pohelper/data/menus.ui.h:2
-msgid "_Previous String"
-msgstr "_Vorheriger String"
-
-#: ../pohelper/data/menus.ui.h:3 ../pohelper/src/gph-plugin.c:1590
-msgid "Go to previous string"
-msgstr "Zum vorherigen String gehen"
-
-#: ../pohelper/data/menus.ui.h:4
-msgid "_Next String"
-msgstr "_Nächster String"
-
-#: ../pohelper/data/menus.ui.h:5 ../pohelper/src/gph-plugin.c:1593
-msgid "Go to next string"
-msgstr "Zur nächsten String gehen"
-
-#: ../pohelper/data/menus.ui.h:6
-msgid "Pre_vious Untranslated"
-msgstr "_Vorherige nicht übersetze Zeichenkette"
-
-#: ../pohelper/data/menus.ui.h:7 ../pohelper/src/gph-plugin.c:1596
-msgid "Go to previous untranslated string"
-msgstr "Geht zu der vorherigen, noch nicht übersetzten Zeichenkette."
-
-#: ../pohelper/data/menus.ui.h:8
-msgid "Next _Untranslated"
-msgstr "Nächste nicht _übersetzte Zeichenkette"
-
-#: ../pohelper/data/menus.ui.h:9 ../pohelper/src/gph-plugin.c:1599
-msgid "Go to next untranslated string"
-msgstr "Geht zu der nächsten, noch nicht übersetzten Zeichenkette."
-
-#: ../pohelper/data/menus.ui.h:10
-msgid "Previous Fu_zzy"
-msgstr "_Vorhergehende unklare Übersetzung"
-
-#: ../pohelper/data/menus.ui.h:11 ../pohelper/src/gph-plugin.c:1602
-msgid "Go to previous fuzzily translated string"
-msgstr "Springt zur vorhergehenden, unklaren (fuzzy) Übersetzung"
-
-#: ../pohelper/data/menus.ui.h:12
-msgid "Next _Fuzzy"
-msgstr "Nächste _unklare Übersetzung"
-
-#: ../pohelper/data/menus.ui.h:13 ../pohelper/src/gph-plugin.c:1605
-msgid "Go to next fuzzily translated string"
-msgstr "Gehe zur nächsten unklaren Übersetzung"
-
-#: ../pohelper/data/menus.ui.h:14
-msgid "Previous Untranslated or Fuzz_y"
-msgstr "Vorherige u_nübersetzt oder -klar."
-
-#: ../pohelper/data/menus.ui.h:15 ../pohelper/src/gph-plugin.c:1608
-msgid "Go to previous untranslated or fuzzy string"
-msgstr "Gehe zum vorherigen unklaren oder unübersetzten String"
-
-#: ../pohelper/data/menus.ui.h:16
-msgid "Next Untranslated _or Fuzzy"
-msgstr "Nächste unübersetzte _oder unklare Übersetzung"
-
-#: ../pohelper/data/menus.ui.h:17 ../pohelper/src/gph-plugin.c:1612
-msgid "Go to next untranslated or fuzzy string"
-msgstr "Springt zum nächsten unklaren (fuzzy) oder unübersetzten String"
-
-#: ../pohelper/data/menus.ui.h:18 ../pohelper/src/gph-plugin.c:1623
-msgid "Toggle current translation fuzziness"
-msgstr "Status der Übersetzung umschalten (Fuzzy)"
-
-#: ../pohelper/data/menus.ui.h:19
-msgid "_Toggle Fuzziness"
-msgstr "_Status tauschen"
-
-#: ../pohelper/data/menus.ui.h:20
-msgid "Paste _Message as Translation"
-msgstr "_Originalstring als Übersetzung verwenden"
-
-#: ../pohelper/data/menus.ui.h:21
-msgid "Paste the original untranslated string to the translation"
-msgstr ""
-"Benutzt die unübersetzte Ausgabe, um diese auch in der übersetzten Form "
-"anzuzeigen."
-
-#: ../pohelper/data/menus.ui.h:22 ../pohelper/src/gph-plugin.c:1620
-msgid "Reflow the current translation string"
-msgstr "Aktuelle Übersetzungen neu umbrechen"
-
-#: ../pohelper/data/menus.ui.h:23
-msgid "_Reflow Translation"
-msgstr "_Übersetzungen neu umbrechen"
-
-#: ../pohelper/data/menus.ui.h:24 ../pohelper/src/gph-plugin.c:1626
-msgid "Show statistics of the current document"
-msgstr "Statistik der aktuellen Übersetzung ansehen"
-
-#: ../pohelper/data/menus.ui.h:25
-msgid "_Show stats"
-msgstr "_Statistik anzeigen"
-
-#: ../pohelper/data/menus.ui.h:26
-msgid ""
-"Whether to update the translation headers (author, revision date, ...) upon "
-"file save"
-msgstr ""
-"Legt fest, ob die Metadaten der Übersetzungsdatei (Autor, Datum ... ) beim "
-"Speichern aktualisiert werden sollen."
-
-#: ../pohelper/data/menus.ui.h:27
-msgid "Update _Headers Upon Save"
-msgstr "_Metadaten beim Speichern aktualisieren"
-
-#: ../pohelper/data/stats.ui.h:1
-msgid "Translation statistics"
-msgstr "Übersetzungsstatistiken"
-
-#: ../pohelper/data/stats.ui.h:2
-msgid "Choose a color for translated strings"
-msgstr "Farbe für übersetze Texte auswählen"
-
-#: ../pohelper/data/stats.ui.h:3
-msgid "Choose a color for fuzzily translated strings"
-msgstr "Farbe für unklare Übersetzungen auswählen"
-
-#: ../pohelper/data/stats.ui.h:4
-msgid "Choose a color for untranslated strings"
-msgstr "Farbe für nicht übersetzte Texte auswählen"
-
-#: ../pohelper/data/stats.ui.h:5
-msgid "Translated:"
-msgstr "Übersetzt:"
-
-#: ../pohelper/data/stats.ui.h:6
-msgid "Fuzzy:"
-msgstr "Unklar:"
-
-#: ../pohelper/data/stats.ui.h:7
-msgid "Untranslated:"
-msgstr "Unübersetzt:"
 
 #: ../pohelper/src/gph-plugin.c:40
 msgid "Translation Helper"
@@ -5966,9 +5666,53 @@ msgstr "<b>Unübersetzt:</b> %.3g%%"
 msgid "%u (%.3g%%)"
 msgstr "%u (%.3g%%)"
 
+#: ../pohelper/src/gph-plugin.c:1590
+msgid "Go to previous string"
+msgstr "Zum vorherigen String gehen"
+
+#: ../pohelper/src/gph-plugin.c:1593
+msgid "Go to next string"
+msgstr "Zur nächsten String gehen"
+
+#: ../pohelper/src/gph-plugin.c:1596
+msgid "Go to previous untranslated string"
+msgstr "Geht zu der vorherigen, noch nicht übersetzten Zeichenkette."
+
+#: ../pohelper/src/gph-plugin.c:1599
+msgid "Go to next untranslated string"
+msgstr "Geht zu der nächsten, noch nicht übersetzten Zeichenkette."
+
+#: ../pohelper/src/gph-plugin.c:1602
+msgid "Go to previous fuzzily translated string"
+msgstr "Springt zur vorhergehenden, unklaren (fuzzy) Übersetzung"
+
+#: ../pohelper/src/gph-plugin.c:1605
+msgid "Go to next fuzzily translated string"
+msgstr "Gehe zur nächsten unklaren Übersetzung"
+
+#: ../pohelper/src/gph-plugin.c:1608
+msgid "Go to previous untranslated or fuzzy string"
+msgstr "Gehe zum vorherigen unklaren oder unübersetzten String"
+
+#: ../pohelper/src/gph-plugin.c:1612
+msgid "Go to next untranslated or fuzzy string"
+msgstr "Springt zum nächsten unklaren (fuzzy) oder unübersetzten String"
+
 #: ../pohelper/src/gph-plugin.c:1616
 msgid "Paste original untranslated string to translation"
 msgstr "Originalen String als Übersetzung nutzen"
+
+#: ../pohelper/src/gph-plugin.c:1620
+msgid "Reflow the current translation string"
+msgstr "Aktuelle Übersetzungen neu umbrechen"
+
+#: ../pohelper/src/gph-plugin.c:1623
+msgid "Toggle current translation fuzziness"
+msgstr "Status der Übersetzung umschalten (Fuzzy)"
+
+#: ../pohelper/src/gph-plugin.c:1626
+msgid "Show statistics of the current document"
+msgstr "Statistik der aktuellen Übersetzung ansehen"
 
 #: ../pohelper/src/gph-plugin.c:1833
 #, c-format
@@ -6263,7 +6007,7 @@ msgid "Add"
 msgstr "Hinzufügen"
 
 #: ../projectorganizer/src/prjorg-sidebar.c:390
-#: ../treebrowser/src/treebrowser.c:2356
+#: ../treebrowser/src/treebrowser.c:2361
 msgid "New File"
 msgstr "Neue Datei"
 
@@ -6882,6 +6626,10 @@ msgstr "_Tooltips anzeigen."
 msgid "<b>Others</b>"
 msgstr "<b>Andere</b>"
 
+#: ../scope/data/scope.glade.h:130 ../scope/data/scope_gtk3.glade.h:130
+msgid "Options"
+msgstr "Optionen"
+
 #: ../scope/data/scope.glade.h:131 ../scope/data/scope_gtk3.glade.h:131
 msgid "_Import"
 msgstr "_Import"
@@ -7493,12 +7241,14 @@ msgid "Checks the spelling of the current document."
 msgstr "Prüft die Rechtschreibung im aktuellen Dokument."
 
 #: ../spellcheck/src/scplugin.c:225
-msgid "Run Spell Check"
+#, fuzzy
+msgid "Run spell check once"
 msgstr "Rechtschreibprüfung ausführen"
 
-#: ../spellcheck/src/scplugin.c:228
-msgid "Toggle Check While Typing"
-msgstr "Rechtschreibung beim Tippen überprüfen ein-/ausschalten"
+#: ../spellcheck/src/scplugin.c:228 ../spellcheck/src/scplugin.c:333
+#, fuzzy
+msgid "Toggle spell check"
+msgstr "Rechtschreibprüfung"
 
 #. initialise the dialog
 #: ../spellcheck/src/scplugin.c:239
@@ -7524,10 +7274,6 @@ msgstr "Falsch geschriebene Wörter und Vorschläge im Meldungsfenster anzeigen"
 #: ../spellcheck/src/scplugin.c:325
 msgid "<b>Interface</b>"
 msgstr "<b>Interface</b>"
-
-#: ../spellcheck/src/scplugin.c:333
-msgid "Check spelling while typing"
-msgstr "Beim Tippen Rechtschreibung überprüfen"
 
 #: ../spellcheck/src/scplugin.c:336
 msgid "Check spelling when opening a document"
@@ -7566,33 +7312,33 @@ msgstr ""
 msgid "<b>Behavior</b>"
 msgstr "<b>Verhalten</b>"
 
-#: ../spellcheck/src/gui.c:76
+#: ../spellcheck/src/gui.c:88
 msgid "Spell checking while typing is now enabled"
 msgstr "»Rechtschreibung beim Tippen überprüfen« ist nun eingeschaltet"
 
-#: ../spellcheck/src/gui.c:78
+#: ../spellcheck/src/gui.c:90
 msgid "Spell checking while typing is now disabled"
 msgstr "»Rechtschreibung beim Tippen überprüfen« ist nun ausgeschaltet"
 
-#: ../spellcheck/src/gui.c:326
+#: ../spellcheck/src/gui.c:323
 msgid "More..."
 msgstr "Mehr ..."
 
-#: ../spellcheck/src/gui.c:347
+#: ../spellcheck/src/gui.c:344
 msgid "(No Suggestions)"
 msgstr "(keine Vorschläge)"
 
-#: ../spellcheck/src/gui.c:360
+#: ../spellcheck/src/gui.c:357
 #, c-format
 msgid "Add \"%s\" to Dictionary"
 msgstr "»%s« zum Wörterbuch hinzufügen"
 
-#: ../spellcheck/src/gui.c:368
+#: ../spellcheck/src/gui.c:365
 msgid "Ignore All"
 msgstr "Alle ignorieren"
 
 # Mit dem Umbruch kann man an dieser Stelle ggf. ja nochmal spielen
-#: ../spellcheck/src/gui.c:441
+#: ../spellcheck/src/gui.c:438
 msgid ""
 "Search term is too long to provide\n"
 "spelling suggestions in the editor menu."
@@ -7600,23 +7346,23 @@ msgstr ""
 "Der Ausdruck ist zu lang, um Vorschläge\n"
 "im Editormenü anzeigen zu können."
 
-#: ../spellcheck/src/gui.c:447
+#: ../spellcheck/src/gui.c:444
 msgid "Perform Spell Check"
 msgstr "Rechtschreibung prüfen"
 
-#: ../spellcheck/src/gui.c:609
+#: ../spellcheck/src/gui.c:606
 #, c-format
 msgid "Default (%s)"
 msgstr "Vorgabe (%s)"
 
-#: ../spellcheck/src/gui.c:620
-#, c-format
-msgid "Toggle spell check while typing (current language: %s)"
+#: ../spellcheck/src/gui.c:617
+#, fuzzy, c-format
+msgid "Toggle spell check (current language: %s)"
 msgstr ""
 "»Rechtschreibung beim Tippen überprüfen« ein-/ausschalten (Aktuelle Sprache: "
 "%s)"
 
-#: ../spellcheck/src/gui.c:698
+#: ../spellcheck/src/gui.c:695
 msgid "Spelling Suggestions"
 msgstr "Rechtschreibvorschläge"
 
@@ -7712,15 +7458,15 @@ msgstr "(leer)"
 msgid "Could not execute configured external command '%s' (%s)."
 msgstr "Konnte das eingestellte externe Werkzeug »%s« nicht ausführen (%s)."
 
-#: ../treebrowser/src/treebrowser.c:1089
+#: ../treebrowser/src/treebrowser.c:1093
 msgid "NewDirectory"
 msgstr "Neues Verzeichnis"
 
-#: ../treebrowser/src/treebrowser.c:1091
+#: ../treebrowser/src/treebrowser.c:1095
 msgid "NewFile"
 msgstr "Neue Datei"
 
-#: ../treebrowser/src/treebrowser.c:1096
+#: ../treebrowser/src/treebrowser.c:1100
 #, c-format
 msgid ""
 "Target file '%s' exists.\n"
@@ -7729,134 +7475,134 @@ msgstr ""
 "Zieldatei »%s« existiert bereits.\n"
 "Möchten Sie diese wirklich mit einer leeren Datei ersetzen?"
 
-#: ../treebrowser/src/treebrowser.c:1142
+#: ../treebrowser/src/treebrowser.c:1146
 #, c-format
 msgid "Do you really want to delete '%s' ?"
 msgstr "Soll »%s« wirklich gelöscht werden?"
 
-#: ../treebrowser/src/treebrowser.c:1255 ../treebrowser/src/treebrowser.c:1257
+#: ../treebrowser/src/treebrowser.c:1259 ../treebrowser/src/treebrowser.c:1261
 msgid "Go _Up"
 msgstr "_Aufwährts"
 
-#: ../treebrowser/src/treebrowser.c:1263 ../treebrowser/src/treebrowser.c:1265
+#: ../treebrowser/src/treebrowser.c:1267 ../treebrowser/src/treebrowser.c:1269
 msgid "Set _Path From Document"
 msgstr "_Pfad des Dokumentes übernehmen"
 
-#: ../treebrowser/src/treebrowser.c:1271 ../treebrowser/src/treebrowser.c:1273
+#: ../treebrowser/src/treebrowser.c:1275 ../treebrowser/src/treebrowser.c:1277
 msgid "_Open Externally"
 msgstr "_Extern öffnen"
 
-#: ../treebrowser/src/treebrowser.c:1279
+#: ../treebrowser/src/treebrowser.c:1283
 msgid "Open _Terminal"
 msgstr "In _Terminal öffnen"
 
-#: ../treebrowser/src/treebrowser.c:1284 ../treebrowser/src/treebrowser.c:1286
+#: ../treebrowser/src/treebrowser.c:1288 ../treebrowser/src/treebrowser.c:1290
 msgid "Set as _Root"
 msgstr "Als _Wurzelverzeichnis festlegen"
 
-#: ../treebrowser/src/treebrowser.c:1293 ../treebrowser/src/treebrowser.c:1295
+#: ../treebrowser/src/treebrowser.c:1297 ../treebrowser/src/treebrowser.c:1299
 msgid "Refres_h"
 msgstr "Auffrisc_hen"
 
-#: ../treebrowser/src/treebrowser.c:1301 ../treebrowser/src/treebrowser.c:1303
+#: ../treebrowser/src/treebrowser.c:1305 ../treebrowser/src/treebrowser.c:1307
 msgid "_Find in Files"
 msgstr "In Dateien _finden"
 
-#: ../treebrowser/src/treebrowser.c:1313 ../treebrowser/src/treebrowser.c:1315
+#: ../treebrowser/src/treebrowser.c:1317 ../treebrowser/src/treebrowser.c:1319
 msgid "N_ew Folder"
 msgstr "N_euer Ordner"
 
-#: ../treebrowser/src/treebrowser.c:1321 ../treebrowser/src/treebrowser.c:1323
+#: ../treebrowser/src/treebrowser.c:1325 ../treebrowser/src/treebrowser.c:1327
 msgid "_New File"
 msgstr "Neue Datei"
 
-#: ../treebrowser/src/treebrowser.c:1329 ../treebrowser/src/treebrowser.c:1331
+#: ../treebrowser/src/treebrowser.c:1333 ../treebrowser/src/treebrowser.c:1335
 msgid "Rena_me"
 msgstr "_Umbenennen"
 
-#: ../treebrowser/src/treebrowser.c:1350 ../treebrowser/src/treebrowser.c:1352
+#: ../treebrowser/src/treebrowser.c:1354 ../treebrowser/src/treebrowser.c:1356
 #, c-format
 msgid "Close: %s"
 msgstr "»%s« schließen"
 
-#: ../treebrowser/src/treebrowser.c:1359 ../treebrowser/src/treebrowser.c:1361
+#: ../treebrowser/src/treebrowser.c:1363 ../treebrowser/src/treebrowser.c:1365
 #, c-format
 msgid "Clo_se Child Documents "
 msgstr "Kinderdokumente _schließen"
 
-#: ../treebrowser/src/treebrowser.c:1368 ../treebrowser/src/treebrowser.c:1370
+#: ../treebrowser/src/treebrowser.c:1372 ../treebrowser/src/treebrowser.c:1374
 msgid "_Copy Full Path to Clipboard"
 msgstr "_Vollständigen Pfad in die Zwischenablage kopieren"
 
-#: ../treebrowser/src/treebrowser.c:1381 ../treebrowser/src/treebrowser.c:1383
+#: ../treebrowser/src/treebrowser.c:1385 ../treebrowser/src/treebrowser.c:1387
 msgid "E_xpand All"
 msgstr "Alle _ausklappen"
 
-#: ../treebrowser/src/treebrowser.c:1389 ../treebrowser/src/treebrowser.c:1391
+#: ../treebrowser/src/treebrowser.c:1393 ../treebrowser/src/treebrowser.c:1395
 msgid "Coll_apse All"
 msgstr "Alle e_inklappen"
 
-#: ../treebrowser/src/treebrowser.c:1399
+#: ../treebrowser/src/treebrowser.c:1403
 msgid "Show Boo_kmarks"
 msgstr "L_esezeichen anzeigen"
 
-#: ../treebrowser/src/treebrowser.c:1404
+#: ../treebrowser/src/treebrowser.c:1408
 msgid "Sho_w Hidden Files"
 msgstr "_Versteckte Dateien anzeigen"
 
-#: ../treebrowser/src/treebrowser.c:1409
+#: ../treebrowser/src/treebrowser.c:1413
 msgid "Show Tool_bars"
 msgstr "_Werkzeugleisten anzeigen"
 
-#: ../treebrowser/src/treebrowser.c:1747
+#: ../treebrowser/src/treebrowser.c:1751
 #, c-format
 msgid "Target file '%s' exists, do you really want to replace it?"
 msgstr "Zieldatei »%s« existiert bereits. Möchten Sie diese wirklich ersetzen?"
 
-#: ../treebrowser/src/treebrowser.c:1883
+#: ../treebrowser/src/treebrowser.c:1887
 msgid "Go up"
 msgstr "Aufwärts"
 
-#: ../treebrowser/src/treebrowser.c:1893 ../treebrowser/src/treebrowser.c:2360
+#: ../treebrowser/src/treebrowser.c:1897 ../treebrowser/src/treebrowser.c:2365
 msgid "Refresh"
 msgstr "Auffrischen"
 
-#: ../treebrowser/src/treebrowser.c:1903
+#: ../treebrowser/src/treebrowser.c:1907
 msgid "Home"
 msgstr "Ausgabe"
 
-#: ../treebrowser/src/treebrowser.c:1913
+#: ../treebrowser/src/treebrowser.c:1917
 msgid "Set path from document"
 msgstr "Pfad des Dokumentes übernehmen"
 
-#: ../treebrowser/src/treebrowser.c:1923
+#: ../treebrowser/src/treebrowser.c:1927
 msgid "Track path"
 msgstr "Pfad aufzeichnen"
 
-#: ../treebrowser/src/treebrowser.c:1933
+#: ../treebrowser/src/treebrowser.c:1937
 msgid "Hide bars"
 msgstr "Leisten verbergen"
 
-#: ../treebrowser/src/treebrowser.c:1943
+#: ../treebrowser/src/treebrowser.c:1947
 msgid ""
 "Filter (*.c;*.h;*.cpp), and if you want temporary filter using the '!' "
 "reverse try for example this '!;*.c;*.h;*.cpp'"
 msgstr "Filter (*.c;*.h;*.cpp). Die Nutzung von »!« invertiert das Ergebnis."
 
-#: ../treebrowser/src/treebrowser.c:1948
+#: ../treebrowser/src/treebrowser.c:1952
 msgid "Addressbar for example '/projects/my-project'"
 msgstr "Adressleiste. Zum Beispiel »/projects/my-project«"
 
-#: ../treebrowser/src/treebrowser.c:1973
+#: ../treebrowser/src/treebrowser.c:1977
 msgid "Tree Browser"
 msgstr "Baumnavigator"
 
-#: ../treebrowser/src/treebrowser.c:2114
+#: ../treebrowser/src/treebrowser.c:2118
 msgid "External open command"
 msgstr "Externer Öffnen-Befehl"
 
-#: ../treebrowser/src/treebrowser.c:2124
-#, c-format
+#: ../treebrowser/src/treebrowser.c:2129
+#, no-c-format
 msgid ""
 "The command to execute when using \"Open with\". You can use %f and %d "
 "wildcards.\n"
@@ -7869,63 +7615,63 @@ msgstr ""
 "%f wird mit dem Dateinamen ersetzt, der den kompletten Pfad beinhaltet.\n"
 "%d wird mit dem Pfad des Verzeichnisses der aktuellen Datei ersetzt."
 
-#: ../treebrowser/src/treebrowser.c:2143
+#: ../treebrowser/src/treebrowser.c:2148
 msgid "The terminal to use with the command \"Open Terminal\""
 msgstr ""
 "Das Terminal, welches für das Kommando »Terminal öffnen« genutzt werden "
 "soll. Z. B. »xterm«."
 
-#: ../treebrowser/src/treebrowser.c:2149
+#: ../treebrowser/src/treebrowser.c:2154
 msgid "Toolbar"
 msgstr "Werkzeugleiste:"
 
-#: ../treebrowser/src/treebrowser.c:2151
+#: ../treebrowser/src/treebrowser.c:2156
 msgid "Hidden"
 msgstr "Versteckt"
 
-#: ../treebrowser/src/treebrowser.c:2152
+#: ../treebrowser/src/treebrowser.c:2157
 msgid "Top"
 msgstr "Oben"
 
-#: ../treebrowser/src/treebrowser.c:2153
+#: ../treebrowser/src/treebrowser.c:2158
 msgid "Bottom"
 msgstr "Unten"
 
-#: ../treebrowser/src/treebrowser.c:2158
+#: ../treebrowser/src/treebrowser.c:2163
 msgid "If position is changed, the option require plugin restart."
 msgstr "Bei einer Veränderung der Position muss das Plugin neu geladen werden."
 
-#: ../treebrowser/src/treebrowser.c:2162
+#: ../treebrowser/src/treebrowser.c:2167
 msgid "Show icons"
 msgstr "Symbole anzeigen:"
 
-#: ../treebrowser/src/treebrowser.c:2164
+#: ../treebrowser/src/treebrowser.c:2169
 msgid "None"
 msgstr "Keines"
 
-#: ../treebrowser/src/treebrowser.c:2165
+#: ../treebrowser/src/treebrowser.c:2170
 msgid "Base"
 msgstr "Basis"
 
-#: ../treebrowser/src/treebrowser.c:2166
+#: ../treebrowser/src/treebrowser.c:2171
 msgid "Content-type"
 msgstr "Inhaltsart"
 
-#: ../treebrowser/src/treebrowser.c:2172
+#: ../treebrowser/src/treebrowser.c:2177
 msgid "Show hidden files"
 msgstr "Versteckte Dateien anzeigen"
 
-#: ../treebrowser/src/treebrowser.c:2181
+#: ../treebrowser/src/treebrowser.c:2186
 msgid "On Windows, this just hide files that are prefixed with '.' (dot)"
 msgstr ""
 "Unter Windows versteckt dies nur Dateien, die mit einem ».« (Punkt) "
 "beginnen. "
 
-#: ../treebrowser/src/treebrowser.c:2183
+#: ../treebrowser/src/treebrowser.c:2188
 msgid "Hide object files"
 msgstr "Objektdateien verbergen"
 
-#: ../treebrowser/src/treebrowser.c:2192
+#: ../treebrowser/src/treebrowser.c:2197
 msgid ""
 "Don't show generated object files in the file browser, this includes *.o, *."
 "obj. *.so, *.dll, *.a, *.lib"
@@ -7933,59 +7679,59 @@ msgstr ""
 "Keine generierten Objektdateien anzeigen. Dies bezieht *.o, *.obj. *.so, *."
 "dll, *.a, *.lib mit ein."
 
-#: ../treebrowser/src/treebrowser.c:2194
+#: ../treebrowser/src/treebrowser.c:2199
 msgid "Reverse filter"
 msgstr "Filter zurücksetzen"
 
-#: ../treebrowser/src/treebrowser.c:2203
+#: ../treebrowser/src/treebrowser.c:2208
 msgid "Follow current document"
 msgstr "Dem aktuellen Dokument folgen"
 
-#: ../treebrowser/src/treebrowser.c:2212
+#: ../treebrowser/src/treebrowser.c:2217
 msgid "Single click, open document and focus it"
 msgstr "Einzelklick öffnet Dokument und fokussiert es"
 
-#: ../treebrowser/src/treebrowser.c:2221
+#: ../treebrowser/src/treebrowser.c:2226
 msgid "Double click open directory"
 msgstr "Doppelklick öffnet ein Verzeichnis"
 
-#: ../treebrowser/src/treebrowser.c:2230
+#: ../treebrowser/src/treebrowser.c:2235
 msgid "On delete file, close it if is opened"
 msgstr "Datei schließen, wenn sie gelöscht wird"
 
-#: ../treebrowser/src/treebrowser.c:2239
+#: ../treebrowser/src/treebrowser.c:2244
 msgid "Focus editor on file open"
 msgstr "Fokus auf Editor legen beim Öffnen von Dateien"
 
-#: ../treebrowser/src/treebrowser.c:2248
+#: ../treebrowser/src/treebrowser.c:2253
 msgid "Show tree lines"
 msgstr "Leere Zeilen anzeigen"
 
-#: ../treebrowser/src/treebrowser.c:2257
+#: ../treebrowser/src/treebrowser.c:2262
 msgid "Show bookmarks"
 msgstr "Lesezeichen anzeigen"
 
-#: ../treebrowser/src/treebrowser.c:2266
+#: ../treebrowser/src/treebrowser.c:2271
 msgid "Open new files"
 msgstr "Neue Dateien öffnen"
 
-#: ../treebrowser/src/treebrowser.c:2350
+#: ../treebrowser/src/treebrowser.c:2355
 msgid "Focus File List"
 msgstr "Dateiliste fokussieren"
 
-#: ../treebrowser/src/treebrowser.c:2352
+#: ../treebrowser/src/treebrowser.c:2357
 msgid "Focus Path Entry"
 msgstr "Pfadeintrag fokussieren"
 
-#: ../treebrowser/src/treebrowser.c:2354
+#: ../treebrowser/src/treebrowser.c:2359
 msgid "Rename Object"
 msgstr "Objekt umbenennen"
 
-#: ../treebrowser/src/treebrowser.c:2358
+#: ../treebrowser/src/treebrowser.c:2363
 msgid "New Folder"
 msgstr "Neues Verzeichnis"
 
-#: ../treebrowser/src/treebrowser.c:2362
+#: ../treebrowser/src/treebrowser.c:2367
 msgid "Track Current"
 msgstr "Pfad aufzeichnen"
 
@@ -8688,13 +8434,6 @@ msgstr "Keine Verzeichnisse"
 msgid "No workbench opened."
 msgstr "Keine Werkbank geöffnet."
 
-#: ../workbench/src/sidebar.c:875
-#, c-format
-msgid "%s: %u Project"
-msgid_plural "%s: %u Projects"
-msgstr[0] "%s: %u Projekt"
-msgstr[1] "%s: %u Projekte"
-
 #: ../workbench/src/sidebar.c:886
 #, fuzzy
 msgid ""
@@ -8810,6 +8549,221 @@ msgstr "XML-Schnipsel"
 #: ../xmlsnippets/src/plugin.c:45
 msgid "Autocompletes XML/HTML tags using snippets."
 msgstr "Autovervollständigt XML/HTML-Tags unter Verwendung von Schnipseln."
+
+#~ msgid "_Monitor repository for changes"
+#~ msgstr "Repository auf Änderungen _überwachen"
+
+#~ msgid ""
+#~ "Whether to automatically update the diff in order to maintain it up to "
+#~ "date when the underlying Git repository changes.  This should generally "
+#~ "be enabled for optimal user experience."
+#~ msgstr ""
+#~ "Legt fest, ob die Diffs automatische aktualisiert werden und sie so immer "
+#~ "auf dem aktuellen Stand gehalten werden sollen. Insbesondere dann, wenn "
+#~ "das zu Grunde liegende git-Repository geändert wurde. In den meisten "
+#~ "Fällen sollte diese Option aktiviert sein."
+
+#~ msgid "_Added lines:"
+#~ msgstr "_Hinzugefügte Zeilen:"
+
+#~ msgid "_Changed lines:"
+#~ msgstr "_Geänderte Zeilen:"
+
+#~ msgid "_Removed lines:"
+#~ msgstr "_Entfernte Zeilen:"
+
+#~ msgid "Colors"
+#~ msgstr "Farben:"
+
+#~ msgid ""
+#~ "The amount to zoom the overview sidebar. This should probably negative if "
+#~ "you want the sidebar zoomed out."
+#~ msgstr ""
+#~ "Legt fest, wie stark die Seitenleiste von »Overview« vergrößert/"
+#~ "verkleinert werden soll. Negative Werte sorgen für eine größere Übersicht."
+
+#~ msgid "Zoom Level:"
+#~ msgstr "Zoom-Stufe:"
+
+#~ msgid "The width of the overview sidebar."
+#~ msgstr "Die Breite der Überblick-Fensters"
+
+#~ msgid "Width:"
+#~ msgstr "Breite:"
+
+#~ msgid ""
+#~ "The number of lines to scroll at a time when scrolling the overview "
+#~ "sidebar."
+#~ msgstr ""
+#~ "Legt die Anzahl der Zeilen fest, die beim Scrollen in der Seitenleiste "
+#~ "zurückgelegt werden sollen."
+
+#~ msgid "Scroll Lines:"
+#~ msgstr "Scrollgeschwindigkeit:"
+
+#~ msgid "Position on left"
+#~ msgstr "Links positionieren"
+
+#~ msgid ""
+#~ "Position the overview bar on the left rather than the right (requires "
+#~ "Geany 1.25 or greater)."
+#~ msgstr ""
+#~ "Diese Option positioniert die Seitenleiste des Plugins an der linken "
+#~ "Seite von Geany. Dies funktioniert nur in Geany-Versionen >= 1.25."
+
+#~ msgid "Hide tooltip"
+#~ msgstr "Tooltips verstecken."
+
+#~ msgid ""
+#~ "Hide the tooltip that is displayed when mousing over the overview that "
+#~ "shows line, column and position information."
+#~ msgstr ""
+#~ "Versteckt die zusätzlichen Informationen, die beim mit der Maus "
+#~ "überstreichen angezeigt werden (Zeile, Spalte etc.)"
+
+#~ msgid "Hide editor scrollbar"
+#~ msgstr "Normale Bildlaufleiste verstecken"
+
+#~ msgid ""
+#~ "Whether to hide Geany's regular editor scrollbar while the overview bar "
+#~ "is visible."
+#~ msgstr ""
+#~ "Mit dieser Option kann Geanys normale Bildlaufleiste versteckt werden, so "
+#~ "dass, wenn das Plugin aktiv ist, allein über die Vorschau im Dokument "
+#~ "navigiert werden kann."
+
+#~ msgid "Disable overlay"
+#~ msgstr "Bildausschnittsmarkierung deaktivieren"
+
+#~ msgid ""
+#~ "Turn off drawing overlay, which shows the region of the main editor view "
+#~ "that is currently in view, ontop of the overview bar."
+#~ msgstr ""
+#~ "Diese Option legt fest, ob der aktuelle Bildschirmausschnitt aus dem "
+#~ "normalen Editorfenster in der Vorschau angezeigt werden soll."
+
+#~ msgid ""
+#~ "The color and opacity of the overlay drawn ontop of the overlay sidebar."
+#~ msgstr ""
+#~ "Konfiguriert die Farbe und Sättigung der Bildausschnittsmarkierung in der "
+#~ "Seitenleiste des Plugins."
+
+#~ msgid "Color:"
+#~ msgstr "Farbe:"
+
+#~ msgid ""
+#~ "The color and opacity of the border drawn around the revealed area in the "
+#~ "overview sidebar. Set to the same as Overlay Color to disable."
+#~ msgstr ""
+#~ "Konfiguriert die Farbe und Sättigung rund um das aktive Gebiet des "
+#~ "Dokumentes. Zum Deaktivieren einfach auf die gleiche Farbe wie die der "
+#~ "Bildausschnittsmarkierung stellen"
+
+#~ msgid "Outline Color:"
+#~ msgstr "Farbe Außenlinie"
+
+#~ msgid "Draw over visible area"
+#~ msgstr "Über sichtbares Gebiet zeichnen"
+
+#~ msgid ""
+#~ "When checked it will draw the overlay ontop of the area that is visible "
+#~ "in the main editor view, when unchecked, it will do the opposite and draw "
+#~ "the overlay everywhere but the visible area, \"revealing\" the visible "
+#~ "part."
+#~ msgstr ""
+#~ "Wenn diese Option aktiv ist, wird die Bildausschnittsmarkierung nur über "
+#~ "den aktiven Bereich gelegt. Ist die Option deaktiviert, wird alles was "
+#~ "nicht sichtbar ist mit einer Markierung versehen. "
+
+#~ msgid "Overlay"
+#~ msgstr "Überlagerung"
+
+#~ msgid "_Translation Helper"
+#~ msgstr "_Übersetzungshelfer"
+
+#~ msgid "_Previous String"
+#~ msgstr "_Vorheriger String"
+
+#~ msgid "_Next String"
+#~ msgstr "_Nächster String"
+
+#~ msgid "Pre_vious Untranslated"
+#~ msgstr "_Vorherige nicht übersetze Zeichenkette"
+
+#~ msgid "Next _Untranslated"
+#~ msgstr "Nächste nicht _übersetzte Zeichenkette"
+
+#~ msgid "Previous Fu_zzy"
+#~ msgstr "_Vorhergehende unklare Übersetzung"
+
+#~ msgid "Next _Fuzzy"
+#~ msgstr "Nächste _unklare Übersetzung"
+
+#~ msgid "Previous Untranslated or Fuzz_y"
+#~ msgstr "Vorherige u_nübersetzt oder -klar."
+
+#~ msgid "Next Untranslated _or Fuzzy"
+#~ msgstr "Nächste unübersetzte _oder unklare Übersetzung"
+
+#~ msgid "_Toggle Fuzziness"
+#~ msgstr "_Status tauschen"
+
+#~ msgid "Paste _Message as Translation"
+#~ msgstr "_Originalstring als Übersetzung verwenden"
+
+#~ msgid "Paste the original untranslated string to the translation"
+#~ msgstr ""
+#~ "Benutzt die unübersetzte Ausgabe, um diese auch in der übersetzten Form "
+#~ "anzuzeigen."
+
+#~ msgid "_Reflow Translation"
+#~ msgstr "_Übersetzungen neu umbrechen"
+
+#~ msgid "_Show stats"
+#~ msgstr "_Statistik anzeigen"
+
+#~ msgid ""
+#~ "Whether to update the translation headers (author, revision date, ...) "
+#~ "upon file save"
+#~ msgstr ""
+#~ "Legt fest, ob die Metadaten der Übersetzungsdatei (Autor, Datum ... ) "
+#~ "beim Speichern aktualisiert werden sollen."
+
+#~ msgid "Update _Headers Upon Save"
+#~ msgstr "_Metadaten beim Speichern aktualisieren"
+
+#~ msgid "Translation statistics"
+#~ msgstr "Übersetzungsstatistiken"
+
+#~ msgid "Choose a color for translated strings"
+#~ msgstr "Farbe für übersetze Texte auswählen"
+
+#~ msgid "Choose a color for fuzzily translated strings"
+#~ msgstr "Farbe für unklare Übersetzungen auswählen"
+
+#~ msgid "Choose a color for untranslated strings"
+#~ msgstr "Farbe für nicht übersetzte Texte auswählen"
+
+#~ msgid "Translated:"
+#~ msgstr "Übersetzt:"
+
+#~ msgid "Fuzzy:"
+#~ msgstr "Unklar:"
+
+#~ msgid "Untranslated:"
+#~ msgstr "Unübersetzt:"
+
+#~ msgid "Toggle Check While Typing"
+#~ msgstr "Rechtschreibung beim Tippen überprüfen ein-/ausschalten"
+
+#~ msgid "Check spelling while typing"
+#~ msgstr "Beim Tippen Rechtschreibung überprüfen"
+
+#, c-format
+#~ msgid "%s: %u Project"
+#~ msgid_plural "%s: %u Projects"
+#~ msgstr[0] "%s: %u Projekt"
+#~ msgstr[1] "%s: %u Projekte"
 
 #~ msgid "_Save"
 #~ msgstr "_Speichern…"

--- a/po/de.po
+++ b/po/de.po
@@ -8036,7 +8036,7 @@ msgstr "Vim-Modus für Geany"
 #: ../vimode/src/backends/backend-geany.c:140
 #, c-format
 msgid "Insert Mode for Dummies: %s"
-msgstr "Einfügen-Modus (Insert) für Neulinge: $s"
+msgstr "Einfügen-Modus (Insert) für Neulinge: %s"
 
 #: ../vimode/src/backends/backend-geany.c:140
 msgid "ON"

--- a/po/el.po
+++ b/po/el.po
@@ -6,8 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: geany-plugins 1.31\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-29 19:41+0200\n"
+"Report-Msgid-Bugs-To: https://github.com/geany/geany/issues\n"
+"POT-Creation-Date: 2022-06-28 07:39+0200\n"
 "PO-Revision-Date: 2017-06-28 22:25+0200\n"
 "Last-Translator: Frank Lanitz <frank@frank.uvena.de>\n"
 "Language-Team: Greek\n"
@@ -21,27 +21,27 @@ msgstr ""
 msgid "(Empty Line)"
 msgstr ""
 
-#: ../addons/src/ao_bookmarklist.c:315
+#: ../addons/src/ao_bookmarklist.c:331
 msgid "_Remove Bookmark"
 msgstr ""
 
 #. Translators: Number is meant at this point.
-#: ../addons/src/ao_bookmarklist.c:342
+#: ../addons/src/ao_bookmarklist.c:358
 msgid "No."
 msgstr ""
 
-#: ../addons/src/ao_bookmarklist.c:350 ../devhelp/src/dhp-object.c:494
+#: ../addons/src/ao_bookmarklist.c:366 ../devhelp/src/dhp-object.c:494
 #: ../devhelp/devhelp/dh-window.c:1142
 msgid "Contents"
 msgstr ""
 
-#: ../addons/src/ao_bookmarklist.c:383 ../treebrowser/src/treebrowser.c:666
+#: ../addons/src/ao_bookmarklist.c:399 ../treebrowser/src/treebrowser.c:666
 #: ../webhelper/src/gwh-plugin.c:328
 msgid "Bookmarks"
 msgstr ""
 
 #. complete update
-#: ../addons/src/ao_tasks.c:373 ../geanyvc/src/geanyvc.c:2679
+#: ../addons/src/ao_tasks.c:373 ../geanyvc/src/geanyvc.c:2730
 msgid "_Update"
 msgstr ""
 
@@ -161,10 +161,10 @@ msgstr ""
 #: ../addons/src/addons.c:364 ../autoclose/src/autoclose.c:920
 #: ../codenav/src/codenavigation.c:281 ../latex/src/latex.c:208
 #: ../latex/src/latex.c:293 ../geanyprj/src/geanyprj.c:176
-#: ../geanyvc/src/geanyvc.c:2079 ../geniuspaste/src/geniuspaste.c:336
+#: ../geanyvc/src/geanyvc.c:2130 ../geniuspaste/src/geniuspaste.c:336
 #: ../lineoperations/src/lo_prefs.c:58 ../sendmail/src/sendmail.c:128
 #: ../sendmail/src/sendmail.c:293 ../spellcheck/src/scplugin.c:124
-#: ../treebrowser/src/treebrowser.c:2102
+#: ../treebrowser/src/treebrowser.c:2106
 #: ../updatechecker/src/updatechecker.c:262
 msgid "Plugin configuration directory could not be created."
 msgstr ""
@@ -703,7 +703,7 @@ msgstr ""
 msgid "Error loading file"
 msgstr ""
 
-#. setting asyncronous mode
+#. setting asynchronous mode
 #. setting null-stop array printing
 #. enable pretty printing
 #: ../debugger/src/dbm_gdb.c:789 ../debugger/src/dbm_gdb.c:792
@@ -1093,7 +1093,7 @@ msgid "A developers' help browser for GNOME"
 msgstr ""
 
 #. Create the current file Submenu
-#: ../devhelp/devhelp/dh-window.c:759 ../geanyvc/src/geanyvc.c:2660
+#: ../devhelp/devhelp/dh-window.c:759 ../geanyvc/src/geanyvc.c:2711
 msgid "_File"
 msgstr ""
 
@@ -1127,11 +1127,11 @@ msgstr ""
 msgid "_Print…"
 msgstr ""
 
-#: ../devhelp/devhelp/dh-window.c:782 ../devhelp/devhelp/eggfindbar.c:342
+#: ../devhelp/devhelp/dh-window.c:782
 msgid "Find Next"
 msgstr ""
 
-#: ../devhelp/devhelp/dh-window.c:784 ../devhelp/devhelp/eggfindbar.c:329
+#: ../devhelp/devhelp/dh-window.c:784
 msgid "Find Previous"
 msgstr ""
 
@@ -1316,7 +1316,7 @@ msgid ""
 "contributing to this plugin?"
 msgstr ""
 
-#: ../geanydoc/src/geanydoc.c:159 ../geanyvc/src/geanyvc.c:442
+#: ../geanydoc/src/geanydoc.c:159 ../geanyvc/src/geanyvc.c:448
 msgid "Could not parse the output of command"
 msgstr ""
 
@@ -2960,14 +2960,14 @@ msgid ""
 "not enough arguments for command \"%s\".\n"
 msgstr ""
 
-#: ../geanylua/glspi_sci.c:637 ../geanylua/glspi_app.c:406
+#: ../geanylua/glspi_sci.c:729 ../geanylua/glspi_app.c:406
 #, c-format
 msgid ""
 "Error in module \"%s\" at function %s():\n"
 "unknown command \"%s\" given for argument #1.\n"
 msgstr ""
 
-#: ../geanylua/glspi_sci.c:781
+#: ../geanylua/glspi_sci.c:924
 #, c-format
 msgid ""
 "Error in module \"%s\" at function %s():\n"
@@ -2975,7 +2975,7 @@ msgid ""
 " unknown flag \"%s\" for element #%d\n"
 msgstr ""
 
-#: ../geanylua/glspi_sci.c:785
+#: ../geanylua/glspi_sci.c:928
 msgid "<too large to display>"
 msgstr ""
 
@@ -3696,7 +3696,7 @@ msgid "New _Below"
 msgstr ""
 
 #: ../geanymacro/src/geanymacro.c:1824 ../geanymacro/src/geanymacro.c:2120
-#: ../treebrowser/src/treebrowser.c:1338 ../treebrowser/src/treebrowser.c:1340
+#: ../treebrowser/src/treebrowser.c:1342 ../treebrowser/src/treebrowser.c:1344
 msgid "_Delete"
 msgstr ""
 
@@ -4059,8 +4059,8 @@ msgstr ""
 msgid "a key with fingerprint"
 msgstr ""
 
-#: ../geanypg/src/verify_aux.c:66 ../spellcheck/src/gui.c:610
-#: ../spellcheck/src/gui.c:621
+#: ../geanypg/src/verify_aux.c:66 ../spellcheck/src/gui.c:607
+#: ../spellcheck/src/gui.c:618
 msgid "unknown"
 msgstr ""
 
@@ -4351,49 +4351,49 @@ msgid ""
 "contributing to this plugin?"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:501
+#: ../geanyvc/src/geanyvc.c:507
 #, c-format
 msgid "geanyvc: s_spawn_sync error: %s"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:587
+#: ../geanyvc/src/geanyvc.c:593
 #, c-format
 msgid "File %s: action %s executed via %s."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:646 ../geanyvc/src/geanyvc.c:657
+#: ../geanyvc/src/geanyvc.c:633 ../geanyvc/src/geanyvc.c:643
 #, c-format
-msgid "geanyvc: vcdiff_file_activated: Unable to rename '%s' to '%s'"
+msgid "geanyvc: diff_external: Unable to rename '%s' to '%s'"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:683 ../geanyvc/src/geanyvc.c:733
+#: ../geanyvc/src/geanyvc.c:698 ../geanyvc/src/geanyvc.c:784
 msgid "No changes were made."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:760
+#: ../geanyvc/src/geanyvc.c:811
 msgid "No history available"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:953 ../geanyvc/src/geanyvc.c:961
+#: ../geanyvc/src/geanyvc.c:1004 ../geanyvc/src/geanyvc.c:1012
 #, c-format
 msgid "Do you really want to revert: %s?"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:969
+#: ../geanyvc/src/geanyvc.c:1020
 #, c-format
 msgid "Do you really want to add: %s?"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:976
+#: ../geanyvc/src/geanyvc.c:1027
 #, c-format
 msgid "Do you really want to remove: %s?"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:999
+#: ../geanyvc/src/geanyvc.c:1050
 msgid "Do you really want to update?"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1126
+#: ../geanyvc/src/geanyvc.c:1177
 msgid ""
 "The resulting differences cannot be displayed because the changes are too "
 "big to display here and would slow down the UI significantly.\n"
@@ -4402,327 +4402,327 @@ msgid ""
 "Geany directly by using the GeanyVC menu (Base Directory -> Diff)."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1280
+#: ../geanyvc/src/geanyvc.c:1331
 msgid "Commit Y/N"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1290
+#: ../geanyvc/src/geanyvc.c:1341
 msgid "Status"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1297
+#: ../geanyvc/src/geanyvc.c:1348
 msgid "Path"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1414
+#: ../geanyvc/src/geanyvc.c:1465
 msgid "Choose a previous commit message"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1476
+#: ../geanyvc/src/geanyvc.c:1527
 #, c-format
 msgid "Line: %d Column: %d"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1523
+#: ../geanyvc/src/geanyvc.c:1574
 msgid "Commit"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1564
+#: ../geanyvc/src/geanyvc.c:1615
 msgid "_De-/select all files"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1608
+#: ../geanyvc/src/geanyvc.c:1659
 msgid "<b>Commit message:</b>"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1632
+#: ../geanyvc/src/geanyvc.c:1683
 msgid "C_ommit"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1740
+#: ../geanyvc/src/geanyvc.c:1791
 msgid "Nothing to commit."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1788
+#: ../geanyvc/src/geanyvc.c:1839
 #, c-format
 msgid ""
 "Error initializing GeanyVC spell checking: %s. Check your configuration."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1823
+#: ../geanyvc/src/geanyvc.c:1874
 #, c-format
 msgid "Commit failed (status: %d, error: %s)."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1824
+#: ../geanyvc/src/geanyvc.c:1875
 msgid "Commit failed; see status in the Message window."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1829
+#: ../geanyvc/src/geanyvc.c:1880
 msgid "Changes committed."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2151
+#: ../geanyvc/src/geanyvc.c:2202
 msgid "Set Changed-flag for document tabs created by the plugin"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2154
+#: ../geanyvc/src/geanyvc.c:2205
 msgid ""
 "If this option is activated, every new by the VC-plugin created document tab "
 "will be marked as changed. Even this option is useful in some cases, it "
 "could cause a big number of annoying \"Do you want to save\"-dialogs."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2162
+#: ../geanyvc/src/geanyvc.c:2213
 msgid "Confirm adding new files to a VCS"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2165
+#: ../geanyvc/src/geanyvc.c:2216
 msgid "Shows a confirmation dialog on adding a new (created) file to VCS."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2171
+#: ../geanyvc/src/geanyvc.c:2222
 msgid "Maximize commit dialog"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2172
+#: ../geanyvc/src/geanyvc.c:2223
 msgid "Show commit dialog maximize."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2178
+#: ../geanyvc/src/geanyvc.c:2229
 msgid "Use external diff viewer"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2180
+#: ../geanyvc/src/geanyvc.c:2231
 msgid "Use external diff viewer for file diff."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2186
+#: ../geanyvc/src/geanyvc.c:2237
 msgid "Show VC entries at editor menu"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2188
+#: ../geanyvc/src/geanyvc.c:2239
 msgid "Show entries for VC functions inside editor menu"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2193
+#: ../geanyvc/src/geanyvc.c:2244
 msgid "Attach menu to menubar"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2195
+#: ../geanyvc/src/geanyvc.c:2246
 msgid ""
 "Whether menu for this plugin are getting placed either inside tools menu or "
 "directly inside Geany's menubar. Will take in account after next start of "
 "GeanyVC"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2203
+#: ../geanyvc/src/geanyvc.c:2254
 msgid "Enable CVS"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2208
+#: ../geanyvc/src/geanyvc.c:2259
 msgid "Enable GIT"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2213
+#: ../geanyvc/src/geanyvc.c:2264
 msgid "Enable Fossil"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2218
+#: ../geanyvc/src/geanyvc.c:2269
 msgid "Enable SVN"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2223
+#: ../geanyvc/src/geanyvc.c:2274
 msgid "Enable SVK"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2228
+#: ../geanyvc/src/geanyvc.c:2279
 msgid "Enable Bazaar"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2233
+#: ../geanyvc/src/geanyvc.c:2284
 msgid "Enable Mercurial"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2239
+#: ../geanyvc/src/geanyvc.c:2290
 msgid "Spellcheck language"
 msgstr ""
 
 #. Diff of current file
 #. Diff of the current dir
 #. Complete diff of base directory
-#: ../geanyvc/src/geanyvc.c:2368 ../geanyvc/src/geanyvc.c:2463
-#: ../geanyvc/src/geanyvc.c:2503
+#: ../geanyvc/src/geanyvc.c:2419 ../geanyvc/src/geanyvc.c:2514
+#: ../geanyvc/src/geanyvc.c:2554
 msgid "_Diff"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2371
+#: ../geanyvc/src/geanyvc.c:2422
 msgid "Make a diff from the current active file"
 msgstr ""
 
 #. Revert current file
 #. Revert current dir
 #. Revert everything
-#: ../geanyvc/src/geanyvc.c:2376 ../geanyvc/src/geanyvc.c:2472
-#: ../geanyvc/src/geanyvc.c:2511
+#: ../geanyvc/src/geanyvc.c:2427 ../geanyvc/src/geanyvc.c:2523
+#: ../geanyvc/src/geanyvc.c:2562
 msgid "_Revert"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2379
+#: ../geanyvc/src/geanyvc.c:2430
 msgid "Restore pristine working copy file (undo local edits)."
 msgstr ""
 
 #. Blame for current file
-#: ../geanyvc/src/geanyvc.c:2388
+#: ../geanyvc/src/geanyvc.c:2439
 msgid "_Blame"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2391
+#: ../geanyvc/src/geanyvc.c:2442
 msgid "Shows the changes made at one file per revision and author."
 msgstr ""
 
 #. History/log of current file
 #. History/log of the current dir
 #. Complete History/Log of base directory
-#: ../geanyvc/src/geanyvc.c:2398 ../geanyvc/src/geanyvc.c:2482
-#: ../geanyvc/src/geanyvc.c:2523
+#: ../geanyvc/src/geanyvc.c:2449 ../geanyvc/src/geanyvc.c:2533
+#: ../geanyvc/src/geanyvc.c:2574
 msgid "_History (log)"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2401
+#: ../geanyvc/src/geanyvc.c:2452
 msgid "Shows the log of the current file"
 msgstr ""
 
 #. base version of the current file
-#: ../geanyvc/src/geanyvc.c:2406
+#: ../geanyvc/src/geanyvc.c:2457
 msgid "_Original"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2409
+#: ../geanyvc/src/geanyvc.c:2460
 msgid "Shows the original of the current file"
 msgstr ""
 
 #. add current file
-#: ../geanyvc/src/geanyvc.c:2417
+#: ../geanyvc/src/geanyvc.c:2468
 msgid "_Add to Version Control"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2419
+#: ../geanyvc/src/geanyvc.c:2470
 msgid "Add file to repository."
 msgstr ""
 
 #. remove current file
-#: ../geanyvc/src/geanyvc.c:2425
+#: ../geanyvc/src/geanyvc.c:2476
 msgid "_Remove from Version Control"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2427
+#: ../geanyvc/src/geanyvc.c:2478
 msgid "Remove file from repository."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2460
+#: ../geanyvc/src/geanyvc.c:2511
 msgid "_Directory"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2466
+#: ../geanyvc/src/geanyvc.c:2517
 msgid "Make a diff from the directory of the current active file"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2475
+#: ../geanyvc/src/geanyvc.c:2526
 msgid "Restore original files in the current folder (undo local edits)."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2485
+#: ../geanyvc/src/geanyvc.c:2536
 msgid "Shows the log of the current directory"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2499
+#: ../geanyvc/src/geanyvc.c:2550
 msgid "_Base Directory"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2505
+#: ../geanyvc/src/geanyvc.c:2556
 msgid "Make a diff from the top VC directory"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2513
+#: ../geanyvc/src/geanyvc.c:2564
 msgid "Revert any local edits."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2526
+#: ../geanyvc/src/geanyvc.c:2577
 msgid "Shows the log of the top VC directory"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2543
+#: ../geanyvc/src/geanyvc.c:2594
 msgid "_VC file Actions"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2552
+#: ../geanyvc/src/geanyvc.c:2603
 msgid "VC _Commit..."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2596
+#: ../geanyvc/src/geanyvc.c:2647
 msgid "Show diff of file"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2598
+#: ../geanyvc/src/geanyvc.c:2649
 msgid "Show diff of directory"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2600
+#: ../geanyvc/src/geanyvc.c:2651
 msgid "Show diff of basedir"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2603
+#: ../geanyvc/src/geanyvc.c:2654
 msgid "Commit changes"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2605
+#: ../geanyvc/src/geanyvc.c:2656
 msgid "Show status"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2607
+#: ../geanyvc/src/geanyvc.c:2658
 msgid "Revert single file"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2609
+#: ../geanyvc/src/geanyvc.c:2660
 msgid "Revert directory"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2611
+#: ../geanyvc/src/geanyvc.c:2662
 msgid "Revert base directory"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2613
+#: ../geanyvc/src/geanyvc.c:2664
 msgid "Update file"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2643
+#: ../geanyvc/src/geanyvc.c:2694
 msgid "_VC"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2650
+#: ../geanyvc/src/geanyvc.c:2701
 msgid "_Version Control"
 msgstr ""
 
 #. Status of basedir
-#: ../geanyvc/src/geanyvc.c:2672
+#: ../geanyvc/src/geanyvc.c:2723
 msgid "_Status"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2674
+#: ../geanyvc/src/geanyvc.c:2725
 msgid "Show status."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2681
+#: ../geanyvc/src/geanyvc.c:2732
 msgid "Update from remote repository."
 msgstr ""
 
 #. Commit all changes
-#: ../geanyvc/src/geanyvc.c:2686
+#: ../geanyvc/src/geanyvc.c:2737
 msgid "_Commit..."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2688
+#: ../geanyvc/src/geanyvc.c:2739
 msgid "Commit changes."
 msgstr ""
 
@@ -4832,33 +4832,6 @@ msgstr ""
 
 #: ../geniuspaste/src/geniuspaste.c:959
 msgid "_Paste it!"
-msgstr ""
-
-#: ../git-changebar/data/prefs.ui.h:1
-msgid "_Monitor repository for changes"
-msgstr ""
-
-#: ../git-changebar/data/prefs.ui.h:2
-msgid ""
-"Whether to automatically update the diff in order to maintain it up to date "
-"when the underlying Git repository changes.  This should generally be "
-"enabled for optimal user experience."
-msgstr ""
-
-#: ../git-changebar/data/prefs.ui.h:3
-msgid "_Added lines:"
-msgstr ""
-
-#: ../git-changebar/data/prefs.ui.h:4
-msgid "_Changed lines:"
-msgstr ""
-
-#: ../git-changebar/data/prefs.ui.h:5
-msgid "_Removed lines:"
-msgstr ""
-
-#: ../git-changebar/data/prefs.ui.h:6
-msgid "Colors"
 msgstr ""
 
 #: ../git-changebar/src/gcb-plugin.c:62
@@ -5037,8 +5010,8 @@ msgstr ""
 #: ../lipsum/src/lipsum.c:184 ../sendmail/src/sendmail.c:396
 #, c-format
 msgid ""
-"Your configuration directory has been successfully moved from \"%s\" to \"%s"
-"\"."
+"Your configuration directory has been successfully moved from \"%s\" to "
+"\"%s\"."
 msgstr ""
 
 #: ../lipsum/src/lipsum.c:199
@@ -5201,7 +5174,7 @@ msgstr ""
 msgid "Unable to read value for '%s' key: %s"
 msgstr ""
 
-#: ../multiterm/src/tab-label.vala:62 ../treebrowser/src/treebrowser.c:2132
+#: ../multiterm/src/tab-label.vala:62 ../treebrowser/src/treebrowser.c:2137
 msgid "Terminal"
 msgstr ""
 
@@ -5239,112 +5212,6 @@ msgstr ""
 msgid "Show Overview"
 msgstr ""
 
-#: ../overview/data/prefs.ui.h:1
-msgid ""
-"The amount to zoom the overview sidebar. This should probably negative if "
-"you want the sidebar zoomed out."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:2
-msgid "Zoom Level:"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:3
-msgid "The width of the overview sidebar."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:4
-msgid "Width:"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:5
-msgid ""
-"The number of lines to scroll at a time when scrolling the overview sidebar."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:6
-msgid "Scroll Lines:"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:7
-msgid "Position on left"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:8
-msgid ""
-"Position the overview bar on the left rather than the right (requires Geany "
-"1.25 or greater)."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:9
-msgid "Hide tooltip"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:10
-msgid ""
-"Hide the tooltip that is displayed when mousing over the overview that shows "
-"line, column and position information."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:11
-msgid "Hide editor scrollbar"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:12
-msgid ""
-"Whether to hide Geany's regular editor scrollbar while the overview bar is "
-"visible."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:13
-msgid "Disable overlay"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:14
-msgid ""
-"Turn off drawing overlay, which shows the region of the main editor view "
-"that is currently in view, ontop of the overview bar."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:15 ../scope/data/scope.glade.h:130
-#: ../scope/data/scope_gtk3.glade.h:130
-msgid "Options"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:16
-msgid ""
-"The color and opacity of the overlay drawn ontop of the overlay sidebar."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:17
-msgid "Color:"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:18
-msgid ""
-"The color and opacity of the border drawn around the revealed area in the "
-"overview sidebar. Set to the same as Overlay Color to disable."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:19
-msgid "Outline Color:"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:20
-msgid "Draw over visible area"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:21
-msgid ""
-"When checked it will draw the overlay ontop of the area that is visible in "
-"the main editor view, when unchecked, it will do the opposite and draw the "
-"overlay everywhere but the visible area, \"revealing\" the visible part."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:22
-msgid "Overlay"
-msgstr ""
-
 #: ../pairtaghighlighter/src/pair_tag_highlighter.c:43
 msgid "Pair Tag Highlighter"
 msgstr ""
@@ -5367,144 +5234,6 @@ msgstr ""
 
 #: ../pairtaghighlighter/src/pair_tag_highlighter.c:504
 msgid "Select To Matching Tag"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:1
-msgid "_Translation Helper"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:2
-msgid "_Previous String"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:3 ../pohelper/src/gph-plugin.c:1590
-msgid "Go to previous string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:4
-msgid "_Next String"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:5 ../pohelper/src/gph-plugin.c:1593
-msgid "Go to next string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:6
-msgid "Pre_vious Untranslated"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:7 ../pohelper/src/gph-plugin.c:1596
-msgid "Go to previous untranslated string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:8
-msgid "Next _Untranslated"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:9 ../pohelper/src/gph-plugin.c:1599
-msgid "Go to next untranslated string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:10
-msgid "Previous Fu_zzy"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:11 ../pohelper/src/gph-plugin.c:1602
-msgid "Go to previous fuzzily translated string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:12
-msgid "Next _Fuzzy"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:13 ../pohelper/src/gph-plugin.c:1605
-msgid "Go to next fuzzily translated string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:14
-msgid "Previous Untranslated or Fuzz_y"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:15 ../pohelper/src/gph-plugin.c:1608
-msgid "Go to previous untranslated or fuzzy string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:16
-msgid "Next Untranslated _or Fuzzy"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:17 ../pohelper/src/gph-plugin.c:1612
-msgid "Go to next untranslated or fuzzy string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:18 ../pohelper/src/gph-plugin.c:1623
-msgid "Toggle current translation fuzziness"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:19
-msgid "_Toggle Fuzziness"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:20
-msgid "Paste _Message as Translation"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:21
-msgid "Paste the original untranslated string to the translation"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:22 ../pohelper/src/gph-plugin.c:1620
-msgid "Reflow the current translation string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:23
-msgid "_Reflow Translation"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:24 ../pohelper/src/gph-plugin.c:1626
-msgid "Show statistics of the current document"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:25
-msgid "_Show stats"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:26
-msgid ""
-"Whether to update the translation headers (author, revision date, ...) upon "
-"file save"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:27
-msgid "Update _Headers Upon Save"
-msgstr ""
-
-#: ../pohelper/data/stats.ui.h:1
-msgid "Translation statistics"
-msgstr ""
-
-#: ../pohelper/data/stats.ui.h:2
-msgid "Choose a color for translated strings"
-msgstr ""
-
-#: ../pohelper/data/stats.ui.h:3
-msgid "Choose a color for fuzzily translated strings"
-msgstr ""
-
-#: ../pohelper/data/stats.ui.h:4
-msgid "Choose a color for untranslated strings"
-msgstr ""
-
-#: ../pohelper/data/stats.ui.h:5
-msgid "Translated:"
-msgstr ""
-
-#: ../pohelper/data/stats.ui.h:6
-msgid "Fuzzy:"
-msgstr ""
-
-#: ../pohelper/data/stats.ui.h:7
-msgid "Untranslated:"
 msgstr ""
 
 #: ../pohelper/src/gph-plugin.c:40
@@ -5535,8 +5264,52 @@ msgstr ""
 msgid "%u (%.3g%%)"
 msgstr ""
 
+#: ../pohelper/src/gph-plugin.c:1590
+msgid "Go to previous string"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1593
+msgid "Go to next string"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1596
+msgid "Go to previous untranslated string"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1599
+msgid "Go to next untranslated string"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1602
+msgid "Go to previous fuzzily translated string"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1605
+msgid "Go to next fuzzily translated string"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1608
+msgid "Go to previous untranslated or fuzzy string"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1612
+msgid "Go to next untranslated or fuzzy string"
+msgstr ""
+
 #: ../pohelper/src/gph-plugin.c:1616
 msgid "Paste original untranslated string to translation"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1620
+msgid "Reflow the current translation string"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1623
+msgid "Toggle current translation fuzziness"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1626
+msgid "Show statistics of the current document"
 msgstr ""
 
 #: ../pohelper/src/gph-plugin.c:1833
@@ -5797,7 +5570,7 @@ msgid "Add"
 msgstr ""
 
 #: ../projectorganizer/src/prjorg-sidebar.c:390
-#: ../treebrowser/src/treebrowser.c:2356
+#: ../treebrowser/src/treebrowser.c:2361
 msgid "New File"
 msgstr ""
 
@@ -6407,6 +6180,10 @@ msgstr ""
 msgid "<b>Others</b>"
 msgstr ""
 
+#: ../scope/data/scope.glade.h:130 ../scope/data/scope_gtk3.glade.h:130
+msgid "Options"
+msgstr ""
+
 #: ../scope/data/scope.glade.h:131 ../scope/data/scope_gtk3.glade.h:131
 msgid "_Import"
 msgstr ""
@@ -6961,11 +6738,11 @@ msgid "Checks the spelling of the current document."
 msgstr ""
 
 #: ../spellcheck/src/scplugin.c:225
-msgid "Run Spell Check"
+msgid "Run spell check once"
 msgstr ""
 
-#: ../spellcheck/src/scplugin.c:228
-msgid "Toggle Check While Typing"
+#: ../spellcheck/src/scplugin.c:228 ../spellcheck/src/scplugin.c:333
+msgid "Toggle spell check"
 msgstr ""
 
 #. initialise the dialog
@@ -6991,10 +6768,6 @@ msgstr ""
 
 #: ../spellcheck/src/scplugin.c:325
 msgid "<b>Interface</b>"
-msgstr ""
-
-#: ../spellcheck/src/scplugin.c:333
-msgid "Check spelling while typing"
 msgstr ""
 
 #: ../spellcheck/src/scplugin.c:336
@@ -7027,52 +6800,52 @@ msgstr ""
 msgid "<b>Behavior</b>"
 msgstr ""
 
-#: ../spellcheck/src/gui.c:76
+#: ../spellcheck/src/gui.c:88
 msgid "Spell checking while typing is now enabled"
 msgstr ""
 
-#: ../spellcheck/src/gui.c:78
+#: ../spellcheck/src/gui.c:90
 msgid "Spell checking while typing is now disabled"
 msgstr ""
 
-#: ../spellcheck/src/gui.c:326
+#: ../spellcheck/src/gui.c:323
 msgid "More..."
 msgstr ""
 
-#: ../spellcheck/src/gui.c:347
+#: ../spellcheck/src/gui.c:344
 msgid "(No Suggestions)"
 msgstr ""
 
-#: ../spellcheck/src/gui.c:360
+#: ../spellcheck/src/gui.c:357
 #, c-format
 msgid "Add \"%s\" to Dictionary"
 msgstr ""
 
-#: ../spellcheck/src/gui.c:368
+#: ../spellcheck/src/gui.c:365
 msgid "Ignore All"
 msgstr ""
 
-#: ../spellcheck/src/gui.c:441
+#: ../spellcheck/src/gui.c:438
 msgid ""
 "Search term is too long to provide\n"
 "spelling suggestions in the editor menu."
 msgstr ""
 
-#: ../spellcheck/src/gui.c:447
+#: ../spellcheck/src/gui.c:444
 msgid "Perform Spell Check"
 msgstr ""
 
-#: ../spellcheck/src/gui.c:609
+#: ../spellcheck/src/gui.c:606
 #, c-format
 msgid "Default (%s)"
 msgstr ""
 
-#: ../spellcheck/src/gui.c:620
+#: ../spellcheck/src/gui.c:617
 #, c-format
-msgid "Toggle spell check while typing (current language: %s)"
+msgid "Toggle spell check (current language: %s)"
 msgstr ""
 
-#: ../spellcheck/src/gui.c:698
+#: ../spellcheck/src/gui.c:695
 msgid "Spelling Suggestions"
 msgstr ""
 
@@ -7165,149 +6938,149 @@ msgstr ""
 msgid "Could not execute configured external command '%s' (%s)."
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1089
+#: ../treebrowser/src/treebrowser.c:1093
 msgid "NewDirectory"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1091
+#: ../treebrowser/src/treebrowser.c:1095
 msgid "NewFile"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1096
+#: ../treebrowser/src/treebrowser.c:1100
 #, c-format
 msgid ""
 "Target file '%s' exists.\n"
 "Do you really want to replace it with an empty file?"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1142
+#: ../treebrowser/src/treebrowser.c:1146
 #, c-format
 msgid "Do you really want to delete '%s' ?"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1255 ../treebrowser/src/treebrowser.c:1257
+#: ../treebrowser/src/treebrowser.c:1259 ../treebrowser/src/treebrowser.c:1261
 msgid "Go _Up"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1263 ../treebrowser/src/treebrowser.c:1265
+#: ../treebrowser/src/treebrowser.c:1267 ../treebrowser/src/treebrowser.c:1269
 msgid "Set _Path From Document"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1271 ../treebrowser/src/treebrowser.c:1273
+#: ../treebrowser/src/treebrowser.c:1275 ../treebrowser/src/treebrowser.c:1277
 msgid "_Open Externally"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1279
+#: ../treebrowser/src/treebrowser.c:1283
 msgid "Open _Terminal"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1284 ../treebrowser/src/treebrowser.c:1286
+#: ../treebrowser/src/treebrowser.c:1288 ../treebrowser/src/treebrowser.c:1290
 msgid "Set as _Root"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1293 ../treebrowser/src/treebrowser.c:1295
+#: ../treebrowser/src/treebrowser.c:1297 ../treebrowser/src/treebrowser.c:1299
 msgid "Refres_h"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1301 ../treebrowser/src/treebrowser.c:1303
+#: ../treebrowser/src/treebrowser.c:1305 ../treebrowser/src/treebrowser.c:1307
 msgid "_Find in Files"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1313 ../treebrowser/src/treebrowser.c:1315
+#: ../treebrowser/src/treebrowser.c:1317 ../treebrowser/src/treebrowser.c:1319
 msgid "N_ew Folder"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1321 ../treebrowser/src/treebrowser.c:1323
+#: ../treebrowser/src/treebrowser.c:1325 ../treebrowser/src/treebrowser.c:1327
 msgid "_New File"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1329 ../treebrowser/src/treebrowser.c:1331
+#: ../treebrowser/src/treebrowser.c:1333 ../treebrowser/src/treebrowser.c:1335
 msgid "Rena_me"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1350 ../treebrowser/src/treebrowser.c:1352
+#: ../treebrowser/src/treebrowser.c:1354 ../treebrowser/src/treebrowser.c:1356
 #, c-format
 msgid "Close: %s"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1359 ../treebrowser/src/treebrowser.c:1361
+#: ../treebrowser/src/treebrowser.c:1363 ../treebrowser/src/treebrowser.c:1365
 #, c-format
 msgid "Clo_se Child Documents "
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1368 ../treebrowser/src/treebrowser.c:1370
+#: ../treebrowser/src/treebrowser.c:1372 ../treebrowser/src/treebrowser.c:1374
 msgid "_Copy Full Path to Clipboard"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1381 ../treebrowser/src/treebrowser.c:1383
+#: ../treebrowser/src/treebrowser.c:1385 ../treebrowser/src/treebrowser.c:1387
 msgid "E_xpand All"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1389 ../treebrowser/src/treebrowser.c:1391
+#: ../treebrowser/src/treebrowser.c:1393 ../treebrowser/src/treebrowser.c:1395
 msgid "Coll_apse All"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1399
+#: ../treebrowser/src/treebrowser.c:1403
 msgid "Show Boo_kmarks"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1404
+#: ../treebrowser/src/treebrowser.c:1408
 msgid "Sho_w Hidden Files"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1409
+#: ../treebrowser/src/treebrowser.c:1413
 msgid "Show Tool_bars"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1747
+#: ../treebrowser/src/treebrowser.c:1751
 #, c-format
 msgid "Target file '%s' exists, do you really want to replace it?"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1883
+#: ../treebrowser/src/treebrowser.c:1887
 msgid "Go up"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1893 ../treebrowser/src/treebrowser.c:2360
+#: ../treebrowser/src/treebrowser.c:1897 ../treebrowser/src/treebrowser.c:2365
 msgid "Refresh"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1903
+#: ../treebrowser/src/treebrowser.c:1907
 msgid "Home"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1913
+#: ../treebrowser/src/treebrowser.c:1917
 msgid "Set path from document"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1923
+#: ../treebrowser/src/treebrowser.c:1927
 msgid "Track path"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1933
+#: ../treebrowser/src/treebrowser.c:1937
 msgid "Hide bars"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1943
+#: ../treebrowser/src/treebrowser.c:1947
 msgid ""
 "Filter (*.c;*.h;*.cpp), and if you want temporary filter using the '!' "
 "reverse try for example this '!;*.c;*.h;*.cpp'"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1948
+#: ../treebrowser/src/treebrowser.c:1952
 msgid "Addressbar for example '/projects/my-project'"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1973
+#: ../treebrowser/src/treebrowser.c:1977
 msgid "Tree Browser"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2114
+#: ../treebrowser/src/treebrowser.c:2118
 msgid "External open command"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2124
-#, c-format
+#: ../treebrowser/src/treebrowser.c:2129
+#, no-c-format
 msgid ""
 "The command to execute when using \"Open with\". You can use %f and %d "
 "wildcards.\n"
@@ -7316,117 +7089,117 @@ msgid ""
 "filename"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2143
+#: ../treebrowser/src/treebrowser.c:2148
 msgid "The terminal to use with the command \"Open Terminal\""
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2149
+#: ../treebrowser/src/treebrowser.c:2154
 msgid "Toolbar"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2151
+#: ../treebrowser/src/treebrowser.c:2156
 msgid "Hidden"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2152
+#: ../treebrowser/src/treebrowser.c:2157
 msgid "Top"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2153
+#: ../treebrowser/src/treebrowser.c:2158
 msgid "Bottom"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2158
+#: ../treebrowser/src/treebrowser.c:2163
 msgid "If position is changed, the option require plugin restart."
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2162
+#: ../treebrowser/src/treebrowser.c:2167
 msgid "Show icons"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2164
+#: ../treebrowser/src/treebrowser.c:2169
 msgid "None"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2165
+#: ../treebrowser/src/treebrowser.c:2170
 msgid "Base"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2166
+#: ../treebrowser/src/treebrowser.c:2171
 msgid "Content-type"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2172
+#: ../treebrowser/src/treebrowser.c:2177
 msgid "Show hidden files"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2181
+#: ../treebrowser/src/treebrowser.c:2186
 msgid "On Windows, this just hide files that are prefixed with '.' (dot)"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2183
+#: ../treebrowser/src/treebrowser.c:2188
 msgid "Hide object files"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2192
+#: ../treebrowser/src/treebrowser.c:2197
 msgid ""
 "Don't show generated object files in the file browser, this includes *.o, *."
 "obj. *.so, *.dll, *.a, *.lib"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2194
+#: ../treebrowser/src/treebrowser.c:2199
 msgid "Reverse filter"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2203
+#: ../treebrowser/src/treebrowser.c:2208
 msgid "Follow current document"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2212
+#: ../treebrowser/src/treebrowser.c:2217
 msgid "Single click, open document and focus it"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2221
+#: ../treebrowser/src/treebrowser.c:2226
 msgid "Double click open directory"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2230
+#: ../treebrowser/src/treebrowser.c:2235
 msgid "On delete file, close it if is opened"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2239
+#: ../treebrowser/src/treebrowser.c:2244
 msgid "Focus editor on file open"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2248
+#: ../treebrowser/src/treebrowser.c:2253
 msgid "Show tree lines"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2257
+#: ../treebrowser/src/treebrowser.c:2262
 msgid "Show bookmarks"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2266
+#: ../treebrowser/src/treebrowser.c:2271
 msgid "Open new files"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2350
+#: ../treebrowser/src/treebrowser.c:2355
 msgid "Focus File List"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2352
+#: ../treebrowser/src/treebrowser.c:2357
 msgid "Focus Path Entry"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2354
+#: ../treebrowser/src/treebrowser.c:2359
 msgid "Rename Object"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2358
+#: ../treebrowser/src/treebrowser.c:2363
 msgid "New Folder"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2362
+#: ../treebrowser/src/treebrowser.c:2367
 msgid "Track Current"
 msgstr ""
 
@@ -8074,13 +7847,6 @@ msgstr ""
 #: ../workbench/src/sidebar.c:857 ../workbench/src/sidebar.c:1384
 msgid "No workbench opened."
 msgstr ""
-
-#: ../workbench/src/sidebar.c:875
-#, c-format
-msgid "%s: %u Project"
-msgid_plural "%s: %u Projects"
-msgstr[0] ""
-msgstr[1] ""
 
 #: ../workbench/src/sidebar.c:886
 msgid ""

--- a/po/es.po
+++ b/po/es.po
@@ -8,8 +8,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Geany-Plugins 1.38\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-30 03:19+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/geany/geany/issues\n"
+"POT-Creation-Date: 2022-06-28 07:39+0200\n"
 "PO-Revision-Date: 2021-09-30 12:17+0200\n"
 "Last-Translator: Lucas Vieites Fariña <lucas.vieites@gmail.com>\n"
 "Language-Team: Español <geany-i18n@uvena.de>\n"
@@ -24,27 +24,27 @@ msgstr ""
 msgid "(Empty Line)"
 msgstr "(Línea vacía)"
 
-#: ../addons/src/ao_bookmarklist.c:315
+#: ../addons/src/ao_bookmarklist.c:331
 msgid "_Remove Bookmark"
 msgstr "Elimina_r marcador"
 
 #. Translators: Number is meant at this point.
-#: ../addons/src/ao_bookmarklist.c:342
+#: ../addons/src/ao_bookmarklist.c:358
 msgid "No."
 msgstr "Nº"
 
-#: ../addons/src/ao_bookmarklist.c:350 ../devhelp/src/dhp-object.c:494
+#: ../addons/src/ao_bookmarklist.c:366 ../devhelp/src/dhp-object.c:494
 #: ../devhelp/devhelp/dh-window.c:1142
 msgid "Contents"
 msgstr "Contenido"
 
-#: ../addons/src/ao_bookmarklist.c:383 ../treebrowser/src/treebrowser.c:666
+#: ../addons/src/ao_bookmarklist.c:399 ../treebrowser/src/treebrowser.c:666
 #: ../webhelper/src/gwh-plugin.c:328
 msgid "Bookmarks"
 msgstr "Marcadores"
 
 #. complete update
-#: ../addons/src/ao_tasks.c:373 ../geanyvc/src/geanyvc.c:2679
+#: ../addons/src/ao_tasks.c:373 ../geanyvc/src/geanyvc.c:2730
 msgid "_Update"
 msgstr "_Actualizar"
 
@@ -165,10 +165,10 @@ msgstr "Copia la ruta de archivo del documento actual al portapapeles. "
 #: ../addons/src/addons.c:364 ../autoclose/src/autoclose.c:920
 #: ../codenav/src/codenavigation.c:281 ../latex/src/latex.c:208
 #: ../latex/src/latex.c:293 ../geanyprj/src/geanyprj.c:176
-#: ../geanyvc/src/geanyvc.c:2079 ../geniuspaste/src/geniuspaste.c:336
+#: ../geanyvc/src/geanyvc.c:2130 ../geniuspaste/src/geniuspaste.c:336
 #: ../lineoperations/src/lo_prefs.c:58 ../sendmail/src/sendmail.c:128
 #: ../sendmail/src/sendmail.c:293 ../spellcheck/src/scplugin.c:124
-#: ../treebrowser/src/treebrowser.c:2102
+#: ../treebrowser/src/treebrowser.c:2106
 #: ../updatechecker/src/updatechecker.c:262
 msgid "Plugin configuration directory could not be created."
 msgstr "No se ha podido crear el directorio de configuración del complemento."
@@ -749,7 +749,7 @@ msgstr ""
 msgid "Error loading file"
 msgstr "Error al cargar un archivo"
 
-#. setting asyncronous mode
+#. setting asynchronous mode
 #. setting null-stop array printing
 #. enable pretty printing
 #: ../debugger/src/dbm_gdb.c:789 ../debugger/src/dbm_gdb.c:792
@@ -1153,7 +1153,7 @@ msgid "A developers' help browser for GNOME"
 msgstr "Un visor de ayuda para el desarrollador de Gnome"
 
 #. Create the current file Submenu
-#: ../devhelp/devhelp/dh-window.c:759 ../geanyvc/src/geanyvc.c:2660
+#: ../devhelp/devhelp/dh-window.c:759 ../geanyvc/src/geanyvc.c:2711
 msgid "_File"
 msgstr "_Archivo"
 
@@ -1187,11 +1187,11 @@ msgstr "Nueva pes_taña"
 msgid "_Print…"
 msgstr "I_mprimir..."
 
-#: ../devhelp/devhelp/dh-window.c:782 ../devhelp/devhelp/eggfindbar.c:342
+#: ../devhelp/devhelp/dh-window.c:782
 msgid "Find Next"
 msgstr "Buscar siguiente"
 
-#: ../devhelp/devhelp/dh-window.c:784 ../devhelp/devhelp/eggfindbar.c:329
+#: ../devhelp/devhelp/dh-window.c:784
 msgid "Find Previous"
 msgstr "Buscar anterior"
 
@@ -1379,7 +1379,7 @@ msgstr ""
 "En este momento este plugin no tiene mantenedor. ¿Te gustaría ayudar a "
 "contribuir a este plugin?"
 
-#: ../geanydoc/src/geanydoc.c:159 ../geanyvc/src/geanyvc.c:442
+#: ../geanydoc/src/geanydoc.c:159 ../geanyvc/src/geanyvc.c:448
 msgid "Could not parse the output of command"
 msgstr "No se ha podido interpretar la salida del comando"
 
@@ -3103,7 +3103,7 @@ msgstr ""
 "Error en el módulo «%s» en la función %s()\n"
 "no hay argumentos suficientes para el comando «%s».\n"
 
-#: ../geanylua/glspi_sci.c:637 ../geanylua/glspi_app.c:406
+#: ../geanylua/glspi_sci.c:729 ../geanylua/glspi_app.c:406
 #, c-format
 msgid ""
 "Error in module \"%s\" at function %s():\n"
@@ -3112,7 +3112,7 @@ msgstr ""
 "Error en el módulo «%s» en la función %s()\n"
 "comando desconocido «%s» para el argumento nº1.\n"
 
-#: ../geanylua/glspi_sci.c:781
+#: ../geanylua/glspi_sci.c:924
 #, c-format
 msgid ""
 "Error in module \"%s\" at function %s():\n"
@@ -3123,7 +3123,7 @@ msgstr ""
 " tabla inválida en el argumento nº %d:\n"
 " indicador «%s» desconocido para el elemento nº %d\n"
 
-#: ../geanylua/glspi_sci.c:785
+#: ../geanylua/glspi_sci.c:928
 msgid "<too large to display>"
 msgstr "<demasiado grande para mostrar>"
 
@@ -3922,7 +3922,7 @@ msgid "New _Below"
 msgstr "Nuevo _debajo"
 
 #: ../geanymacro/src/geanymacro.c:1824 ../geanymacro/src/geanymacro.c:2120
-#: ../treebrowser/src/treebrowser.c:1338 ../treebrowser/src/treebrowser.c:1340
+#: ../treebrowser/src/treebrowser.c:1342 ../treebrowser/src/treebrowser.c:1344
 msgid "_Delete"
 msgstr "_Eliminar"
 
@@ -4339,8 +4339,8 @@ msgstr ""
 msgid "a key with fingerprint"
 msgstr "un clave con huella dactilar"
 
-#: ../geanypg/src/verify_aux.c:66 ../spellcheck/src/gui.c:610
-#: ../spellcheck/src/gui.c:621
+#: ../geanypg/src/verify_aux.c:66 ../spellcheck/src/gui.c:607
+#: ../spellcheck/src/gui.c:618
 msgid "unknown"
 msgstr "desconocido"
 
@@ -4655,49 +4655,49 @@ msgstr ""
 "En este momento este plugin no tiene mantenedor. ¿Te gustaría ayudar a "
 "contribuir a este plugin?"
 
-#: ../geanyvc/src/geanyvc.c:501
+#: ../geanyvc/src/geanyvc.c:507
 #, c-format
 msgid "geanyvc: s_spawn_sync error: %s"
 msgstr "Error de geanyvc: s_spawn_sync: %s"
 
-#: ../geanyvc/src/geanyvc.c:587
+#: ../geanyvc/src/geanyvc.c:593
 #, c-format
 msgid "File %s: action %s executed via %s."
 msgstr "Archivo %s: acción %s ejecutado vía %s."
 
-#: ../geanyvc/src/geanyvc.c:646 ../geanyvc/src/geanyvc.c:657
-#, c-format
-msgid "geanyvc: vcdiff_file_activated: Unable to rename '%s' to '%s'"
+#: ../geanyvc/src/geanyvc.c:633 ../geanyvc/src/geanyvc.c:643
+#, fuzzy, c-format
+msgid "geanyvc: diff_external: Unable to rename '%s' to '%s'"
 msgstr "geanyvc: vcdiff_file_activated: No se puede renombrar «%s» a «%s»"
 
-#: ../geanyvc/src/geanyvc.c:683 ../geanyvc/src/geanyvc.c:733
+#: ../geanyvc/src/geanyvc.c:698 ../geanyvc/src/geanyvc.c:784
 msgid "No changes were made."
 msgstr "No se han realizado cambios."
 
-#: ../geanyvc/src/geanyvc.c:760
+#: ../geanyvc/src/geanyvc.c:811
 msgid "No history available"
 msgstr "No hay historia disponible"
 
-#: ../geanyvc/src/geanyvc.c:953 ../geanyvc/src/geanyvc.c:961
+#: ../geanyvc/src/geanyvc.c:1004 ../geanyvc/src/geanyvc.c:1012
 #, c-format
 msgid "Do you really want to revert: %s?"
 msgstr "¿Está seguro de que quiere revertir «%s»?"
 
-#: ../geanyvc/src/geanyvc.c:969
+#: ../geanyvc/src/geanyvc.c:1020
 #, c-format
 msgid "Do you really want to add: %s?"
 msgstr "¿Está seguro de que quiere añadir «%s»?"
 
-#: ../geanyvc/src/geanyvc.c:976
+#: ../geanyvc/src/geanyvc.c:1027
 #, c-format
 msgid "Do you really want to remove: %s?"
 msgstr "¿Está seguro de que quiere eliminar «%s»?"
 
-#: ../geanyvc/src/geanyvc.c:999
+#: ../geanyvc/src/geanyvc.c:1050
 msgid "Do you really want to update?"
 msgstr "¿Está seguro de que quiere actualizar?"
 
-#: ../geanyvc/src/geanyvc.c:1126
+#: ../geanyvc/src/geanyvc.c:1177
 msgid ""
 "The resulting differences cannot be displayed because the changes are too "
 "big to display here and would slow down the UI significantly.\n"
@@ -4710,48 +4710,48 @@ msgstr ""
 "/nPara ver las diferencias cancele este diálogo y abra las diferencias "
 "directamente en Geany mediante el menú GeanyVC (Directorio base -> Diff)."
 
-#: ../geanyvc/src/geanyvc.c:1280
+#: ../geanyvc/src/geanyvc.c:1331
 msgid "Commit Y/N"
 msgstr "Commit S/N"
 
-#: ../geanyvc/src/geanyvc.c:1290
+#: ../geanyvc/src/geanyvc.c:1341
 msgid "Status"
 msgstr "Estado"
 
-#: ../geanyvc/src/geanyvc.c:1297
+#: ../geanyvc/src/geanyvc.c:1348
 msgid "Path"
 msgstr "Ruta"
 
-#: ../geanyvc/src/geanyvc.c:1414
+#: ../geanyvc/src/geanyvc.c:1465
 msgid "Choose a previous commit message"
 msgstr "Elija un mensaje de commit anterior"
 
-#: ../geanyvc/src/geanyvc.c:1476
+#: ../geanyvc/src/geanyvc.c:1527
 #, c-format
 msgid "Line: %d Column: %d"
 msgstr "Línea: %d Columna: %d"
 
-#: ../geanyvc/src/geanyvc.c:1523
+#: ../geanyvc/src/geanyvc.c:1574
 msgid "Commit"
 msgstr "Commit"
 
-#: ../geanyvc/src/geanyvc.c:1564
+#: ../geanyvc/src/geanyvc.c:1615
 msgid "_De-/select all files"
 msgstr "_De/seleccionar todos los archivos"
 
-#: ../geanyvc/src/geanyvc.c:1608
+#: ../geanyvc/src/geanyvc.c:1659
 msgid "<b>Commit message:</b>"
 msgstr "<b>Mensaje de commit:</b>"
 
-#: ../geanyvc/src/geanyvc.c:1632
+#: ../geanyvc/src/geanyvc.c:1683
 msgid "C_ommit"
 msgstr "C_ommit"
 
-#: ../geanyvc/src/geanyvc.c:1740
+#: ../geanyvc/src/geanyvc.c:1791
 msgid "Nothing to commit."
 msgstr "No hay nada para commit."
 
-#: ../geanyvc/src/geanyvc.c:1788
+#: ../geanyvc/src/geanyvc.c:1839
 #, c-format
 msgid ""
 "Error initializing GeanyVC spell checking: %s. Check your configuration."
@@ -4759,26 +4759,26 @@ msgstr ""
 "Ha ocurrido un error al iniciar la comprobación ortográfica GeanyVC: %s. "
 "Compruebe su configuración."
 
-#: ../geanyvc/src/geanyvc.c:1823
+#: ../geanyvc/src/geanyvc.c:1874
 #, c-format
 msgid "Commit failed (status: %d, error: %s)."
 msgstr "Ha fallado el commit (estado: %d, error: %s)."
 
-#: ../geanyvc/src/geanyvc.c:1824
+#: ../geanyvc/src/geanyvc.c:1875
 msgid "Commit failed; see status in the Message window."
 msgstr "Ha fallado el commit, vea el estado en la ventana de mensajes."
 
-#: ../geanyvc/src/geanyvc.c:1829
+#: ../geanyvc/src/geanyvc.c:1880
 msgid "Changes committed."
 msgstr "Los cambios han sido enviados."
 
-#: ../geanyvc/src/geanyvc.c:2151
+#: ../geanyvc/src/geanyvc.c:2202
 msgid "Set Changed-flag for document tabs created by the plugin"
 msgstr ""
 "Fijar el indicador «Modificado» para pestañas de documentos creados por el "
 "complemento"
 
-#: ../geanyvc/src/geanyvc.c:2154
+#: ../geanyvc/src/geanyvc.c:2205
 msgid ""
 "If this option is activated, every new by the VC-plugin created document tab "
 "will be marked as changed. Even this option is useful in some cases, it "
@@ -4789,43 +4789,43 @@ msgstr ""
 "puede ser útil en algunos casos, podrá causar la aparición de una molesta "
 "cantidad de diálogos del tipo «¿Desea guardar el archivo?»."
 
-#: ../geanyvc/src/geanyvc.c:2162
+#: ../geanyvc/src/geanyvc.c:2213
 msgid "Confirm adding new files to a VCS"
 msgstr "Confirmar la adición de archivos nuevos al VCS"
 
-#: ../geanyvc/src/geanyvc.c:2165
+#: ../geanyvc/src/geanyvc.c:2216
 msgid "Shows a confirmation dialog on adding a new (created) file to VCS."
 msgstr "Muestra un diálogo de confirmación al añadir un archivo nuevo al VCS."
 
-#: ../geanyvc/src/geanyvc.c:2171
+#: ../geanyvc/src/geanyvc.c:2222
 msgid "Maximize commit dialog"
 msgstr "Maximizar el diálogo de commit"
 
-#: ../geanyvc/src/geanyvc.c:2172
+#: ../geanyvc/src/geanyvc.c:2223
 msgid "Show commit dialog maximize."
 msgstr "Mostrar el diálogo de commit maximizado."
 
-#: ../geanyvc/src/geanyvc.c:2178
+#: ../geanyvc/src/geanyvc.c:2229
 msgid "Use external diff viewer"
 msgstr "Usar un visor de diffs externo"
 
-#: ../geanyvc/src/geanyvc.c:2180
+#: ../geanyvc/src/geanyvc.c:2231
 msgid "Use external diff viewer for file diff."
 msgstr "Usar un programa externo para visualizar diferencias entre archivos."
 
-#: ../geanyvc/src/geanyvc.c:2186
+#: ../geanyvc/src/geanyvc.c:2237
 msgid "Show VC entries at editor menu"
 msgstr "Mostrar menús de VC en el menú del editor"
 
-#: ../geanyvc/src/geanyvc.c:2188
+#: ../geanyvc/src/geanyvc.c:2239
 msgid "Show entries for VC functions inside editor menu"
 msgstr "Mostrar opciones de menú para funciones de VC en los menús del editor"
 
-#: ../geanyvc/src/geanyvc.c:2193
+#: ../geanyvc/src/geanyvc.c:2244
 msgid "Attach menu to menubar"
 msgstr "Añadir menú a la barra de menús"
 
-#: ../geanyvc/src/geanyvc.c:2195
+#: ../geanyvc/src/geanyvc.c:2246
 msgid ""
 "Whether menu for this plugin are getting placed either inside tools menu or "
 "directly inside Geany's menubar. Will take in account after next start of "
@@ -4835,215 +4835,215 @@ msgstr ""
 "o directamente den la barra de menús de Geany. Se tendrá en cuenta después "
 "de reiniciar GeanyVC"
 
-#: ../geanyvc/src/geanyvc.c:2203
+#: ../geanyvc/src/geanyvc.c:2254
 msgid "Enable CVS"
 msgstr "Activar CVS"
 
-#: ../geanyvc/src/geanyvc.c:2208
+#: ../geanyvc/src/geanyvc.c:2259
 msgid "Enable GIT"
 msgstr "Activar GIT"
 
-#: ../geanyvc/src/geanyvc.c:2213
+#: ../geanyvc/src/geanyvc.c:2264
 msgid "Enable Fossil"
 msgstr "Activar Fossil"
 
-#: ../geanyvc/src/geanyvc.c:2218
+#: ../geanyvc/src/geanyvc.c:2269
 msgid "Enable SVN"
 msgstr "Activar SVN"
 
-#: ../geanyvc/src/geanyvc.c:2223
+#: ../geanyvc/src/geanyvc.c:2274
 msgid "Enable SVK"
 msgstr "Activar SVK"
 
-#: ../geanyvc/src/geanyvc.c:2228
+#: ../geanyvc/src/geanyvc.c:2279
 msgid "Enable Bazaar"
 msgstr "Activar Bazaar"
 
-#: ../geanyvc/src/geanyvc.c:2233
+#: ../geanyvc/src/geanyvc.c:2284
 msgid "Enable Mercurial"
 msgstr "Activar Mercurial"
 
-#: ../geanyvc/src/geanyvc.c:2239
+#: ../geanyvc/src/geanyvc.c:2290
 msgid "Spellcheck language"
 msgstr "Idioma de comprobación ortográfica"
 
 #. Diff of current file
 #. Diff of the current dir
 #. Complete diff of base directory
-#: ../geanyvc/src/geanyvc.c:2368 ../geanyvc/src/geanyvc.c:2463
-#: ../geanyvc/src/geanyvc.c:2503
+#: ../geanyvc/src/geanyvc.c:2419 ../geanyvc/src/geanyvc.c:2514
+#: ../geanyvc/src/geanyvc.c:2554
 msgid "_Diff"
 msgstr "_Diff"
 
-#: ../geanyvc/src/geanyvc.c:2371
+#: ../geanyvc/src/geanyvc.c:2422
 msgid "Make a diff from the current active file"
 msgstr "Crear un diff del archivo actual"
 
 #. Revert current file
 #. Revert current dir
 #. Revert everything
-#: ../geanyvc/src/geanyvc.c:2376 ../geanyvc/src/geanyvc.c:2472
-#: ../geanyvc/src/geanyvc.c:2511
+#: ../geanyvc/src/geanyvc.c:2427 ../geanyvc/src/geanyvc.c:2523
+#: ../geanyvc/src/geanyvc.c:2562
 msgid "_Revert"
 msgstr "_Revertir"
 
-#: ../geanyvc/src/geanyvc.c:2379
+#: ../geanyvc/src/geanyvc.c:2430
 msgid "Restore pristine working copy file (undo local edits)."
 msgstr "Restaurar una copia limpia de trabajo (deshacer ediciones locales)."
 
 #. Blame for current file
-#: ../geanyvc/src/geanyvc.c:2388
+#: ../geanyvc/src/geanyvc.c:2439
 msgid "_Blame"
 msgstr "_Culpar"
 
-#: ../geanyvc/src/geanyvc.c:2391
+#: ../geanyvc/src/geanyvc.c:2442
 msgid "Shows the changes made at one file per revision and author."
 msgstr "Muestra los cambios hechos a un archivo por revisión y autor."
 
 #. History/log of current file
 #. History/log of the current dir
 #. Complete History/Log of base directory
-#: ../geanyvc/src/geanyvc.c:2398 ../geanyvc/src/geanyvc.c:2482
-#: ../geanyvc/src/geanyvc.c:2523
+#: ../geanyvc/src/geanyvc.c:2449 ../geanyvc/src/geanyvc.c:2533
+#: ../geanyvc/src/geanyvc.c:2574
 msgid "_History (log)"
 msgstr "_Historial (registro)"
 
-#: ../geanyvc/src/geanyvc.c:2401
+#: ../geanyvc/src/geanyvc.c:2452
 msgid "Shows the log of the current file"
 msgstr "Muestra el registro del archivo actual"
 
 #. base version of the current file
-#: ../geanyvc/src/geanyvc.c:2406
+#: ../geanyvc/src/geanyvc.c:2457
 msgid "_Original"
 msgstr "_Original"
 
-#: ../geanyvc/src/geanyvc.c:2409
+#: ../geanyvc/src/geanyvc.c:2460
 msgid "Shows the original of the current file"
 msgstr "Muestra el original del archivo actual"
 
 #. add current file
-#: ../geanyvc/src/geanyvc.c:2417
+#: ../geanyvc/src/geanyvc.c:2468
 msgid "_Add to Version Control"
 msgstr "_Añadir a control de versiones"
 
-#: ../geanyvc/src/geanyvc.c:2419
+#: ../geanyvc/src/geanyvc.c:2470
 msgid "Add file to repository."
 msgstr "Añadir un archivo al repositorio."
 
 #. remove current file
-#: ../geanyvc/src/geanyvc.c:2425
+#: ../geanyvc/src/geanyvc.c:2476
 msgid "_Remove from Version Control"
 msgstr "Elimina_r del Control de Versiones"
 
-#: ../geanyvc/src/geanyvc.c:2427
+#: ../geanyvc/src/geanyvc.c:2478
 msgid "Remove file from repository."
 msgstr "Eliminar el archivo del repositorio."
 
-#: ../geanyvc/src/geanyvc.c:2460
+#: ../geanyvc/src/geanyvc.c:2511
 msgid "_Directory"
 msgstr "_Directorio"
 
-#: ../geanyvc/src/geanyvc.c:2466
+#: ../geanyvc/src/geanyvc.c:2517
 msgid "Make a diff from the directory of the current active file"
 msgstr "Realizar un diff del directorio del archivo actual"
 
-#: ../geanyvc/src/geanyvc.c:2475
+#: ../geanyvc/src/geanyvc.c:2526
 msgid "Restore original files in the current folder (undo local edits)."
 msgstr ""
 "Restaurar los archivos originales en el directorio actual (deshacer "
 "ediciones locales)."
 
-#: ../geanyvc/src/geanyvc.c:2485
+#: ../geanyvc/src/geanyvc.c:2536
 msgid "Shows the log of the current directory"
 msgstr "Muestra el registro del directorio actual"
 
-#: ../geanyvc/src/geanyvc.c:2499
+#: ../geanyvc/src/geanyvc.c:2550
 msgid "_Base Directory"
 msgstr "Directorio _Base"
 
-#: ../geanyvc/src/geanyvc.c:2505
+#: ../geanyvc/src/geanyvc.c:2556
 msgid "Make a diff from the top VC directory"
 msgstr "Crear un diff desde el directorio superior de CV"
 
-#: ../geanyvc/src/geanyvc.c:2513
+#: ../geanyvc/src/geanyvc.c:2564
 msgid "Revert any local edits."
 msgstr "Revertir cualquier modificación local"
 
-#: ../geanyvc/src/geanyvc.c:2526
+#: ../geanyvc/src/geanyvc.c:2577
 msgid "Shows the log of the top VC directory"
 msgstr "Muestra el registro del directorio superior de CV"
 
-#: ../geanyvc/src/geanyvc.c:2543
+#: ../geanyvc/src/geanyvc.c:2594
 msgid "_VC file Actions"
 msgstr "Acciones de archivo _VC"
 
-#: ../geanyvc/src/geanyvc.c:2552
+#: ../geanyvc/src/geanyvc.c:2603
 msgid "VC _Commit..."
 msgstr "_Commit CV..."
 
-#: ../geanyvc/src/geanyvc.c:2596
+#: ../geanyvc/src/geanyvc.c:2647
 msgid "Show diff of file"
 msgstr "Mostrar diff del archivo"
 
-#: ../geanyvc/src/geanyvc.c:2598
+#: ../geanyvc/src/geanyvc.c:2649
 msgid "Show diff of directory"
 msgstr "Mostrar diff del directorio"
 
-#: ../geanyvc/src/geanyvc.c:2600
+#: ../geanyvc/src/geanyvc.c:2651
 msgid "Show diff of basedir"
 msgstr "Mostrar diff del directorio base"
 
-#: ../geanyvc/src/geanyvc.c:2603
+#: ../geanyvc/src/geanyvc.c:2654
 msgid "Commit changes"
 msgstr "Hacer commit de los cambios"
 
-#: ../geanyvc/src/geanyvc.c:2605
+#: ../geanyvc/src/geanyvc.c:2656
 msgid "Show status"
 msgstr "Mostrar estado"
 
-#: ../geanyvc/src/geanyvc.c:2607
+#: ../geanyvc/src/geanyvc.c:2658
 msgid "Revert single file"
 msgstr "Revertir un solo archivo"
 
-#: ../geanyvc/src/geanyvc.c:2609
+#: ../geanyvc/src/geanyvc.c:2660
 msgid "Revert directory"
 msgstr "Revertir directorio"
 
-#: ../geanyvc/src/geanyvc.c:2611
+#: ../geanyvc/src/geanyvc.c:2662
 msgid "Revert base directory"
 msgstr "Revertir directorio base"
 
-#: ../geanyvc/src/geanyvc.c:2613
+#: ../geanyvc/src/geanyvc.c:2664
 msgid "Update file"
 msgstr "Actualizar archivo"
 
-#: ../geanyvc/src/geanyvc.c:2643
+#: ../geanyvc/src/geanyvc.c:2694
 msgid "_VC"
 msgstr "C_V"
 
-#: ../geanyvc/src/geanyvc.c:2650
+#: ../geanyvc/src/geanyvc.c:2701
 msgid "_Version Control"
 msgstr "Control de _versiones"
 
 #. Status of basedir
-#: ../geanyvc/src/geanyvc.c:2672
+#: ../geanyvc/src/geanyvc.c:2723
 msgid "_Status"
 msgstr "E_stado"
 
-#: ../geanyvc/src/geanyvc.c:2674
+#: ../geanyvc/src/geanyvc.c:2725
 msgid "Show status."
 msgstr "Mostrar estado."
 
-#: ../geanyvc/src/geanyvc.c:2681
+#: ../geanyvc/src/geanyvc.c:2732
 msgid "Update from remote repository."
 msgstr "Actualizar desde el repositorio remoto."
 
 #. Commit all changes
-#: ../geanyvc/src/geanyvc.c:2686
+#: ../geanyvc/src/geanyvc.c:2737
 msgid "_Commit..."
 msgstr "_Commit..."
 
-#: ../geanyvc/src/geanyvc.c:2688
+#: ../geanyvc/src/geanyvc.c:2739
 msgid "Commit changes."
 msgstr "Hacer commit de los cambios."
 
@@ -5169,36 +5169,6 @@ msgstr "Mostrar su pegado en una nueva pestaña del navegador"
 #: ../geniuspaste/src/geniuspaste.c:959
 msgid "_Paste it!"
 msgstr "_Péguelo"
-
-#: ../git-changebar/data/prefs.ui.h:1
-msgid "_Monitor repository for changes"
-msgstr "_Monitorear el repositorio por si hay cambios"
-
-#: ../git-changebar/data/prefs.ui.h:2
-msgid ""
-"Whether to automatically update the diff in order to maintain it up to date "
-"when the underlying Git repository changes.  This should generally be "
-"enabled for optimal user experience."
-msgstr ""
-"Indica si desea actualizar el diff automáticamente para mantenerlo al día "
-"con los cambios del repositorio Git subyacente. Esto debería estar activado "
-"para obtener una experiencia de usuario óptima."
-
-#: ../git-changebar/data/prefs.ui.h:3
-msgid "_Added lines:"
-msgstr "Líneas _añadidas:"
-
-#: ../git-changebar/data/prefs.ui.h:4
-msgid "_Changed lines:"
-msgstr "Líneas _cambiadas:"
-
-#: ../git-changebar/data/prefs.ui.h:5
-msgid "_Removed lines:"
-msgstr "Líneas _eliminadas:"
-
-#: ../git-changebar/data/prefs.ui.h:6
-msgid "Colors"
-msgstr "Colores"
 
 #: ../git-changebar/src/gcb-plugin.c:62
 msgid "Git Change Bar"
@@ -5388,8 +5358,8 @@ msgstr ""
 #: ../lipsum/src/lipsum.c:184 ../sendmail/src/sendmail.c:396
 #, c-format
 msgid ""
-"Your configuration directory has been successfully moved from \"%s\" to \"%s"
-"\"."
+"Your configuration directory has been successfully moved from \"%s\" to "
+"\"%s\"."
 msgstr ""
 "Su directorio de configuración ha sido movido con éxito de «%s» a «%s»."
 
@@ -5557,7 +5527,7 @@ msgstr "No se ha podido escribir en el archivo de configuración: %s"
 msgid "Unable to read value for '%s' key: %s"
 msgstr "No se ha podido leer el valor de la clave «%s»: %s"
 
-#: ../multiterm/src/tab-label.vala:62 ../treebrowser/src/treebrowser.c:2132
+#: ../multiterm/src/tab-label.vala:62 ../treebrowser/src/treebrowser.c:2137
 msgid "Terminal"
 msgstr "Terminal"
 
@@ -5595,133 +5565,6 @@ msgstr "Línea <b>%d</b>, Columna <b>%d</b>, Posición <b>%d</b>"
 msgid "Show Overview"
 msgstr "Mostrar vista global"
 
-#: ../overview/data/prefs.ui.h:1
-msgid ""
-"The amount to zoom the overview sidebar. This should probably negative if "
-"you want the sidebar zoomed out."
-msgstr ""
-"La cantidad de zoom de la barra lateral de vista global. Esto deberá ser "
-"negativo si desea la barra lateral sin zoom."
-
-#: ../overview/data/prefs.ui.h:2
-msgid "Zoom Level:"
-msgstr "Nivel de zoom:"
-
-#: ../overview/data/prefs.ui.h:3
-msgid "The width of the overview sidebar."
-msgstr "La anchura de la barra lateral de vista global."
-
-#: ../overview/data/prefs.ui.h:4
-msgid "Width:"
-msgstr "Anchura:"
-
-#: ../overview/data/prefs.ui.h:5
-msgid ""
-"The number of lines to scroll at a time when scrolling the overview sidebar."
-msgstr ""
-"La cantidad de líneas que se desplazará la barra lateral de vista global al "
-"navegar."
-
-#: ../overview/data/prefs.ui.h:6
-msgid "Scroll Lines:"
-msgstr "Líneas de desplazamiento:"
-
-#: ../overview/data/prefs.ui.h:7
-msgid "Position on left"
-msgstr "Colocar a la izquierda"
-
-#: ../overview/data/prefs.ui.h:8
-msgid ""
-"Position the overview bar on the left rather than the right (requires Geany "
-"1.25 or greater)."
-msgstr ""
-"Colocar la barra de vista global a la izquierda (necesita Geany 1.15 o "
-"superior)."
-
-#: ../overview/data/prefs.ui.h:9
-msgid "Hide tooltip"
-msgstr "Ocultar ayuda emergente"
-
-#: ../overview/data/prefs.ui.h:10
-msgid ""
-"Hide the tooltip that is displayed when mousing over the overview that shows "
-"line, column and position information."
-msgstr ""
-"Oculta la ayuda emergente que indica línea, columna y posicón y se muestra "
-"al colocar el ratón sobre la vista global."
-
-#: ../overview/data/prefs.ui.h:11
-msgid "Hide editor scrollbar"
-msgstr "Ocultar la barra de desplazamiento del editor"
-
-#: ../overview/data/prefs.ui.h:12
-msgid ""
-"Whether to hide Geany's regular editor scrollbar while the overview bar is "
-"visible."
-msgstr ""
-"Indica si se oculta la barra de desplazamiento de Geany cuando está visible "
-"la barra de vista global."
-
-#: ../overview/data/prefs.ui.h:13
-msgid "Disable overlay"
-msgstr "Desactivar cobertura"
-
-#: ../overview/data/prefs.ui.h:14
-msgid ""
-"Turn off drawing overlay, which shows the region of the main editor view "
-"that is currently in view, ontop of the overview bar."
-msgstr ""
-"Desactiva la cobertura, que muestra la región de la vista del editor "
-"principal, encima de la barra de vista global."
-
-#: ../overview/data/prefs.ui.h:15 ../scope/data/scope.glade.h:130
-#: ../scope/data/scope_gtk3.glade.h:130
-msgid "Options"
-msgstr "Opciones"
-
-#: ../overview/data/prefs.ui.h:16
-msgid ""
-"The color and opacity of the overlay drawn ontop of the overlay sidebar."
-msgstr ""
-"El color y la opacidad de la cobertura dibujada encima de la barra lateral "
-"de cobertura."
-
-#: ../overview/data/prefs.ui.h:17
-msgid "Color:"
-msgstr "Color:"
-
-#: ../overview/data/prefs.ui.h:18
-msgid ""
-"The color and opacity of the border drawn around the revealed area in the "
-"overview sidebar. Set to the same as Overlay Color to disable."
-msgstr ""
-"El color y la opcidad del borde alrededor del área mostrada en la barra "
-"lateral de vista global. Fijar al mismo que Color de cobertura para "
-"desactivar."
-
-#: ../overview/data/prefs.ui.h:19
-msgid "Outline Color:"
-msgstr "Color del borde:"
-
-#: ../overview/data/prefs.ui.h:20
-msgid "Draw over visible area"
-msgstr "Dibujar por encima del área visible"
-
-#: ../overview/data/prefs.ui.h:21
-msgid ""
-"When checked it will draw the overlay ontop of the area that is visible in "
-"the main editor view, when unchecked, it will do the opposite and draw the "
-"overlay everywhere but the visible area, \"revealing\" the visible part."
-msgstr ""
-"Si se marca dibujará la cobertura encima del área que está visible en la "
-"vista principal del editor. Al contrario hará lo opuesto, es decir, dibujará "
-"la cobertura en todas partes excepto el área visible, \"revelando\" el área "
-"visible."
-
-#: ../overview/data/prefs.ui.h:22
-msgid "Overlay"
-msgstr "Cobertura"
-
 #: ../pairtaghighlighter/src/pair_tag_highlighter.c:43
 msgid "Pair Tag Highlighter"
 msgstr "Resaltador de etiquetas parejas"
@@ -5745,146 +5588,6 @@ msgstr "Ir a etiqueta correspondiente"
 #: ../pairtaghighlighter/src/pair_tag_highlighter.c:504
 msgid "Select To Matching Tag"
 msgstr "Seleccionar hasta etiqueta correspondiente"
-
-#: ../pohelper/data/menus.ui.h:1
-msgid "_Translation Helper"
-msgstr "Ayudante de _traducción"
-
-#: ../pohelper/data/menus.ui.h:2
-msgid "_Previous String"
-msgstr "Cadena _anterior"
-
-#: ../pohelper/data/menus.ui.h:3 ../pohelper/src/gph-plugin.c:1590
-msgid "Go to previous string"
-msgstr "Ir a la cadena anterior"
-
-#: ../pohelper/data/menus.ui.h:4
-msgid "_Next String"
-msgstr "Cadena _siguiente"
-
-#: ../pohelper/data/menus.ui.h:5 ../pohelper/src/gph-plugin.c:1593
-msgid "Go to next string"
-msgstr "Ir a la siguiente cadena"
-
-#: ../pohelper/data/menus.ui.h:6
-msgid "Pre_vious Untranslated"
-msgstr "A_nterior sin traducir"
-
-#: ../pohelper/data/menus.ui.h:7 ../pohelper/src/gph-plugin.c:1596
-msgid "Go to previous untranslated string"
-msgstr "Ir a la anterior cadena sin traducir"
-
-#: ../pohelper/data/menus.ui.h:8
-msgid "Next _Untranslated"
-msgstr "Siguien_te sin traducir"
-
-#: ../pohelper/data/menus.ui.h:9 ../pohelper/src/gph-plugin.c:1599
-msgid "Go to next untranslated string"
-msgstr "Ir a la siguiente cadena sin traducir"
-
-#: ../pohelper/data/menus.ui.h:10
-msgid "Previous Fu_zzy"
-msgstr "Difu_sa anterior"
-
-#: ../pohelper/data/menus.ui.h:11 ../pohelper/src/gph-plugin.c:1602
-msgid "Go to previous fuzzily translated string"
-msgstr "Ir a la traducción difusa anterior"
-
-#: ../pohelper/data/menus.ui.h:12
-msgid "Next _Fuzzy"
-msgstr "Siguiente di_fusa"
-
-#: ../pohelper/data/menus.ui.h:13 ../pohelper/src/gph-plugin.c:1605
-msgid "Go to next fuzzily translated string"
-msgstr "Ir a la siguiente traducción difusa"
-
-#: ../pohelper/data/menus.ui.h:14
-msgid "Previous Untranslated or Fuzz_y"
-msgstr "Anterior sin traducir o difu_sa"
-
-#: ../pohelper/data/menus.ui.h:15 ../pohelper/src/gph-plugin.c:1608
-msgid "Go to previous untranslated or fuzzy string"
-msgstr "Ir a la anterior cadena sin traducir o difusa"
-
-#: ../pohelper/data/menus.ui.h:16
-msgid "Next Untranslated _or Fuzzy"
-msgstr "Siguiente sin traducir _o difusa"
-
-#: ../pohelper/data/menus.ui.h:17 ../pohelper/src/gph-plugin.c:1612
-msgid "Go to next untranslated or fuzzy string"
-msgstr "Ir a la siguiente cadena sin traducir o difusa"
-
-#: ../pohelper/data/menus.ui.h:18 ../pohelper/src/gph-plugin.c:1623
-msgid "Toggle current translation fuzziness"
-msgstr "Conmutar estado de traducción difusa"
-
-#: ../pohelper/data/menus.ui.h:19
-msgid "_Toggle Fuzziness"
-msgstr "Conmu_tar difuso"
-
-#: ../pohelper/data/menus.ui.h:20
-msgid "Paste _Message as Translation"
-msgstr "Pegar _original como traducción"
-
-#: ../pohelper/data/menus.ui.h:21
-msgid "Paste the original untranslated string to the translation"
-msgstr "Pegar la cadena original sin traducir como traducción"
-
-#: ../pohelper/data/menus.ui.h:22 ../pohelper/src/gph-plugin.c:1620
-msgid "Reflow the current translation string"
-msgstr "Refluir la cadena de traducción actual"
-
-#: ../pohelper/data/menus.ui.h:23
-msgid "_Reflow Translation"
-msgstr "_Refluir traducción"
-
-#: ../pohelper/data/menus.ui.h:24 ../pohelper/src/gph-plugin.c:1626
-msgid "Show statistics of the current document"
-msgstr "Mostrar estadísticas del documento actual"
-
-#: ../pohelper/data/menus.ui.h:25
-msgid "_Show stats"
-msgstr "Mo_strar estadísticas"
-
-#: ../pohelper/data/menus.ui.h:26
-msgid ""
-"Whether to update the translation headers (author, revision date, ...) upon "
-"file save"
-msgstr ""
-"Indica si se actualizan las cabeceras de la traducción (autor, fecha de "
-"revisión, etc.) al guardar el archivo"
-
-#: ../pohelper/data/menus.ui.h:27
-msgid "Update _Headers Upon Save"
-msgstr "Actualizar _cabeceras al guardar"
-
-#: ../pohelper/data/stats.ui.h:1
-msgid "Translation statistics"
-msgstr "Estadísticas de traducción"
-
-#: ../pohelper/data/stats.ui.h:2
-msgid "Choose a color for translated strings"
-msgstr "Elija un color para las cadenas traducidas"
-
-#: ../pohelper/data/stats.ui.h:3
-msgid "Choose a color for fuzzily translated strings"
-msgstr "Elija un color para las cadenas de traducción difusa"
-
-#: ../pohelper/data/stats.ui.h:4
-msgid "Choose a color for untranslated strings"
-msgstr "Elija un color para las cadenas sin traducir"
-
-#: ../pohelper/data/stats.ui.h:5
-msgid "Translated:"
-msgstr "Traducido:"
-
-#: ../pohelper/data/stats.ui.h:6
-msgid "Fuzzy:"
-msgstr "Difuso:"
-
-#: ../pohelper/data/stats.ui.h:7
-msgid "Untranslated:"
-msgstr "Sin traducir:"
 
 #: ../pohelper/src/gph-plugin.c:40
 msgid "Translation Helper"
@@ -5914,9 +5617,53 @@ msgstr "<b>Sin traducir:</b> %.3g%%"
 msgid "%u (%.3g%%)"
 msgstr "%u (%.3g%%)"
 
+#: ../pohelper/src/gph-plugin.c:1590
+msgid "Go to previous string"
+msgstr "Ir a la cadena anterior"
+
+#: ../pohelper/src/gph-plugin.c:1593
+msgid "Go to next string"
+msgstr "Ir a la siguiente cadena"
+
+#: ../pohelper/src/gph-plugin.c:1596
+msgid "Go to previous untranslated string"
+msgstr "Ir a la anterior cadena sin traducir"
+
+#: ../pohelper/src/gph-plugin.c:1599
+msgid "Go to next untranslated string"
+msgstr "Ir a la siguiente cadena sin traducir"
+
+#: ../pohelper/src/gph-plugin.c:1602
+msgid "Go to previous fuzzily translated string"
+msgstr "Ir a la traducción difusa anterior"
+
+#: ../pohelper/src/gph-plugin.c:1605
+msgid "Go to next fuzzily translated string"
+msgstr "Ir a la siguiente traducción difusa"
+
+#: ../pohelper/src/gph-plugin.c:1608
+msgid "Go to previous untranslated or fuzzy string"
+msgstr "Ir a la anterior cadena sin traducir o difusa"
+
+#: ../pohelper/src/gph-plugin.c:1612
+msgid "Go to next untranslated or fuzzy string"
+msgstr "Ir a la siguiente cadena sin traducir o difusa"
+
 #: ../pohelper/src/gph-plugin.c:1616
 msgid "Paste original untranslated string to translation"
 msgstr "Pegar cadena original sin traducir como traducción"
+
+#: ../pohelper/src/gph-plugin.c:1620
+msgid "Reflow the current translation string"
+msgstr "Refluir la cadena de traducción actual"
+
+#: ../pohelper/src/gph-plugin.c:1623
+msgid "Toggle current translation fuzziness"
+msgstr "Conmutar estado de traducción difusa"
+
+#: ../pohelper/src/gph-plugin.c:1626
+msgid "Show statistics of the current document"
+msgstr "Mostrar estadísticas del documento actual"
 
 #: ../pohelper/src/gph-plugin.c:1833
 #, c-format
@@ -6208,7 +5955,7 @@ msgid "Add"
 msgstr "Añadir"
 
 #: ../projectorganizer/src/prjorg-sidebar.c:390
-#: ../treebrowser/src/treebrowser.c:2356
+#: ../treebrowser/src/treebrowser.c:2361
 msgid "New File"
 msgstr "Archivo nuevo"
 
@@ -6819,6 +6566,10 @@ msgstr "Mostrar ayuda emergen_te"
 msgid "<b>Others</b>"
 msgstr "<b>Otros</b>"
 
+#: ../scope/data/scope.glade.h:130 ../scope/data/scope_gtk3.glade.h:130
+msgid "Options"
+msgstr "Opciones"
+
 #: ../scope/data/scope.glade.h:131 ../scope/data/scope_gtk3.glade.h:131
 msgid "_Import"
 msgstr "_Importar"
@@ -7410,12 +7161,14 @@ msgid "Checks the spelling of the current document."
 msgstr "Comprueba la ortografía del documento actual."
 
 #: ../spellcheck/src/scplugin.c:225
-msgid "Run Spell Check"
+#, fuzzy
+msgid "Run spell check once"
 msgstr "Ejecutar comprobación ortográfica"
 
-#: ../spellcheck/src/scplugin.c:228
-msgid "Toggle Check While Typing"
-msgstr "Conmutar corrección al escribir"
+#: ../spellcheck/src/scplugin.c:228 ../spellcheck/src/scplugin.c:333
+#, fuzzy
+msgid "Toggle spell check"
+msgstr "Corrección ortográfica"
 
 #. initialise the dialog
 #: ../spellcheck/src/scplugin.c:239
@@ -7443,10 +7196,6 @@ msgstr "Mostrar palabras mal escritas y sugerencias en la ventana de mensajes"
 #: ../spellcheck/src/scplugin.c:325
 msgid "<b>Interface</b>"
 msgstr "<b>Interfaz</b>"
-
-#: ../spellcheck/src/scplugin.c:333
-msgid "Check spelling while typing"
-msgstr "Corrección al escribir"
 
 #: ../spellcheck/src/scplugin.c:336
 msgid "Check spelling when opening a document"
@@ -7484,32 +7233,32 @@ msgstr ""
 msgid "<b>Behavior</b>"
 msgstr "<b>Comportamiento</b>"
 
-#: ../spellcheck/src/gui.c:76
+#: ../spellcheck/src/gui.c:88
 msgid "Spell checking while typing is now enabled"
 msgstr "Está activada la comprobación ortográfica mientras escribe"
 
-#: ../spellcheck/src/gui.c:78
+#: ../spellcheck/src/gui.c:90
 msgid "Spell checking while typing is now disabled"
 msgstr "Está desactivada la comprobación ortográfica mientras escribe"
 
-#: ../spellcheck/src/gui.c:326
+#: ../spellcheck/src/gui.c:323
 msgid "More..."
 msgstr "Más..."
 
-#: ../spellcheck/src/gui.c:347
+#: ../spellcheck/src/gui.c:344
 msgid "(No Suggestions)"
 msgstr "(No hay sugerencias)"
 
-#: ../spellcheck/src/gui.c:360
+#: ../spellcheck/src/gui.c:357
 #, c-format
 msgid "Add \"%s\" to Dictionary"
 msgstr "Añadir «%s» al diccionario"
 
-#: ../spellcheck/src/gui.c:368
+#: ../spellcheck/src/gui.c:365
 msgid "Ignore All"
 msgstr "Ignorar todo"
 
-#: ../spellcheck/src/gui.c:441
+#: ../spellcheck/src/gui.c:438
 msgid ""
 "Search term is too long to provide\n"
 "spelling suggestions in the editor menu."
@@ -7517,21 +7266,21 @@ msgstr ""
 "El término de búsqueda es demasiado largo\n"
 "para proporcionar sugerencias en el menú."
 
-#: ../spellcheck/src/gui.c:447
+#: ../spellcheck/src/gui.c:444
 msgid "Perform Spell Check"
 msgstr "Realizar comprobación ortográfica"
 
-#: ../spellcheck/src/gui.c:609
+#: ../spellcheck/src/gui.c:606
 #, c-format
 msgid "Default (%s)"
 msgstr "Predeterminado (%s)"
 
-#: ../spellcheck/src/gui.c:620
-#, c-format
-msgid "Toggle spell check while typing (current language: %s)"
+#: ../spellcheck/src/gui.c:617
+#, fuzzy, c-format
+msgid "Toggle spell check (current language: %s)"
 msgstr "Conmutar comprobación ortográfica al escribir (idioma actual: %s)"
 
-#: ../spellcheck/src/gui.c:698
+#: ../spellcheck/src/gui.c:695
 msgid "Spelling Suggestions"
 msgstr "Sugerencias"
 
@@ -7629,15 +7378,15 @@ msgstr "(Vacío)"
 msgid "Could not execute configured external command '%s' (%s)."
 msgstr "No se ha podido ejecutar el comando externo configurado «%s» (%s)."
 
-#: ../treebrowser/src/treebrowser.c:1089
+#: ../treebrowser/src/treebrowser.c:1093
 msgid "NewDirectory"
 msgstr "NewDirectory"
 
-#: ../treebrowser/src/treebrowser.c:1091
+#: ../treebrowser/src/treebrowser.c:1095
 msgid "NewFile"
 msgstr "NewFile"
 
-#: ../treebrowser/src/treebrowser.c:1096
+#: ../treebrowser/src/treebrowser.c:1100
 #, c-format
 msgid ""
 "Target file '%s' exists.\n"
@@ -7646,116 +7395,116 @@ msgstr ""
 "El archivo de destino «%s» existe.\n"
 "¿Está seguro de que desea reemplazarlo con un archivo vacío?"
 
-#: ../treebrowser/src/treebrowser.c:1142
+#: ../treebrowser/src/treebrowser.c:1146
 #, c-format
 msgid "Do you really want to delete '%s' ?"
 msgstr "¿Está seguro de que desea eliminar «%s»?"
 
-#: ../treebrowser/src/treebrowser.c:1255 ../treebrowser/src/treebrowser.c:1257
+#: ../treebrowser/src/treebrowser.c:1259 ../treebrowser/src/treebrowser.c:1261
 msgid "Go _Up"
 msgstr "S_ubir"
 
-#: ../treebrowser/src/treebrowser.c:1263 ../treebrowser/src/treebrowser.c:1265
+#: ../treebrowser/src/treebrowser.c:1267 ../treebrowser/src/treebrowser.c:1269
 msgid "Set _Path From Document"
 msgstr "_Fijar ruta del documento"
 
-#: ../treebrowser/src/treebrowser.c:1271 ../treebrowser/src/treebrowser.c:1273
+#: ../treebrowser/src/treebrowser.c:1275 ../treebrowser/src/treebrowser.c:1277
 msgid "_Open Externally"
 msgstr "_Abrir externamente"
 
-#: ../treebrowser/src/treebrowser.c:1279
+#: ../treebrowser/src/treebrowser.c:1283
 msgid "Open _Terminal"
 msgstr "Abrir _Terminal"
 
-#: ../treebrowser/src/treebrowser.c:1284 ../treebrowser/src/treebrowser.c:1286
+#: ../treebrowser/src/treebrowser.c:1288 ../treebrowser/src/treebrowser.c:1290
 msgid "Set as _Root"
 msgstr "Fijar como _raíz"
 
-#: ../treebrowser/src/treebrowser.c:1293 ../treebrowser/src/treebrowser.c:1295
+#: ../treebrowser/src/treebrowser.c:1297 ../treebrowser/src/treebrowser.c:1299
 msgid "Refres_h"
 msgstr "_Refrescar"
 
-#: ../treebrowser/src/treebrowser.c:1301 ../treebrowser/src/treebrowser.c:1303
+#: ../treebrowser/src/treebrowser.c:1305 ../treebrowser/src/treebrowser.c:1307
 msgid "_Find in Files"
 msgstr "_Buscar en archivos"
 
-#: ../treebrowser/src/treebrowser.c:1313 ../treebrowser/src/treebrowser.c:1315
+#: ../treebrowser/src/treebrowser.c:1317 ../treebrowser/src/treebrowser.c:1319
 msgid "N_ew Folder"
 msgstr "Carpeta nu_eva"
 
-#: ../treebrowser/src/treebrowser.c:1321 ../treebrowser/src/treebrowser.c:1323
+#: ../treebrowser/src/treebrowser.c:1325 ../treebrowser/src/treebrowser.c:1327
 msgid "_New File"
 msgstr "Archivo _nuevo"
 
-#: ../treebrowser/src/treebrowser.c:1329 ../treebrowser/src/treebrowser.c:1331
+#: ../treebrowser/src/treebrowser.c:1333 ../treebrowser/src/treebrowser.c:1335
 msgid "Rena_me"
 msgstr "Reno_mbrar"
 
-#: ../treebrowser/src/treebrowser.c:1350 ../treebrowser/src/treebrowser.c:1352
+#: ../treebrowser/src/treebrowser.c:1354 ../treebrowser/src/treebrowser.c:1356
 #, c-format
 msgid "Close: %s"
 msgstr "Cerrar: %s"
 
-#: ../treebrowser/src/treebrowser.c:1359 ../treebrowser/src/treebrowser.c:1361
+#: ../treebrowser/src/treebrowser.c:1363 ../treebrowser/src/treebrowser.c:1365
 #, c-format
 msgid "Clo_se Child Documents "
 msgstr "_Cerrar documentos hijo"
 
-#: ../treebrowser/src/treebrowser.c:1368 ../treebrowser/src/treebrowser.c:1370
+#: ../treebrowser/src/treebrowser.c:1372 ../treebrowser/src/treebrowser.c:1374
 msgid "_Copy Full Path to Clipboard"
 msgstr "_Copiar ruta completa al portapapeles"
 
-#: ../treebrowser/src/treebrowser.c:1381 ../treebrowser/src/treebrowser.c:1383
+#: ../treebrowser/src/treebrowser.c:1385 ../treebrowser/src/treebrowser.c:1387
 msgid "E_xpand All"
 msgstr "E_xpandir todos"
 
-#: ../treebrowser/src/treebrowser.c:1389 ../treebrowser/src/treebrowser.c:1391
+#: ../treebrowser/src/treebrowser.c:1393 ../treebrowser/src/treebrowser.c:1395
 msgid "Coll_apse All"
 msgstr "Col_apsar todos"
 
-#: ../treebrowser/src/treebrowser.c:1399
+#: ../treebrowser/src/treebrowser.c:1403
 msgid "Show Boo_kmarks"
 msgstr "Mostrar marca_dores"
 
-#: ../treebrowser/src/treebrowser.c:1404
+#: ../treebrowser/src/treebrowser.c:1408
 msgid "Sho_w Hidden Files"
 msgstr "Mostrar archivos _ocultos"
 
-#: ../treebrowser/src/treebrowser.c:1409
+#: ../treebrowser/src/treebrowser.c:1413
 msgid "Show Tool_bars"
 msgstr "Mostrar _barras de herramientas"
 
-#: ../treebrowser/src/treebrowser.c:1747
+#: ../treebrowser/src/treebrowser.c:1751
 #, c-format
 msgid "Target file '%s' exists, do you really want to replace it?"
 msgstr ""
 "El archivo de destino «%s» existe. ¿Está seguro de que desea reemplazarlo?"
 
-#: ../treebrowser/src/treebrowser.c:1883
+#: ../treebrowser/src/treebrowser.c:1887
 msgid "Go up"
 msgstr "Subir"
 
-#: ../treebrowser/src/treebrowser.c:1893 ../treebrowser/src/treebrowser.c:2360
+#: ../treebrowser/src/treebrowser.c:1897 ../treebrowser/src/treebrowser.c:2365
 msgid "Refresh"
 msgstr "Refrescar"
 
-#: ../treebrowser/src/treebrowser.c:1903
+#: ../treebrowser/src/treebrowser.c:1907
 msgid "Home"
 msgstr "Inicio"
 
-#: ../treebrowser/src/treebrowser.c:1913
+#: ../treebrowser/src/treebrowser.c:1917
 msgid "Set path from document"
 msgstr "Fijar ruta del documento"
 
-#: ../treebrowser/src/treebrowser.c:1923
+#: ../treebrowser/src/treebrowser.c:1927
 msgid "Track path"
 msgstr "Rastrear ruta"
 
-#: ../treebrowser/src/treebrowser.c:1933
+#: ../treebrowser/src/treebrowser.c:1937
 msgid "Hide bars"
 msgstr "Ocultar barras"
 
-#: ../treebrowser/src/treebrowser.c:1943
+#: ../treebrowser/src/treebrowser.c:1947
 msgid ""
 "Filter (*.c;*.h;*.cpp), and if you want temporary filter using the '!' "
 "reverse try for example this '!;*.c;*.h;*.cpp'"
@@ -7763,20 +7512,20 @@ msgstr ""
 "Filtro (*.c;*.h;*.cpp), y si quiere un filtro temporal utilice «!», por "
 "ejemplo: '!;*.c;*.h;*.cpp'"
 
-#: ../treebrowser/src/treebrowser.c:1948
+#: ../treebrowser/src/treebrowser.c:1952
 msgid "Addressbar for example '/projects/my-project'"
 msgstr "Barra de direcciones, por ejemplo «/proyectos/mi-proyecto»"
 
-#: ../treebrowser/src/treebrowser.c:1973
+#: ../treebrowser/src/treebrowser.c:1977
 msgid "Tree Browser"
 msgstr "Visor de árbol"
 
-#: ../treebrowser/src/treebrowser.c:2114
+#: ../treebrowser/src/treebrowser.c:2118
 msgid "External open command"
 msgstr "Comando de apertura externa"
 
-#: ../treebrowser/src/treebrowser.c:2124
-#, c-format
+#: ../treebrowser/src/treebrowser.c:2129
+#, no-c-format
 msgid ""
 "The command to execute when using \"Open with\". You can use %f and %d "
 "wildcards.\n"
@@ -7789,61 +7538,61 @@ msgstr ""
 "%f se reemplazará con el nombre de archivo con la ruta completa\n"
 "%d se reemplazará con la ruta del directorio sin el nombre de archivo"
 
-#: ../treebrowser/src/treebrowser.c:2143
+#: ../treebrowser/src/treebrowser.c:2148
 msgid "The terminal to use with the command \"Open Terminal\""
 msgstr "La terminal que se usará con el comando «Abrir terminal»"
 
-#: ../treebrowser/src/treebrowser.c:2149
+#: ../treebrowser/src/treebrowser.c:2154
 msgid "Toolbar"
 msgstr "Barra de herramientas"
 
-#: ../treebrowser/src/treebrowser.c:2151
+#: ../treebrowser/src/treebrowser.c:2156
 msgid "Hidden"
 msgstr "Oculta"
 
-#: ../treebrowser/src/treebrowser.c:2152
+#: ../treebrowser/src/treebrowser.c:2157
 msgid "Top"
 msgstr "Arriba"
 
-#: ../treebrowser/src/treebrowser.c:2153
+#: ../treebrowser/src/treebrowser.c:2158
 msgid "Bottom"
 msgstr "Abajo"
 
-#: ../treebrowser/src/treebrowser.c:2158
+#: ../treebrowser/src/treebrowser.c:2163
 msgid "If position is changed, the option require plugin restart."
 msgstr "Si se cambia la posición será necesario reiniciar el complemento."
 
-#: ../treebrowser/src/treebrowser.c:2162
+#: ../treebrowser/src/treebrowser.c:2167
 msgid "Show icons"
 msgstr "Mostrar iconos"
 
-#: ../treebrowser/src/treebrowser.c:2164
+#: ../treebrowser/src/treebrowser.c:2169
 msgid "None"
 msgstr "Ninguno"
 
-#: ../treebrowser/src/treebrowser.c:2165
+#: ../treebrowser/src/treebrowser.c:2170
 msgid "Base"
 msgstr "Base"
 
-#: ../treebrowser/src/treebrowser.c:2166
+#: ../treebrowser/src/treebrowser.c:2171
 msgid "Content-type"
 msgstr "Tipo de contenido"
 
-#: ../treebrowser/src/treebrowser.c:2172
+#: ../treebrowser/src/treebrowser.c:2177
 msgid "Show hidden files"
 msgstr "Mostrar archivos ocultos"
 
-#: ../treebrowser/src/treebrowser.c:2181
+#: ../treebrowser/src/treebrowser.c:2186
 msgid "On Windows, this just hide files that are prefixed with '.' (dot)"
 msgstr ""
 "En Windows esto solamente oculta archivos cuyo nombre empieza con un "
 "«.» (punto)."
 
-#: ../treebrowser/src/treebrowser.c:2183
+#: ../treebrowser/src/treebrowser.c:2188
 msgid "Hide object files"
 msgstr "Ocultar archivos objeto"
 
-#: ../treebrowser/src/treebrowser.c:2192
+#: ../treebrowser/src/treebrowser.c:2197
 msgid ""
 "Don't show generated object files in the file browser, this includes *.o, *."
 "obj. *.so, *.dll, *.a, *.lib"
@@ -7851,59 +7600,59 @@ msgstr ""
 "No mostrar los archivos objeto generados en el visor de archivos, esto "
 "incluye *.o, *.obj. *.so, *.dll, *.a, *.lib"
 
-#: ../treebrowser/src/treebrowser.c:2194
+#: ../treebrowser/src/treebrowser.c:2199
 msgid "Reverse filter"
 msgstr "Invertir filtro"
 
-#: ../treebrowser/src/treebrowser.c:2203
+#: ../treebrowser/src/treebrowser.c:2208
 msgid "Follow current document"
 msgstr "Seguir documento actual"
 
-#: ../treebrowser/src/treebrowser.c:2212
+#: ../treebrowser/src/treebrowser.c:2217
 msgid "Single click, open document and focus it"
 msgstr "Una sola pulsación abre el documento y lo enfoca"
 
-#: ../treebrowser/src/treebrowser.c:2221
+#: ../treebrowser/src/treebrowser.c:2226
 msgid "Double click open directory"
 msgstr "Doble pulsación para abrir un directorio"
 
-#: ../treebrowser/src/treebrowser.c:2230
+#: ../treebrowser/src/treebrowser.c:2235
 msgid "On delete file, close it if is opened"
 msgstr "Al borrar un archivo, cerrarlo si está abierto"
 
-#: ../treebrowser/src/treebrowser.c:2239
+#: ../treebrowser/src/treebrowser.c:2244
 msgid "Focus editor on file open"
 msgstr "Enfocar el editor al abrir un archivo"
 
-#: ../treebrowser/src/treebrowser.c:2248
+#: ../treebrowser/src/treebrowser.c:2253
 msgid "Show tree lines"
 msgstr "Mostrar líneas de árbol"
 
-#: ../treebrowser/src/treebrowser.c:2257
+#: ../treebrowser/src/treebrowser.c:2262
 msgid "Show bookmarks"
 msgstr "Mostrar marcadores"
 
-#: ../treebrowser/src/treebrowser.c:2266
+#: ../treebrowser/src/treebrowser.c:2271
 msgid "Open new files"
 msgstr "Abrir archivos nuevos"
 
-#: ../treebrowser/src/treebrowser.c:2350
+#: ../treebrowser/src/treebrowser.c:2355
 msgid "Focus File List"
 msgstr "Enfocar lista de archivos"
 
-#: ../treebrowser/src/treebrowser.c:2352
+#: ../treebrowser/src/treebrowser.c:2357
 msgid "Focus Path Entry"
 msgstr "Enfocar entrada de ruta"
 
-#: ../treebrowser/src/treebrowser.c:2354
+#: ../treebrowser/src/treebrowser.c:2359
 msgid "Rename Object"
 msgstr "Renombrar objeto"
 
-#: ../treebrowser/src/treebrowser.c:2358
+#: ../treebrowser/src/treebrowser.c:2363
 msgid "New Folder"
 msgstr "Carpeta nueva"
 
-#: ../treebrowser/src/treebrowser.c:2362
+#: ../treebrowser/src/treebrowser.c:2367
 msgid "Track Current"
 msgstr "Rastrear ruta actual"
 
@@ -8591,13 +8340,6 @@ msgstr "No hay directorios"
 msgid "No workbench opened."
 msgstr "No hay área de trabajo abierta."
 
-#: ../workbench/src/sidebar.c:875
-#, c-format
-msgid "%s: %u Project"
-msgid_plural "%s: %u Projects"
-msgstr[0] "%s: %u Proyectos"
-msgstr[1] "%s: %u Proyectos"
-
 #: ../workbench/src/sidebar.c:886
 msgid ""
 "Add a project using the context menu\n"
@@ -8711,6 +8453,218 @@ msgstr "Recortes XML"
 #: ../xmlsnippets/src/plugin.c:45
 msgid "Autocompletes XML/HTML tags using snippets."
 msgstr "Autocompleta etiquetas XML/HTML mediante recortes"
+
+#~ msgid "_Monitor repository for changes"
+#~ msgstr "_Monitorear el repositorio por si hay cambios"
+
+#~ msgid ""
+#~ "Whether to automatically update the diff in order to maintain it up to "
+#~ "date when the underlying Git repository changes.  This should generally "
+#~ "be enabled for optimal user experience."
+#~ msgstr ""
+#~ "Indica si desea actualizar el diff automáticamente para mantenerlo al día "
+#~ "con los cambios del repositorio Git subyacente. Esto debería estar "
+#~ "activado para obtener una experiencia de usuario óptima."
+
+#~ msgid "_Added lines:"
+#~ msgstr "Líneas _añadidas:"
+
+#~ msgid "_Changed lines:"
+#~ msgstr "Líneas _cambiadas:"
+
+#~ msgid "_Removed lines:"
+#~ msgstr "Líneas _eliminadas:"
+
+#~ msgid "Colors"
+#~ msgstr "Colores"
+
+#~ msgid ""
+#~ "The amount to zoom the overview sidebar. This should probably negative if "
+#~ "you want the sidebar zoomed out."
+#~ msgstr ""
+#~ "La cantidad de zoom de la barra lateral de vista global. Esto deberá ser "
+#~ "negativo si desea la barra lateral sin zoom."
+
+#~ msgid "Zoom Level:"
+#~ msgstr "Nivel de zoom:"
+
+#~ msgid "The width of the overview sidebar."
+#~ msgstr "La anchura de la barra lateral de vista global."
+
+#~ msgid "Width:"
+#~ msgstr "Anchura:"
+
+#~ msgid ""
+#~ "The number of lines to scroll at a time when scrolling the overview "
+#~ "sidebar."
+#~ msgstr ""
+#~ "La cantidad de líneas que se desplazará la barra lateral de vista global "
+#~ "al navegar."
+
+#~ msgid "Scroll Lines:"
+#~ msgstr "Líneas de desplazamiento:"
+
+#~ msgid "Position on left"
+#~ msgstr "Colocar a la izquierda"
+
+#~ msgid ""
+#~ "Position the overview bar on the left rather than the right (requires "
+#~ "Geany 1.25 or greater)."
+#~ msgstr ""
+#~ "Colocar la barra de vista global a la izquierda (necesita Geany 1.15 o "
+#~ "superior)."
+
+#~ msgid "Hide tooltip"
+#~ msgstr "Ocultar ayuda emergente"
+
+#~ msgid ""
+#~ "Hide the tooltip that is displayed when mousing over the overview that "
+#~ "shows line, column and position information."
+#~ msgstr ""
+#~ "Oculta la ayuda emergente que indica línea, columna y posicón y se "
+#~ "muestra al colocar el ratón sobre la vista global."
+
+#~ msgid "Hide editor scrollbar"
+#~ msgstr "Ocultar la barra de desplazamiento del editor"
+
+#~ msgid ""
+#~ "Whether to hide Geany's regular editor scrollbar while the overview bar "
+#~ "is visible."
+#~ msgstr ""
+#~ "Indica si se oculta la barra de desplazamiento de Geany cuando está "
+#~ "visible la barra de vista global."
+
+#~ msgid "Disable overlay"
+#~ msgstr "Desactivar cobertura"
+
+#~ msgid ""
+#~ "Turn off drawing overlay, which shows the region of the main editor view "
+#~ "that is currently in view, ontop of the overview bar."
+#~ msgstr ""
+#~ "Desactiva la cobertura, que muestra la región de la vista del editor "
+#~ "principal, encima de la barra de vista global."
+
+#~ msgid ""
+#~ "The color and opacity of the overlay drawn ontop of the overlay sidebar."
+#~ msgstr ""
+#~ "El color y la opacidad de la cobertura dibujada encima de la barra "
+#~ "lateral de cobertura."
+
+#~ msgid "Color:"
+#~ msgstr "Color:"
+
+#~ msgid ""
+#~ "The color and opacity of the border drawn around the revealed area in the "
+#~ "overview sidebar. Set to the same as Overlay Color to disable."
+#~ msgstr ""
+#~ "El color y la opcidad del borde alrededor del área mostrada en la barra "
+#~ "lateral de vista global. Fijar al mismo que Color de cobertura para "
+#~ "desactivar."
+
+#~ msgid "Outline Color:"
+#~ msgstr "Color del borde:"
+
+#~ msgid "Draw over visible area"
+#~ msgstr "Dibujar por encima del área visible"
+
+#~ msgid ""
+#~ "When checked it will draw the overlay ontop of the area that is visible "
+#~ "in the main editor view, when unchecked, it will do the opposite and draw "
+#~ "the overlay everywhere but the visible area, \"revealing\" the visible "
+#~ "part."
+#~ msgstr ""
+#~ "Si se marca dibujará la cobertura encima del área que está visible en la "
+#~ "vista principal del editor. Al contrario hará lo opuesto, es decir, "
+#~ "dibujará la cobertura en todas partes excepto el área visible, "
+#~ "\"revelando\" el área visible."
+
+#~ msgid "Overlay"
+#~ msgstr "Cobertura"
+
+#~ msgid "_Translation Helper"
+#~ msgstr "Ayudante de _traducción"
+
+#~ msgid "_Previous String"
+#~ msgstr "Cadena _anterior"
+
+#~ msgid "_Next String"
+#~ msgstr "Cadena _siguiente"
+
+#~ msgid "Pre_vious Untranslated"
+#~ msgstr "A_nterior sin traducir"
+
+#~ msgid "Next _Untranslated"
+#~ msgstr "Siguien_te sin traducir"
+
+#~ msgid "Previous Fu_zzy"
+#~ msgstr "Difu_sa anterior"
+
+#~ msgid "Next _Fuzzy"
+#~ msgstr "Siguiente di_fusa"
+
+#~ msgid "Previous Untranslated or Fuzz_y"
+#~ msgstr "Anterior sin traducir o difu_sa"
+
+#~ msgid "Next Untranslated _or Fuzzy"
+#~ msgstr "Siguiente sin traducir _o difusa"
+
+#~ msgid "_Toggle Fuzziness"
+#~ msgstr "Conmu_tar difuso"
+
+#~ msgid "Paste _Message as Translation"
+#~ msgstr "Pegar _original como traducción"
+
+#~ msgid "Paste the original untranslated string to the translation"
+#~ msgstr "Pegar la cadena original sin traducir como traducción"
+
+#~ msgid "_Reflow Translation"
+#~ msgstr "_Refluir traducción"
+
+#~ msgid "_Show stats"
+#~ msgstr "Mo_strar estadísticas"
+
+#~ msgid ""
+#~ "Whether to update the translation headers (author, revision date, ...) "
+#~ "upon file save"
+#~ msgstr ""
+#~ "Indica si se actualizan las cabeceras de la traducción (autor, fecha de "
+#~ "revisión, etc.) al guardar el archivo"
+
+#~ msgid "Update _Headers Upon Save"
+#~ msgstr "Actualizar _cabeceras al guardar"
+
+#~ msgid "Translation statistics"
+#~ msgstr "Estadísticas de traducción"
+
+#~ msgid "Choose a color for translated strings"
+#~ msgstr "Elija un color para las cadenas traducidas"
+
+#~ msgid "Choose a color for fuzzily translated strings"
+#~ msgstr "Elija un color para las cadenas de traducción difusa"
+
+#~ msgid "Choose a color for untranslated strings"
+#~ msgstr "Elija un color para las cadenas sin traducir"
+
+#~ msgid "Translated:"
+#~ msgstr "Traducido:"
+
+#~ msgid "Fuzzy:"
+#~ msgstr "Difuso:"
+
+#~ msgid "Untranslated:"
+#~ msgstr "Sin traducir:"
+
+#~ msgid "Toggle Check While Typing"
+#~ msgstr "Conmutar corrección al escribir"
+
+#~ msgid "Check spelling while typing"
+#~ msgstr "Corrección al escribir"
+
+#, c-format
+#~ msgid "%s: %u Project"
+#~ msgid_plural "%s: %u Projects"
+#~ msgstr[0] "%s: %u Proyectos"
+#~ msgstr[1] "%s: %u Proyectos"
 
 #~ msgid "_Save"
 #~ msgstr "_Guardar"

--- a/po/fr.po
+++ b/po/fr.po
@@ -8,8 +8,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Geany-Plugins 1.30\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-29 19:41+0200\n"
+"Report-Msgid-Bugs-To: https://github.com/geany/geany/issues\n"
+"POT-Creation-Date: 2022-06-28 07:39+0200\n"
 "PO-Revision-Date: 2018-02-19 17:07-0600\n"
 "Last-Translator: Colomban Wendling <ban@herbesfolles.org>\n"
 "Language-Team: French <geany-i18n@uvena.de>\n"
@@ -23,27 +23,27 @@ msgstr ""
 msgid "(Empty Line)"
 msgstr "(Ligne vide)"
 
-#: ../addons/src/ao_bookmarklist.c:315
+#: ../addons/src/ao_bookmarklist.c:331
 msgid "_Remove Bookmark"
 msgstr "_Supprimer le marque-page"
 
 #. Translators: Number is meant at this point.
-#: ../addons/src/ao_bookmarklist.c:342
+#: ../addons/src/ao_bookmarklist.c:358
 msgid "No."
 msgstr "N°"
 
-#: ../addons/src/ao_bookmarklist.c:350 ../devhelp/src/dhp-object.c:494
+#: ../addons/src/ao_bookmarklist.c:366 ../devhelp/src/dhp-object.c:494
 #: ../devhelp/devhelp/dh-window.c:1142
 msgid "Contents"
 msgstr "Contenu"
 
-#: ../addons/src/ao_bookmarklist.c:383 ../treebrowser/src/treebrowser.c:666
+#: ../addons/src/ao_bookmarklist.c:399 ../treebrowser/src/treebrowser.c:666
 #: ../webhelper/src/gwh-plugin.c:328
 msgid "Bookmarks"
 msgstr "Marque-pages"
 
 #. complete update
-#: ../addons/src/ao_tasks.c:373 ../geanyvc/src/geanyvc.c:2679
+#: ../addons/src/ao_tasks.c:373 ../geanyvc/src/geanyvc.c:2730
 msgid "_Update"
 msgstr "Mettre à jo_ur"
 
@@ -165,10 +165,10 @@ msgstr "Copie le chemin du document courant dans le presse-papier"
 #: ../addons/src/addons.c:364 ../autoclose/src/autoclose.c:920
 #: ../codenav/src/codenavigation.c:281 ../latex/src/latex.c:208
 #: ../latex/src/latex.c:293 ../geanyprj/src/geanyprj.c:176
-#: ../geanyvc/src/geanyvc.c:2079 ../geniuspaste/src/geniuspaste.c:336
+#: ../geanyvc/src/geanyvc.c:2130 ../geniuspaste/src/geniuspaste.c:336
 #: ../lineoperations/src/lo_prefs.c:58 ../sendmail/src/sendmail.c:128
 #: ../sendmail/src/sendmail.c:293 ../spellcheck/src/scplugin.c:124
-#: ../treebrowser/src/treebrowser.c:2102
+#: ../treebrowser/src/treebrowser.c:2106
 #: ../updatechecker/src/updatechecker.c:262
 msgid "Plugin configuration directory could not be created."
 msgstr "Le répertoire de configuration du plugin n'a pas pu être créé."
@@ -745,7 +745,7 @@ msgstr "~\"Chargement du fichier cible.\\n\""
 msgid "Error loading file"
 msgstr "Erreur lors du chargement du fichier"
 
-#. setting asyncronous mode
+#. setting asynchronous mode
 #. setting null-stop array printing
 #. enable pretty printing
 #: ../debugger/src/dbm_gdb.c:789 ../debugger/src/dbm_gdb.c:792
@@ -1150,7 +1150,7 @@ msgid "A developers' help browser for GNOME"
 msgstr "Un navigateur d'aide aux développeurs pour GNOME"
 
 #. Create the current file Submenu
-#: ../devhelp/devhelp/dh-window.c:759 ../geanyvc/src/geanyvc.c:2660
+#: ../devhelp/devhelp/dh-window.c:759 ../geanyvc/src/geanyvc.c:2711
 msgid "_File"
 msgstr "_Fichier"
 
@@ -1185,11 +1185,11 @@ msgstr "Nouvel ongle_t"
 msgid "_Print…"
 msgstr "Im_primer…"
 
-#: ../devhelp/devhelp/dh-window.c:782 ../devhelp/devhelp/eggfindbar.c:342
+#: ../devhelp/devhelp/dh-window.c:782
 msgid "Find Next"
 msgstr "Rechercher le suivant"
 
-#: ../devhelp/devhelp/dh-window.c:784 ../devhelp/devhelp/eggfindbar.c:329
+#: ../devhelp/devhelp/dh-window.c:784
 msgid "Find Previous"
 msgstr "Rechercher le précédent"
 
@@ -1379,7 +1379,7 @@ msgstr ""
 "Ce plugin n'a pas de mainteneur en ce moment. Voudriez-vous aider en "
 "contribuant à ce plugin ?"
 
-#: ../geanydoc/src/geanydoc.c:159 ../geanyvc/src/geanyvc.c:442
+#: ../geanydoc/src/geanydoc.c:159 ../geanyvc/src/geanyvc.c:448
 msgid "Could not parse the output of command"
 msgstr "Impossible d'analyser la sortie de la commande"
 
@@ -3107,7 +3107,7 @@ msgstr ""
 "Erreur dans le module \"%s\" à la fonction %s() :\n"
 "pas assez d'arguments pour la commande \"%s\".\n"
 
-#: ../geanylua/glspi_sci.c:637 ../geanylua/glspi_app.c:406
+#: ../geanylua/glspi_sci.c:729 ../geanylua/glspi_app.c:406
 #, c-format
 msgid ""
 "Error in module \"%s\" at function %s():\n"
@@ -3116,7 +3116,7 @@ msgstr ""
 "Erreur dans le module \"%s\" à la fonction %s() :\n"
 "commande \"%s\" donnée pour l'argument n° 1 inconnue.\n"
 
-#: ../geanylua/glspi_sci.c:781
+#: ../geanylua/glspi_sci.c:924
 #, c-format
 msgid ""
 "Error in module \"%s\" at function %s():\n"
@@ -3127,7 +3127,7 @@ msgstr ""
 " tableau invalide pour l'argument n° %d :\n"
 " drapeau \"%s\" inconnu pour l'élément n° %d\n"
 
-#: ../geanylua/glspi_sci.c:785
+#: ../geanylua/glspi_sci.c:928
 msgid "<too large to display>"
 msgstr "<trop large pour l'afficher>"
 
@@ -3921,7 +3921,7 @@ msgid "New _Below"
 msgstr "Nouveau a_près"
 
 #: ../geanymacro/src/geanymacro.c:1824 ../geanymacro/src/geanymacro.c:2120
-#: ../treebrowser/src/treebrowser.c:1338 ../treebrowser/src/treebrowser.c:1340
+#: ../treebrowser/src/treebrowser.c:1342 ../treebrowser/src/treebrowser.c:1344
 msgid "_Delete"
 msgstr "_Supprimer"
 
@@ -4340,8 +4340,8 @@ msgstr ""
 msgid "a key with fingerprint"
 msgstr "une clé avec empreinte"
 
-#: ../geanypg/src/verify_aux.c:66 ../spellcheck/src/gui.c:610
-#: ../spellcheck/src/gui.c:621
+#: ../geanypg/src/verify_aux.c:66 ../spellcheck/src/gui.c:607
+#: ../spellcheck/src/gui.c:618
 msgid "unknown"
 msgstr "inconnue"
 
@@ -4658,50 +4658,50 @@ msgstr ""
 "Ce plugin n'est pas développé activement en ce moment. Voudriez-vous aider "
 "en contribuant à ce plugin ?"
 
-#: ../geanyvc/src/geanyvc.c:501
+#: ../geanyvc/src/geanyvc.c:507
 #, c-format
 msgid "geanyvc: s_spawn_sync error: %s"
 msgstr "geanyvc : erreur de s_spawn_sync : %s"
 
-#: ../geanyvc/src/geanyvc.c:587
+#: ../geanyvc/src/geanyvc.c:593
 #, c-format
 msgid "File %s: action %s executed via %s."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:646 ../geanyvc/src/geanyvc.c:657
-#, c-format
-msgid "geanyvc: vcdiff_file_activated: Unable to rename '%s' to '%s'"
+#: ../geanyvc/src/geanyvc.c:633 ../geanyvc/src/geanyvc.c:643
+#, fuzzy, c-format
+msgid "geanyvc: diff_external: Unable to rename '%s' to '%s'"
 msgstr ""
 "geanyvc : vcdiff_file_activated : Impossible de renommer « %s » en « %s »"
 
-#: ../geanyvc/src/geanyvc.c:683 ../geanyvc/src/geanyvc.c:733
+#: ../geanyvc/src/geanyvc.c:698 ../geanyvc/src/geanyvc.c:784
 msgid "No changes were made."
 msgstr "Aucune modification n'a été effectuée."
 
-#: ../geanyvc/src/geanyvc.c:760
+#: ../geanyvc/src/geanyvc.c:811
 msgid "No history available"
 msgstr "Pas d'historique disponible"
 
-#: ../geanyvc/src/geanyvc.c:953 ../geanyvc/src/geanyvc.c:961
+#: ../geanyvc/src/geanyvc.c:1004 ../geanyvc/src/geanyvc.c:1012
 #, c-format
 msgid "Do you really want to revert: %s?"
 msgstr "Voulez-vous vraiment rétablir : %s ?"
 
-#: ../geanyvc/src/geanyvc.c:969
+#: ../geanyvc/src/geanyvc.c:1020
 #, c-format
 msgid "Do you really want to add: %s?"
 msgstr "Voulez-vous vraiment ajouter : %s ?"
 
-#: ../geanyvc/src/geanyvc.c:976
+#: ../geanyvc/src/geanyvc.c:1027
 #, c-format
 msgid "Do you really want to remove: %s?"
 msgstr "Voulez-vous vraiment supprimer : %s ?"
 
-#: ../geanyvc/src/geanyvc.c:999
+#: ../geanyvc/src/geanyvc.c:1050
 msgid "Do you really want to update?"
 msgstr "Voulez-vous vraiment mettre à jour ?"
 
-#: ../geanyvc/src/geanyvc.c:1126
+#: ../geanyvc/src/geanyvc.c:1177
 msgid ""
 "The resulting differences cannot be displayed because the changes are too "
 "big to display here and would slow down the UI significantly.\n"
@@ -4715,48 +4715,48 @@ msgstr ""
 "Pour afficher les différences, fermez ce dialogue et ouvrez le diff "
 "directement dans Geany en utilisant le menu GeanyVC (Dossier racine -> Diff)."
 
-#: ../geanyvc/src/geanyvc.c:1280
+#: ../geanyvc/src/geanyvc.c:1331
 msgid "Commit Y/N"
 msgstr "Commiter (O/N)"
 
-#: ../geanyvc/src/geanyvc.c:1290
+#: ../geanyvc/src/geanyvc.c:1341
 msgid "Status"
 msgstr "Statut"
 
-#: ../geanyvc/src/geanyvc.c:1297
+#: ../geanyvc/src/geanyvc.c:1348
 msgid "Path"
 msgstr "Chemin"
 
-#: ../geanyvc/src/geanyvc.c:1414
+#: ../geanyvc/src/geanyvc.c:1465
 msgid "Choose a previous commit message"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1476
+#: ../geanyvc/src/geanyvc.c:1527
 #, c-format
 msgid "Line: %d Column: %d"
 msgstr "Ligne : %d Colonne : %d"
 
-#: ../geanyvc/src/geanyvc.c:1523
+#: ../geanyvc/src/geanyvc.c:1574
 msgid "Commit"
 msgstr "Commit"
 
-#: ../geanyvc/src/geanyvc.c:1564
+#: ../geanyvc/src/geanyvc.c:1615
 msgid "_De-/select all files"
 msgstr "Sélectionner/_désélectionner tous les fichiers"
 
-#: ../geanyvc/src/geanyvc.c:1608
+#: ../geanyvc/src/geanyvc.c:1659
 msgid "<b>Commit message:</b>"
 msgstr "<b>Message de commit :</b>"
 
-#: ../geanyvc/src/geanyvc.c:1632
+#: ../geanyvc/src/geanyvc.c:1683
 msgid "C_ommit"
 msgstr "C_ommit"
 
-#: ../geanyvc/src/geanyvc.c:1740
+#: ../geanyvc/src/geanyvc.c:1791
 msgid "Nothing to commit."
 msgstr "Rien à commiter."
 
-#: ../geanyvc/src/geanyvc.c:1788
+#: ../geanyvc/src/geanyvc.c:1839
 #, c-format
 msgid ""
 "Error initializing GeanyVC spell checking: %s. Check your configuration."
@@ -4764,26 +4764,26 @@ msgstr ""
 "Erreur lors de l'initialisation de la vérification orthographique de "
 "GeanyVC : %s. Vérifiez votre configuration."
 
-#: ../geanyvc/src/geanyvc.c:1823
+#: ../geanyvc/src/geanyvc.c:1874
 #, c-format
 msgid "Commit failed (status: %d, error: %s)."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1824
+#: ../geanyvc/src/geanyvc.c:1875
 #, fuzzy
 msgid "Commit failed; see status in the Message window."
 msgstr "Montrer les tâches disponibles dans la fenêtre des messages"
 
-#: ../geanyvc/src/geanyvc.c:1829
+#: ../geanyvc/src/geanyvc.c:1880
 #, fuzzy
 msgid "Changes committed."
 msgstr "Rien à commiter."
 
-#: ../geanyvc/src/geanyvc.c:2151
+#: ../geanyvc/src/geanyvc.c:2202
 msgid "Set Changed-flag for document tabs created by the plugin"
 msgstr "Marquer les documents créés par le plugin comme modifiés"
 
-#: ../geanyvc/src/geanyvc.c:2154
+#: ../geanyvc/src/geanyvc.c:2205
 msgid ""
 "If this option is activated, every new by the VC-plugin created document tab "
 "will be marked as changed. Even this option is useful in some cases, it "
@@ -4794,47 +4794,47 @@ msgstr ""
 "cas, elle peut résulter en de nombreux et ennuyeux dialogues demandant si le "
 "document doit être enregistré."
 
-#: ../geanyvc/src/geanyvc.c:2162
+#: ../geanyvc/src/geanyvc.c:2213
 msgid "Confirm adding new files to a VCS"
 msgstr "Confirmer l'ajout de nouveaux fichiers au VCS"
 
-#: ../geanyvc/src/geanyvc.c:2165
+#: ../geanyvc/src/geanyvc.c:2216
 msgid "Shows a confirmation dialog on adding a new (created) file to VCS."
 msgstr ""
 "Affiche un dialogue de confirmation lors de l'ajout d'un nouveau fichier au "
 "VCS"
 
-#: ../geanyvc/src/geanyvc.c:2171
+#: ../geanyvc/src/geanyvc.c:2222
 msgid "Maximize commit dialog"
 msgstr "Maximiser le dialogue de commit"
 
-#: ../geanyvc/src/geanyvc.c:2172
+#: ../geanyvc/src/geanyvc.c:2223
 msgid "Show commit dialog maximize."
 msgstr "Afficher le dialogue de commit maximisé."
 
-#: ../geanyvc/src/geanyvc.c:2178
+#: ../geanyvc/src/geanyvc.c:2229
 msgid "Use external diff viewer"
 msgstr "Utiliser une visionneuse de diff externe"
 
-#: ../geanyvc/src/geanyvc.c:2180
+#: ../geanyvc/src/geanyvc.c:2231
 msgid "Use external diff viewer for file diff."
 msgstr "Utiliser une visionneuse externe pour afficher les diff de fichiers."
 
-#: ../geanyvc/src/geanyvc.c:2186
+#: ../geanyvc/src/geanyvc.c:2237
 msgid "Show VC entries at editor menu"
 msgstr "Montrer les commandes dans le menu de l'éditeur"
 
-#: ../geanyvc/src/geanyvc.c:2188
+#: ../geanyvc/src/geanyvc.c:2239
 msgid "Show entries for VC functions inside editor menu"
 msgstr ""
 "Afficher les entrées pour les fonctionnalités du VCS dans le menu de "
 "l'éditeur"
 
-#: ../geanyvc/src/geanyvc.c:2193
+#: ../geanyvc/src/geanyvc.c:2244
 msgid "Attach menu to menubar"
 msgstr "Attacher le menu à la barre de menu"
 
-#: ../geanyvc/src/geanyvc.c:2195
+#: ../geanyvc/src/geanyvc.c:2246
 msgid ""
 "Whether menu for this plugin are getting placed either inside tools menu or "
 "directly inside Geany's menubar. Will take in account after next start of "
@@ -4844,68 +4844,68 @@ msgstr ""
 "directement dans la barre de menus de Geany. Un redémarrage du plugin est "
 "nécessaire pour appliquer cette option."
 
-#: ../geanyvc/src/geanyvc.c:2203
+#: ../geanyvc/src/geanyvc.c:2254
 msgid "Enable CVS"
 msgstr "Activer CVS"
 
-#: ../geanyvc/src/geanyvc.c:2208
+#: ../geanyvc/src/geanyvc.c:2259
 msgid "Enable GIT"
 msgstr "Activer Git"
 
-#: ../geanyvc/src/geanyvc.c:2213
+#: ../geanyvc/src/geanyvc.c:2264
 msgid "Enable Fossil"
 msgstr "Activer Fossil"
 
-#: ../geanyvc/src/geanyvc.c:2218
+#: ../geanyvc/src/geanyvc.c:2269
 msgid "Enable SVN"
 msgstr "Activer SVN"
 
-#: ../geanyvc/src/geanyvc.c:2223
+#: ../geanyvc/src/geanyvc.c:2274
 msgid "Enable SVK"
 msgstr "Activer SVK"
 
-#: ../geanyvc/src/geanyvc.c:2228
+#: ../geanyvc/src/geanyvc.c:2279
 msgid "Enable Bazaar"
 msgstr "Activer Bazaar"
 
-#: ../geanyvc/src/geanyvc.c:2233
+#: ../geanyvc/src/geanyvc.c:2284
 msgid "Enable Mercurial"
 msgstr "Activer Mercurial"
 
-#: ../geanyvc/src/geanyvc.c:2239
+#: ../geanyvc/src/geanyvc.c:2290
 msgid "Spellcheck language"
 msgstr "Langue de la vérification orthographique"
 
 #. Diff of current file
 #. Diff of the current dir
 #. Complete diff of base directory
-#: ../geanyvc/src/geanyvc.c:2368 ../geanyvc/src/geanyvc.c:2463
-#: ../geanyvc/src/geanyvc.c:2503
+#: ../geanyvc/src/geanyvc.c:2419 ../geanyvc/src/geanyvc.c:2514
+#: ../geanyvc/src/geanyvc.c:2554
 msgid "_Diff"
 msgstr "_Diff"
 
-#: ../geanyvc/src/geanyvc.c:2371
+#: ../geanyvc/src/geanyvc.c:2422
 msgid "Make a diff from the current active file"
 msgstr "Faire un diff depuis le fichier courant"
 
 #. Revert current file
 #. Revert current dir
 #. Revert everything
-#: ../geanyvc/src/geanyvc.c:2376 ../geanyvc/src/geanyvc.c:2472
-#: ../geanyvc/src/geanyvc.c:2511
+#: ../geanyvc/src/geanyvc.c:2427 ../geanyvc/src/geanyvc.c:2523
+#: ../geanyvc/src/geanyvc.c:2562
 msgid "_Revert"
 msgstr "_Rétablir"
 
-#: ../geanyvc/src/geanyvc.c:2379
+#: ../geanyvc/src/geanyvc.c:2430
 msgid "Restore pristine working copy file (undo local edits)."
 msgstr "Restaurer la copie locale originale (annule les changements locaux)."
 
 #. Blame for current file
-#: ../geanyvc/src/geanyvc.c:2388
+#: ../geanyvc/src/geanyvc.c:2439
 msgid "_Blame"
 msgstr "_Blame"
 
-#: ../geanyvc/src/geanyvc.c:2391
+#: ../geanyvc/src/geanyvc.c:2442
 msgid "Shows the changes made at one file per revision and author."
 msgstr ""
 "Affiche les changements effectués dans un fichier par révision et auteur."
@@ -4913,147 +4913,147 @@ msgstr ""
 #. History/log of current file
 #. History/log of the current dir
 #. Complete History/Log of base directory
-#: ../geanyvc/src/geanyvc.c:2398 ../geanyvc/src/geanyvc.c:2482
-#: ../geanyvc/src/geanyvc.c:2523
+#: ../geanyvc/src/geanyvc.c:2449 ../geanyvc/src/geanyvc.c:2533
+#: ../geanyvc/src/geanyvc.c:2574
 msgid "_History (log)"
 msgstr "_Historique (log)"
 
-#: ../geanyvc/src/geanyvc.c:2401
+#: ../geanyvc/src/geanyvc.c:2452
 msgid "Shows the log of the current file"
 msgstr "Afficher l'historique du fichier courant"
 
 #. base version of the current file
-#: ../geanyvc/src/geanyvc.c:2406
+#: ../geanyvc/src/geanyvc.c:2457
 msgid "_Original"
 msgstr "_Original"
 
-#: ../geanyvc/src/geanyvc.c:2409
+#: ../geanyvc/src/geanyvc.c:2460
 msgid "Shows the original of the current file"
 msgstr "Affiche l'original du fichier courant"
 
 #. add current file
-#: ../geanyvc/src/geanyvc.c:2417
+#: ../geanyvc/src/geanyvc.c:2468
 msgid "_Add to Version Control"
 msgstr "_Ajouter au gestionnaire de versions"
 
-#: ../geanyvc/src/geanyvc.c:2419
+#: ../geanyvc/src/geanyvc.c:2470
 msgid "Add file to repository."
 msgstr "Ajouter le fichier au dépôt"
 
 #. remove current file
-#: ../geanyvc/src/geanyvc.c:2425
+#: ../geanyvc/src/geanyvc.c:2476
 msgid "_Remove from Version Control"
 msgstr "_Supprimer du gestionnaire de versions"
 
-#: ../geanyvc/src/geanyvc.c:2427
+#: ../geanyvc/src/geanyvc.c:2478
 msgid "Remove file from repository."
 msgstr "Supprimer le fichier du dépôt"
 
-#: ../geanyvc/src/geanyvc.c:2460
+#: ../geanyvc/src/geanyvc.c:2511
 msgid "_Directory"
 msgstr "_Dossier"
 
-#: ../geanyvc/src/geanyvc.c:2466
+#: ../geanyvc/src/geanyvc.c:2517
 msgid "Make a diff from the directory of the current active file"
 msgstr "Faire un diff depuis le dossier contenant le fichier courant"
 
-#: ../geanyvc/src/geanyvc.c:2475
+#: ../geanyvc/src/geanyvc.c:2526
 msgid "Restore original files in the current folder (undo local edits)."
 msgstr ""
 "Restaurer la copie originale des fichiers dans le dossier courant (annule "
 "les changements locaux)."
 
-#: ../geanyvc/src/geanyvc.c:2485
+#: ../geanyvc/src/geanyvc.c:2536
 msgid "Shows the log of the current directory"
 msgstr "Afficher l'historique du dossier courant"
 
-#: ../geanyvc/src/geanyvc.c:2499
+#: ../geanyvc/src/geanyvc.c:2550
 msgid "_Base Directory"
 msgstr "Dossier _racine"
 
-#: ../geanyvc/src/geanyvc.c:2505
+#: ../geanyvc/src/geanyvc.c:2556
 msgid "Make a diff from the top VC directory"
 msgstr "Faire un diff depuis le dossier racine du VCS"
 
-#: ../geanyvc/src/geanyvc.c:2513
+#: ../geanyvc/src/geanyvc.c:2564
 msgid "Revert any local edits."
 msgstr "Annuler les changements locaux."
 
-#: ../geanyvc/src/geanyvc.c:2526
+#: ../geanyvc/src/geanyvc.c:2577
 msgid "Shows the log of the top VC directory"
 msgstr "Afficher l'historique du dossier racine du VCS"
 
-#: ../geanyvc/src/geanyvc.c:2543
+#: ../geanyvc/src/geanyvc.c:2594
 msgid "_VC file Actions"
 msgstr "Actions du _VCS sur le fichier"
 
-#: ../geanyvc/src/geanyvc.c:2552
+#: ../geanyvc/src/geanyvc.c:2603
 msgid "VC _Commit..."
 msgstr "Co_mmit du VCS..."
 
-#: ../geanyvc/src/geanyvc.c:2596
+#: ../geanyvc/src/geanyvc.c:2647
 msgid "Show diff of file"
 msgstr "Afficher le diff du fichier"
 
-#: ../geanyvc/src/geanyvc.c:2598
+#: ../geanyvc/src/geanyvc.c:2649
 msgid "Show diff of directory"
 msgstr "Afficher le diff du dossier"
 
-#: ../geanyvc/src/geanyvc.c:2600
+#: ../geanyvc/src/geanyvc.c:2651
 msgid "Show diff of basedir"
 msgstr "Afficher le diff du dossier racine"
 
-#: ../geanyvc/src/geanyvc.c:2603
+#: ../geanyvc/src/geanyvc.c:2654
 msgid "Commit changes"
 msgstr "Commiter les changements"
 
-#: ../geanyvc/src/geanyvc.c:2605
+#: ../geanyvc/src/geanyvc.c:2656
 msgid "Show status"
 msgstr "Afficher le statut"
 
-#: ../geanyvc/src/geanyvc.c:2607
+#: ../geanyvc/src/geanyvc.c:2658
 msgid "Revert single file"
 msgstr "Rétablir un seul fichier"
 
-#: ../geanyvc/src/geanyvc.c:2609
+#: ../geanyvc/src/geanyvc.c:2660
 msgid "Revert directory"
 msgstr "Rétablir le dossier"
 
-#: ../geanyvc/src/geanyvc.c:2611
+#: ../geanyvc/src/geanyvc.c:2662
 msgid "Revert base directory"
 msgstr "Rétablir le dossier racine"
 
-#: ../geanyvc/src/geanyvc.c:2613
+#: ../geanyvc/src/geanyvc.c:2664
 msgid "Update file"
 msgstr "Mettre le fichier à jour"
 
-#: ../geanyvc/src/geanyvc.c:2643
+#: ../geanyvc/src/geanyvc.c:2694
 msgid "_VC"
 msgstr "Gestionnaire de _versions"
 
-#: ../geanyvc/src/geanyvc.c:2650
+#: ../geanyvc/src/geanyvc.c:2701
 msgid "_Version Control"
 msgstr "Gestionnaire de _versions"
 
 #. Status of basedir
-#: ../geanyvc/src/geanyvc.c:2672
+#: ../geanyvc/src/geanyvc.c:2723
 msgid "_Status"
 msgstr "_Statut"
 
-#: ../geanyvc/src/geanyvc.c:2674
+#: ../geanyvc/src/geanyvc.c:2725
 msgid "Show status."
 msgstr "Afficher le statut."
 
-#: ../geanyvc/src/geanyvc.c:2681
+#: ../geanyvc/src/geanyvc.c:2732
 msgid "Update from remote repository."
 msgstr "Mettre à jour depuis le dépôt distant."
 
 #. Commit all changes
-#: ../geanyvc/src/geanyvc.c:2686
+#: ../geanyvc/src/geanyvc.c:2737
 msgid "_Commit..."
 msgstr "_Commit..."
 
-#: ../geanyvc/src/geanyvc.c:2688
+#: ../geanyvc/src/geanyvc.c:2739
 msgid "Commit changes."
 msgstr "Commiter les changements."
 
@@ -5153,8 +5153,8 @@ msgid ""
 "Your paste can be found here:\n"
 "<a href=\"%s\" title=\"Click to open the paste in your browser\">%s</a>"
 msgstr ""
-"Votre code est disponible à l'adresse suivante :<a href=\"%s\" title="
-"\"Cliquez pour ouvrir votre paste dans votre navigateur\">%s</a>"
+"Votre code est disponible à l'adresse suivante :<a href=\"%s\" "
+"title=\"Cliquez pour ouvrir votre paste dans votre navigateur\">%s</a>"
 
 #: ../geniuspaste/src/geniuspaste.c:881
 msgid "There are no opened documents. Open one and retry.\n"
@@ -5179,36 +5179,6 @@ msgstr "Afficher votre paste dans un nouvel onglet de navigateur"
 #: ../geniuspaste/src/geniuspaste.c:959
 msgid "_Paste it!"
 msgstr "_Envoyez-le !"
-
-#: ../git-changebar/data/prefs.ui.h:1
-msgid "_Monitor repository for changes"
-msgstr "_Surveiller les changements du dépôt"
-
-#: ../git-changebar/data/prefs.ui.h:2
-msgid ""
-"Whether to automatically update the diff in order to maintain it up to date "
-"when the underlying Git repository changes.  This should generally be "
-"enabled for optimal user experience."
-msgstr ""
-"Choisit s'il faut mettre le diff à jour automatiquement de façon à le garder "
-"à jour lorsque le dépôt Git change.  Ceci devrait généralement être activé "
-"pour une expérience utilisateur optimale."
-
-#: ../git-changebar/data/prefs.ui.h:3
-msgid "_Added lines:"
-msgstr "Lignes _ajoutées :"
-
-#: ../git-changebar/data/prefs.ui.h:4
-msgid "_Changed lines:"
-msgstr "Lignes _modifiées :"
-
-#: ../git-changebar/data/prefs.ui.h:5
-msgid "_Removed lines:"
-msgstr "Lignes supp_rimées :"
-
-#: ../git-changebar/data/prefs.ui.h:6
-msgid "Colors"
-msgstr "Couleurs"
 
 #: ../git-changebar/src/gcb-plugin.c:62
 msgid "Git Change Bar"
@@ -5403,8 +5373,8 @@ msgstr ""
 #: ../lipsum/src/lipsum.c:184 ../sendmail/src/sendmail.c:396
 #, c-format
 msgid ""
-"Your configuration directory has been successfully moved from \"%s\" to \"%s"
-"\"."
+"Your configuration directory has been successfully moved from \"%s\" to "
+"\"%s\"."
 msgstr ""
 "Votre dossier de configuration a été déplacé avec succès depuis « %s » vers "
 "« %s »."
@@ -5572,7 +5542,7 @@ msgstr "Impossible d'écrire la configuration par défaut : %s"
 msgid "Unable to read value for '%s' key: %s"
 msgstr "Impossible de lire la valeur de la clé « %s » : %s"
 
-#: ../multiterm/src/tab-label.vala:62 ../treebrowser/src/treebrowser.c:2132
+#: ../multiterm/src/tab-label.vala:62 ../treebrowser/src/treebrowser.c:2137
 msgid "Terminal"
 msgstr "Terminal"
 
@@ -5610,130 +5580,6 @@ msgstr "Ligne <b>%d</b>, colonne <b>%d</b>, position <b>%d</b>"
 msgid "Show Overview"
 msgstr "Afficher la vue d'ensemble"
 
-#: ../overview/data/prefs.ui.h:1
-msgid ""
-"The amount to zoom the overview sidebar. This should probably negative if "
-"you want the sidebar zoomed out."
-msgstr ""
-"Combien zoomer la vue d'ensemble. Ceci devrait probablement être négatif si "
-"vous voulez que la barre latérale soit dézoomée."
-
-#: ../overview/data/prefs.ui.h:2
-msgid "Zoom Level:"
-msgstr "Niveau de zoom :"
-
-#: ../overview/data/prefs.ui.h:3
-msgid "The width of the overview sidebar."
-msgstr "Largeur de la vue d'ensemble."
-
-#: ../overview/data/prefs.ui.h:4
-msgid "Width:"
-msgstr "Largeur :"
-
-#: ../overview/data/prefs.ui.h:5
-msgid ""
-"The number of lines to scroll at a time when scrolling the overview sidebar."
-msgstr ""
-"Nombre de lignes à faire défiler en même temps lors du défilement de la vue "
-"d'ensemble"
-
-#: ../overview/data/prefs.ui.h:6
-msgid "Scroll Lines:"
-msgstr "Lignes à faire défiler :"
-
-#: ../overview/data/prefs.ui.h:7
-msgid "Position on left"
-msgstr "Placer à gauche"
-
-#: ../overview/data/prefs.ui.h:8
-msgid ""
-"Position the overview bar on the left rather than the right (requires Geany "
-"1.25 or greater)."
-msgstr ""
-"Placer la vue d'ensemble sur la gauche plutôt que la droite (nécessite Geany "
-"1.25 ou plus récent)."
-
-#: ../overview/data/prefs.ui.h:9
-msgid "Hide tooltip"
-msgstr "Cache l'infobulle"
-
-#: ../overview/data/prefs.ui.h:10
-msgid ""
-"Hide the tooltip that is displayed when mousing over the overview that shows "
-"line, column and position information."
-msgstr ""
-"Cacher l'infobulle qui est affichée lorsque la souris est au dessus de la "
-"vue d'ensemble et qui affiche les ligne, colonne et position."
-
-#: ../overview/data/prefs.ui.h:11
-msgid "Hide editor scrollbar"
-msgstr "Cacher la barre de défilement de l'éditeur"
-
-#: ../overview/data/prefs.ui.h:12
-msgid ""
-"Whether to hide Geany's regular editor scrollbar while the overview bar is "
-"visible."
-msgstr ""
-"Choisit s'il faut cacher la barre de défilement classique de l'éditeur "
-"lorsque la vue d'ensemble est visible."
-
-#: ../overview/data/prefs.ui.h:13
-msgid "Disable overlay"
-msgstr "Désactiver l'overlay"
-
-#: ../overview/data/prefs.ui.h:14
-msgid ""
-"Turn off drawing overlay, which shows the region of the main editor view "
-"that is currently in view, ontop of the overview bar."
-msgstr ""
-"Désactive l'overlay qui affiche la partie actuellement visible de l'éditeur "
-"par dessus la vue d'ensemble."
-
-#: ../overview/data/prefs.ui.h:15 ../scope/data/scope.glade.h:130
-#: ../scope/data/scope_gtk3.glade.h:130
-msgid "Options"
-msgstr "Options"
-
-#: ../overview/data/prefs.ui.h:16
-msgid ""
-"The color and opacity of the overlay drawn ontop of the overlay sidebar."
-msgstr "Couleur et opacité de l'overlay dessiné par dessus la vue d'ensemble."
-
-#: ../overview/data/prefs.ui.h:17
-msgid "Color:"
-msgstr "Couleur :"
-
-#: ../overview/data/prefs.ui.h:18
-msgid ""
-"The color and opacity of the border drawn around the revealed area in the "
-"overview sidebar. Set to the same as Overlay Color to disable."
-msgstr ""
-"Couleur et opacité de la bordure dessinée autour de la partie visible dans "
-"la vue d'ensemble. Utilisez la même couleur que pour l'overlay pour "
-"désactiver la bordure."
-
-#: ../overview/data/prefs.ui.h:19
-msgid "Outline Color:"
-msgstr "Couleur de la bordure :"
-
-#: ../overview/data/prefs.ui.h:20
-msgid "Draw over visible area"
-msgstr "Dessiner par dessus la partie visible"
-
-#: ../overview/data/prefs.ui.h:21
-msgid ""
-"When checked it will draw the overlay ontop of the area that is visible in "
-"the main editor view, when unchecked, it will do the opposite and draw the "
-"overlay everywhere but the visible area, \"revealing\" the visible part."
-msgstr ""
-"Quand activé, l'overlay sera dessiné sur la partie visible dans l'éditeur.  "
-"Sinon, il sera dessiné au dessus de la partie cachée, « révélant » la partie "
-"visible."
-
-#: ../overview/data/prefs.ui.h:22
-msgid "Overlay"
-msgstr "Overlay"
-
 #: ../pairtaghighlighter/src/pair_tag_highlighter.c:43
 msgid "Pair Tag Highlighter"
 msgstr ""
@@ -5764,146 +5610,6 @@ msgstr "Aller au tag correspondant"
 msgid "Select To Matching Tag"
 msgstr "Aller au tag correspondant"
 
-#: ../pohelper/data/menus.ui.h:1
-msgid "_Translation Helper"
-msgstr "Assistant de _traduction"
-
-#: ../pohelper/data/menus.ui.h:2
-msgid "_Previous String"
-msgstr "Chaîne _précédente"
-
-#: ../pohelper/data/menus.ui.h:3 ../pohelper/src/gph-plugin.c:1590
-msgid "Go to previous string"
-msgstr "Aller à la chaîne précédente"
-
-#: ../pohelper/data/menus.ui.h:4
-msgid "_Next String"
-msgstr "Chaîne suiva_nte"
-
-#: ../pohelper/data/menus.ui.h:5 ../pohelper/src/gph-plugin.c:1593
-msgid "Go to next string"
-msgstr "Aller à la chaîne suivante"
-
-#: ../pohelper/data/menus.ui.h:6
-msgid "Pre_vious Untranslated"
-msgstr "Non-traduite pr_écédente"
-
-#: ../pohelper/data/menus.ui.h:7 ../pohelper/src/gph-plugin.c:1596
-msgid "Go to previous untranslated string"
-msgstr "Aller à la chaîne non-traduite précédente"
-
-#: ../pohelper/data/menus.ui.h:8
-msgid "Next _Untranslated"
-msgstr "Non-traduite s_uivante"
-
-#: ../pohelper/data/menus.ui.h:9 ../pohelper/src/gph-plugin.c:1599
-msgid "Go to next untranslated string"
-msgstr "Aller à la chaîne non-traduite suivante"
-
-#: ../pohelper/data/menus.ui.h:10
-msgid "Previous Fu_zzy"
-msgstr "Appro_ximative précédente"
-
-#: ../pohelper/data/menus.ui.h:11 ../pohelper/src/gph-plugin.c:1602
-msgid "Go to previous fuzzily translated string"
-msgstr "Aller à la chaîne traduite approximativement précédente"
-
-#: ../pohelper/data/menus.ui.h:12
-msgid "Next _Fuzzy"
-msgstr "Approximati_ve suivante"
-
-#: ../pohelper/data/menus.ui.h:13 ../pohelper/src/gph-plugin.c:1605
-msgid "Go to next fuzzily translated string"
-msgstr "Aller à la chaîne traduite approximativement suivante"
-
-#: ../pohelper/data/menus.ui.h:14
-msgid "Previous Untranslated or Fuzz_y"
-msgstr "Non-traduite ou _approximative précédente"
-
-#: ../pohelper/data/menus.ui.h:15 ../pohelper/src/gph-plugin.c:1608
-msgid "Go to previous untranslated or fuzzy string"
-msgstr "Aller à la chaîne non-traduite ou approximative précédente"
-
-#: ../pohelper/data/menus.ui.h:16
-msgid "Next Untranslated _or Fuzzy"
-msgstr "Non-traduite ou approximative _suivante"
-
-#: ../pohelper/data/menus.ui.h:17 ../pohelper/src/gph-plugin.c:1612
-msgid "Go to next untranslated or fuzzy string"
-msgstr "Aller la chaîne non-traduite ou approximative suivante"
-
-#: ../pohelper/data/menus.ui.h:18 ../pohelper/src/gph-plugin.c:1623
-msgid "Toggle current translation fuzziness"
-msgstr "Basculer l'état approximatif de la chaîne courante"
-
-#: ../pohelper/data/menus.ui.h:19
-msgid "_Toggle Fuzziness"
-msgstr "Basculer l'état approxima_tif"
-
-#: ../pohelper/data/menus.ui.h:20
-msgid "Paste _Message as Translation"
-msgstr "Copier le _message dans la traduction"
-
-#: ../pohelper/data/menus.ui.h:21
-msgid "Paste the original untranslated string to the translation"
-msgstr "Copier la chaîne non-traduite originale dans la traduction"
-
-#: ../pohelper/data/menus.ui.h:22 ../pohelper/src/gph-plugin.c:1620
-msgid "Reflow the current translation string"
-msgstr "Reformater la chaîne de traduction courante"
-
-#: ../pohelper/data/menus.ui.h:23
-msgid "_Reflow Translation"
-msgstr "_Reformater la traduction"
-
-#: ../pohelper/data/menus.ui.h:24 ../pohelper/src/gph-plugin.c:1626
-msgid "Show statistics of the current document"
-msgstr "Afficher les statistiques du document courant"
-
-#: ../pohelper/data/menus.ui.h:25
-msgid "_Show stats"
-msgstr "Afficher les _statistiques"
-
-#: ../pohelper/data/menus.ui.h:26
-msgid ""
-"Whether to update the translation headers (author, revision date, ...) upon "
-"file save"
-msgstr ""
-"Active ou désactive la mise-à-jour des en-têtes de traduction (auteur, date "
-"de révision, etc.) lors de l'enregistrement du fichier"
-
-#: ../pohelper/data/menus.ui.h:27
-msgid "Update _Headers Upon Save"
-msgstr "Mettre à _jour les en-têtes lors de l'enregistrement"
-
-#: ../pohelper/data/stats.ui.h:1
-msgid "Translation statistics"
-msgstr "Statistiques de la traduction"
-
-#: ../pohelper/data/stats.ui.h:2
-msgid "Choose a color for translated strings"
-msgstr "Sélectionner une couleur pour les chaînes traduites"
-
-#: ../pohelper/data/stats.ui.h:3
-msgid "Choose a color for fuzzily translated strings"
-msgstr "Sélectionner une couleur pour les chaînes traduites approximativement"
-
-#: ../pohelper/data/stats.ui.h:4
-msgid "Choose a color for untranslated strings"
-msgstr "Sélectionner une couleur pour les chaînes non-traduites"
-
-#: ../pohelper/data/stats.ui.h:5
-msgid "Translated:"
-msgstr "Traduites :"
-
-#: ../pohelper/data/stats.ui.h:6
-msgid "Fuzzy:"
-msgstr "Approximatives :"
-
-#: ../pohelper/data/stats.ui.h:7
-msgid "Untranslated:"
-msgstr "Non-traduites :"
-
 #: ../pohelper/src/gph-plugin.c:40
 msgid "Translation Helper"
 msgstr "Assistant de traduction"
@@ -5932,9 +5638,53 @@ msgstr "<b>Non-traduites :</b> %.3g%%"
 msgid "%u (%.3g%%)"
 msgstr "%u (%.3g%%)"
 
+#: ../pohelper/src/gph-plugin.c:1590
+msgid "Go to previous string"
+msgstr "Aller à la chaîne précédente"
+
+#: ../pohelper/src/gph-plugin.c:1593
+msgid "Go to next string"
+msgstr "Aller à la chaîne suivante"
+
+#: ../pohelper/src/gph-plugin.c:1596
+msgid "Go to previous untranslated string"
+msgstr "Aller à la chaîne non-traduite précédente"
+
+#: ../pohelper/src/gph-plugin.c:1599
+msgid "Go to next untranslated string"
+msgstr "Aller à la chaîne non-traduite suivante"
+
+#: ../pohelper/src/gph-plugin.c:1602
+msgid "Go to previous fuzzily translated string"
+msgstr "Aller à la chaîne traduite approximativement précédente"
+
+#: ../pohelper/src/gph-plugin.c:1605
+msgid "Go to next fuzzily translated string"
+msgstr "Aller à la chaîne traduite approximativement suivante"
+
+#: ../pohelper/src/gph-plugin.c:1608
+msgid "Go to previous untranslated or fuzzy string"
+msgstr "Aller à la chaîne non-traduite ou approximative précédente"
+
+#: ../pohelper/src/gph-plugin.c:1612
+msgid "Go to next untranslated or fuzzy string"
+msgstr "Aller la chaîne non-traduite ou approximative suivante"
+
 #: ../pohelper/src/gph-plugin.c:1616
 msgid "Paste original untranslated string to translation"
 msgstr "Copier la chaîne non-traduite originale dans la traduction"
+
+#: ../pohelper/src/gph-plugin.c:1620
+msgid "Reflow the current translation string"
+msgstr "Reformater la chaîne de traduction courante"
+
+#: ../pohelper/src/gph-plugin.c:1623
+msgid "Toggle current translation fuzziness"
+msgstr "Basculer l'état approximatif de la chaîne courante"
+
+#: ../pohelper/src/gph-plugin.c:1626
+msgid "Show statistics of the current document"
+msgstr "Afficher les statistiques du document courant"
 
 #: ../pohelper/src/gph-plugin.c:1833
 #, c-format
@@ -6220,7 +5970,7 @@ msgid "Add"
 msgstr "Ajouter"
 
 #: ../projectorganizer/src/prjorg-sidebar.c:390
-#: ../treebrowser/src/treebrowser.c:2356
+#: ../treebrowser/src/treebrowser.c:2361
 msgid "New File"
 msgstr "Nouveau fichier"
 
@@ -6861,6 +6611,10 @@ msgstr "Afficher les _infobulles"
 msgid "<b>Others</b>"
 msgstr "<b>Autres</b>"
 
+#: ../scope/data/scope.glade.h:130 ../scope/data/scope_gtk3.glade.h:130
+msgid "Options"
+msgstr "Options"
+
 #: ../scope/data/scope.glade.h:131 ../scope/data/scope_gtk3.glade.h:131
 msgid "_Import"
 msgstr "_Importer"
@@ -7462,12 +7216,14 @@ msgid "Checks the spelling of the current document."
 msgstr "Vérifie l'orthographe du document courant."
 
 #: ../spellcheck/src/scplugin.c:225
-msgid "Run Spell Check"
+#, fuzzy
+msgid "Run spell check once"
 msgstr "Lancer la vérification orthographique"
 
-#: ../spellcheck/src/scplugin.c:228
-msgid "Toggle Check While Typing"
-msgstr "Basculer la vérification lors de la frappe"
+#: ../spellcheck/src/scplugin.c:228 ../spellcheck/src/scplugin.c:333
+#, fuzzy
+msgid "Toggle spell check"
+msgstr "Vérification orthographique"
 
 #. initialise the dialog
 #: ../spellcheck/src/scplugin.c:239
@@ -7493,10 +7249,6 @@ msgstr "Afficher mots et suggestions dans la fenêtre de messages"
 #: ../spellcheck/src/scplugin.c:325
 msgid "<b>Interface</b>"
 msgstr "<b>Interface</b>"
-
-#: ../spellcheck/src/scplugin.c:333
-msgid "Check spelling while typing"
-msgstr "Vérifier l'orthographe lors de la frappe"
 
 #: ../spellcheck/src/scplugin.c:336
 msgid "Check spelling when opening a document"
@@ -7534,34 +7286,34 @@ msgstr ""
 msgid "<b>Behavior</b>"
 msgstr "<b>Comportement</b>"
 
-#: ../spellcheck/src/gui.c:76
+#: ../spellcheck/src/gui.c:88
 msgid "Spell checking while typing is now enabled"
 msgstr ""
 "La vérification orthographique lors de la frappe est maintenant activée"
 
-#: ../spellcheck/src/gui.c:78
+#: ../spellcheck/src/gui.c:90
 msgid "Spell checking while typing is now disabled"
 msgstr ""
 "La vérification orthographique lors de la frappe est maintenant désactivée"
 
-#: ../spellcheck/src/gui.c:326
+#: ../spellcheck/src/gui.c:323
 msgid "More..."
 msgstr "Plus…"
 
-#: ../spellcheck/src/gui.c:347
+#: ../spellcheck/src/gui.c:344
 msgid "(No Suggestions)"
 msgstr "(Aucune suggestion)"
 
-#: ../spellcheck/src/gui.c:360
+#: ../spellcheck/src/gui.c:357
 #, c-format
 msgid "Add \"%s\" to Dictionary"
 msgstr "Ajouter « %s » au dictionnaire"
 
-#: ../spellcheck/src/gui.c:368
+#: ../spellcheck/src/gui.c:365
 msgid "Ignore All"
 msgstr "Ignorer tout"
 
-#: ../spellcheck/src/gui.c:441
+#: ../spellcheck/src/gui.c:438
 msgid ""
 "Search term is too long to provide\n"
 "spelling suggestions in the editor menu."
@@ -7569,23 +7321,23 @@ msgstr ""
 "Le terme à rechercher est trop long pour afficher\n"
 "les suggestions dans le menu de l'éditeur."
 
-#: ../spellcheck/src/gui.c:447
+#: ../spellcheck/src/gui.c:444
 msgid "Perform Spell Check"
 msgstr "Effectuer la vérification orthographique"
 
-#: ../spellcheck/src/gui.c:609
+#: ../spellcheck/src/gui.c:606
 #, c-format
 msgid "Default (%s)"
 msgstr "Par défaut (%s)"
 
-#: ../spellcheck/src/gui.c:620
-#, c-format
-msgid "Toggle spell check while typing (current language: %s)"
+#: ../spellcheck/src/gui.c:617
+#, fuzzy, c-format
+msgid "Toggle spell check (current language: %s)"
 msgstr ""
 "Basculer la vérification orthographique lors de la frappe (langue courante : "
 "%s)"
 
-#: ../spellcheck/src/gui.c:698
+#: ../spellcheck/src/gui.c:695
 msgid "Spelling Suggestions"
 msgstr "Suggestions d'orthographe"
 
@@ -7684,15 +7436,15 @@ msgstr "(Vide)"
 msgid "Could not execute configured external command '%s' (%s)."
 msgstr "Impossible d'exécuter la commande d'ouverture externe « %s » (%s)."
 
-#: ../treebrowser/src/treebrowser.c:1089
+#: ../treebrowser/src/treebrowser.c:1093
 msgid "NewDirectory"
 msgstr "NouveauDossier"
 
-#: ../treebrowser/src/treebrowser.c:1091
+#: ../treebrowser/src/treebrowser.c:1095
 msgid "NewFile"
 msgstr "NouveauFichier"
 
-#: ../treebrowser/src/treebrowser.c:1096
+#: ../treebrowser/src/treebrowser.c:1100
 #, fuzzy, c-format
 msgid ""
 "Target file '%s' exists.\n"
@@ -7701,140 +7453,140 @@ msgstr ""
 "Le fichier de destination « %s » existe, voulez-vous vraiment le remplacer "
 "par un fichier vide ?"
 
-#: ../treebrowser/src/treebrowser.c:1142
+#: ../treebrowser/src/treebrowser.c:1146
 #, c-format
 msgid "Do you really want to delete '%s' ?"
 msgstr "Voulez-vous vraiment supprimer « %s » ?"
 
-#: ../treebrowser/src/treebrowser.c:1255 ../treebrowser/src/treebrowser.c:1257
+#: ../treebrowser/src/treebrowser.c:1259 ../treebrowser/src/treebrowser.c:1261
 #, fuzzy
 msgid "Go _Up"
 msgstr "_Monter"
 
-#: ../treebrowser/src/treebrowser.c:1263 ../treebrowser/src/treebrowser.c:1265
+#: ../treebrowser/src/treebrowser.c:1267 ../treebrowser/src/treebrowser.c:1269
 #, fuzzy
 msgid "Set _Path From Document"
 msgstr "_Définir le chemin depuis le document"
 
-#: ../treebrowser/src/treebrowser.c:1271 ../treebrowser/src/treebrowser.c:1273
+#: ../treebrowser/src/treebrowser.c:1275 ../treebrowser/src/treebrowser.c:1277
 #, fuzzy
 msgid "_Open Externally"
 msgstr "_Ouvrir dans un programme externe"
 
-#: ../treebrowser/src/treebrowser.c:1279
+#: ../treebrowser/src/treebrowser.c:1283
 msgid "Open _Terminal"
 msgstr "Ouvrir dans un _terminal"
 
-#: ../treebrowser/src/treebrowser.c:1284 ../treebrowser/src/treebrowser.c:1286
+#: ../treebrowser/src/treebrowser.c:1288 ../treebrowser/src/treebrowser.c:1290
 msgid "Set as _Root"
 msgstr "Définir comme _racine"
 
-#: ../treebrowser/src/treebrowser.c:1293 ../treebrowser/src/treebrowser.c:1295
+#: ../treebrowser/src/treebrowser.c:1297 ../treebrowser/src/treebrowser.c:1299
 msgid "Refres_h"
 msgstr "Rafraîc_hir"
 
-#: ../treebrowser/src/treebrowser.c:1301 ../treebrowser/src/treebrowser.c:1303
+#: ../treebrowser/src/treebrowser.c:1305 ../treebrowser/src/treebrowser.c:1307
 msgid "_Find in Files"
 msgstr "Rechercher dans les _fichiers"
 
-#: ../treebrowser/src/treebrowser.c:1313 ../treebrowser/src/treebrowser.c:1315
+#: ../treebrowser/src/treebrowser.c:1317 ../treebrowser/src/treebrowser.c:1319
 msgid "N_ew Folder"
 msgstr "Nouveau _dossier"
 
-#: ../treebrowser/src/treebrowser.c:1321 ../treebrowser/src/treebrowser.c:1323
+#: ../treebrowser/src/treebrowser.c:1325 ../treebrowser/src/treebrowser.c:1327
 msgid "_New File"
 msgstr "_Nouveau fichier"
 
-#: ../treebrowser/src/treebrowser.c:1329 ../treebrowser/src/treebrowser.c:1331
+#: ../treebrowser/src/treebrowser.c:1333 ../treebrowser/src/treebrowser.c:1335
 msgid "Rena_me"
 msgstr "Reno_mmer"
 
-#: ../treebrowser/src/treebrowser.c:1350 ../treebrowser/src/treebrowser.c:1352
+#: ../treebrowser/src/treebrowser.c:1354 ../treebrowser/src/treebrowser.c:1356
 #, c-format
 msgid "Close: %s"
 msgstr "Fermer « %s »"
 
-#: ../treebrowser/src/treebrowser.c:1359 ../treebrowser/src/treebrowser.c:1361
+#: ../treebrowser/src/treebrowser.c:1363 ../treebrowser/src/treebrowser.c:1365
 #, c-format
 msgid "Clo_se Child Documents "
 msgstr "Fermer les documents enf_ants"
 
-#: ../treebrowser/src/treebrowser.c:1368 ../treebrowser/src/treebrowser.c:1370
+#: ../treebrowser/src/treebrowser.c:1372 ../treebrowser/src/treebrowser.c:1374
 msgid "_Copy Full Path to Clipboard"
 msgstr "_Copier le chemin complet dans le presse-papier"
 
-#: ../treebrowser/src/treebrowser.c:1381 ../treebrowser/src/treebrowser.c:1383
+#: ../treebrowser/src/treebrowser.c:1385 ../treebrowser/src/treebrowser.c:1387
 msgid "E_xpand All"
 msgstr "Tout _étendre"
 
-#: ../treebrowser/src/treebrowser.c:1389 ../treebrowser/src/treebrowser.c:1391
+#: ../treebrowser/src/treebrowser.c:1393 ../treebrowser/src/treebrowser.c:1395
 msgid "Coll_apse All"
 msgstr "Tout re_plier"
 
-#: ../treebrowser/src/treebrowser.c:1399
+#: ../treebrowser/src/treebrowser.c:1403
 msgid "Show Boo_kmarks"
 msgstr "Afficher les mar_que-pages"
 
-#: ../treebrowser/src/treebrowser.c:1404
+#: ../treebrowser/src/treebrowser.c:1408
 msgid "Sho_w Hidden Files"
 msgstr "Aff_icher les fichiers cachés"
 
-#: ../treebrowser/src/treebrowser.c:1409
+#: ../treebrowser/src/treebrowser.c:1413
 msgid "Show Tool_bars"
 msgstr "Afficher les _barres d'outils"
 
-#: ../treebrowser/src/treebrowser.c:1747
+#: ../treebrowser/src/treebrowser.c:1751
 #, c-format
 msgid "Target file '%s' exists, do you really want to replace it?"
 msgstr ""
 "Le fichier de destination « %s » existe déjà, voulez-vous vraiment le "
 "remplacer ?"
 
-#: ../treebrowser/src/treebrowser.c:1883
+#: ../treebrowser/src/treebrowser.c:1887
 msgid "Go up"
 msgstr "Dossier parent"
 
-#: ../treebrowser/src/treebrowser.c:1893 ../treebrowser/src/treebrowser.c:2360
+#: ../treebrowser/src/treebrowser.c:1897 ../treebrowser/src/treebrowser.c:2365
 msgid "Refresh"
 msgstr "Rafraîchir"
 
-#: ../treebrowser/src/treebrowser.c:1903
+#: ../treebrowser/src/treebrowser.c:1907
 msgid "Home"
 msgstr "Dossier personnel"
 
-#: ../treebrowser/src/treebrowser.c:1913
+#: ../treebrowser/src/treebrowser.c:1917
 msgid "Set path from document"
 msgstr "Définir le chemin depuis le document"
 
 # Qu'est-ce que ça fait en pratique ?
-#: ../treebrowser/src/treebrowser.c:1923
+#: ../treebrowser/src/treebrowser.c:1927
 msgid "Track path"
 msgstr "Suivre le chemin"
 
-#: ../treebrowser/src/treebrowser.c:1933
+#: ../treebrowser/src/treebrowser.c:1937
 msgid "Hide bars"
 msgstr "Cacher les barres d'outils"
 
-#: ../treebrowser/src/treebrowser.c:1943
+#: ../treebrowser/src/treebrowser.c:1947
 msgid ""
 "Filter (*.c;*.h;*.cpp), and if you want temporary filter using the '!' "
 "reverse try for example this '!;*.c;*.h;*.cpp'"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1948
+#: ../treebrowser/src/treebrowser.c:1952
 msgid "Addressbar for example '/projects/my-project'"
 msgstr "Barre de chemin, par exemple « /projets/mon-projet »"
 
-#: ../treebrowser/src/treebrowser.c:1973
+#: ../treebrowser/src/treebrowser.c:1977
 msgid "Tree Browser"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2114
+#: ../treebrowser/src/treebrowser.c:2118
 msgid "External open command"
 msgstr "Commande du programme externe"
 
-#: ../treebrowser/src/treebrowser.c:2124
-#, c-format
+#: ../treebrowser/src/treebrowser.c:2129
+#, no-c-format
 msgid ""
 "The command to execute when using \"Open with\". You can use %f and %d "
 "wildcards.\n"
@@ -7847,61 +7599,61 @@ msgstr ""
 "%f sera remplacé par le chemin complet du fichier\n"
 "%d sera remplacé par le chemin complet du dossier qui contient le fichier"
 
-#: ../treebrowser/src/treebrowser.c:2143
+#: ../treebrowser/src/treebrowser.c:2148
 msgid "The terminal to use with the command \"Open Terminal\""
 msgstr "Le terminal à utiliser avec la commande « Ouvrir dans un terminal »"
 
-#: ../treebrowser/src/treebrowser.c:2149
+#: ../treebrowser/src/treebrowser.c:2154
 msgid "Toolbar"
 msgstr "Barre d'outils"
 
-#: ../treebrowser/src/treebrowser.c:2151
+#: ../treebrowser/src/treebrowser.c:2156
 msgid "Hidden"
 msgstr "Cachée"
 
-#: ../treebrowser/src/treebrowser.c:2152
+#: ../treebrowser/src/treebrowser.c:2157
 msgid "Top"
 msgstr "Au dessus"
 
-#: ../treebrowser/src/treebrowser.c:2153
+#: ../treebrowser/src/treebrowser.c:2158
 msgid "Bottom"
 msgstr "En dessous"
 
-#: ../treebrowser/src/treebrowser.c:2158
+#: ../treebrowser/src/treebrowser.c:2163
 msgid "If position is changed, the option require plugin restart."
 msgstr "Cette option nécessite un redémarrage du plugin."
 
-#: ../treebrowser/src/treebrowser.c:2162
+#: ../treebrowser/src/treebrowser.c:2167
 msgid "Show icons"
 msgstr "Afficher les icônes"
 
-#: ../treebrowser/src/treebrowser.c:2164
+#: ../treebrowser/src/treebrowser.c:2169
 msgid "None"
 msgstr "Aucune"
 
-#: ../treebrowser/src/treebrowser.c:2165
+#: ../treebrowser/src/treebrowser.c:2170
 msgid "Base"
 msgstr "Basiques"
 
-#: ../treebrowser/src/treebrowser.c:2166
+#: ../treebrowser/src/treebrowser.c:2171
 msgid "Content-type"
 msgstr "Depuis le type de contenu"
 
-#: ../treebrowser/src/treebrowser.c:2172
+#: ../treebrowser/src/treebrowser.c:2177
 msgid "Show hidden files"
 msgstr "Afficher les fichiers cachés"
 
-#: ../treebrowser/src/treebrowser.c:2181
+#: ../treebrowser/src/treebrowser.c:2186
 msgid "On Windows, this just hide files that are prefixed with '.' (dot)"
 msgstr ""
 "Sous Windows cette option ne cache que les fichiers dont le nom commence par "
 "un « . » (un point)"
 
-#: ../treebrowser/src/treebrowser.c:2183
+#: ../treebrowser/src/treebrowser.c:2188
 msgid "Hide object files"
 msgstr "Cacher les fichiers objets"
 
-#: ../treebrowser/src/treebrowser.c:2192
+#: ../treebrowser/src/treebrowser.c:2197
 msgid ""
 "Don't show generated object files in the file browser, this includes *.o, *."
 "obj. *.so, *.dll, *.a, *.lib"
@@ -7909,60 +7661,60 @@ msgstr ""
 "Ne pas afficher les objets auto-générés dans le navigateur de fichiers (*.o, "
 "*.obj. *.so, *.dll, *.a et *.lib entre autres)"
 
-#: ../treebrowser/src/treebrowser.c:2194
+#: ../treebrowser/src/treebrowser.c:2199
 msgid "Reverse filter"
 msgstr "Inverser le filtre"
 
-#: ../treebrowser/src/treebrowser.c:2203
+#: ../treebrowser/src/treebrowser.c:2208
 msgid "Follow current document"
 msgstr "Suivre le document courant"
 
-#: ../treebrowser/src/treebrowser.c:2212
+#: ../treebrowser/src/treebrowser.c:2217
 msgid "Single click, open document and focus it"
 msgstr "Un simple clic ouvre le document et lui donne le focus"
 
-#: ../treebrowser/src/treebrowser.c:2221
+#: ../treebrowser/src/treebrowser.c:2226
 msgid "Double click open directory"
 msgstr "Un double clic ouvre le dossier"
 
-#: ../treebrowser/src/treebrowser.c:2230
+#: ../treebrowser/src/treebrowser.c:2235
 msgid "On delete file, close it if is opened"
 msgstr "Fermer les fichiers lorsqu'ils sont supprimés"
 
-#: ../treebrowser/src/treebrowser.c:2239
+#: ../treebrowser/src/treebrowser.c:2244
 msgid "Focus editor on file open"
 msgstr "Donner le focus à l'éditeur lors de l'ouverture d'un fichier"
 
-#: ../treebrowser/src/treebrowser.c:2248
+#: ../treebrowser/src/treebrowser.c:2253
 msgid "Show tree lines"
 msgstr "Afficher les guides d'arborescence"
 
-#: ../treebrowser/src/treebrowser.c:2257
+#: ../treebrowser/src/treebrowser.c:2262
 msgid "Show bookmarks"
 msgstr "Afficher les marque-pages"
 
-#: ../treebrowser/src/treebrowser.c:2266
+#: ../treebrowser/src/treebrowser.c:2271
 msgid "Open new files"
 msgstr "Ouvrir les nouveaux fichiers"
 
-#: ../treebrowser/src/treebrowser.c:2350
+#: ../treebrowser/src/treebrowser.c:2355
 msgid "Focus File List"
 msgstr "Aller à la liste de fichiers"
 
-#: ../treebrowser/src/treebrowser.c:2352
+#: ../treebrowser/src/treebrowser.c:2357
 msgid "Focus Path Entry"
 msgstr "Aller au champ de chemin"
 
-#: ../treebrowser/src/treebrowser.c:2354
+#: ../treebrowser/src/treebrowser.c:2359
 msgid "Rename Object"
 msgstr "Renommer l'objet"
 
-#: ../treebrowser/src/treebrowser.c:2358
+#: ../treebrowser/src/treebrowser.c:2363
 msgid "New Folder"
 msgstr "Nouveau dossier"
 
 # Qu'est-ce que ça fait en pratique ?
-#: ../treebrowser/src/treebrowser.c:2362
+#: ../treebrowser/src/treebrowser.c:2367
 #, fuzzy
 msgid "Track Current"
 msgstr "Suivre le chemin"
@@ -8665,13 +8417,6 @@ msgstr "Aucun répertoire"
 msgid "No workbench opened."
 msgstr "Aucun plan de travail ouvert."
 
-#: ../workbench/src/sidebar.c:875
-#, c-format
-msgid "%s: %u Project"
-msgid_plural "%s: %u Projects"
-msgstr[0] "%s : %u projet"
-msgstr[1] "%s : %u projets"
-
 #: ../workbench/src/sidebar.c:886
 #, fuzzy
 msgid ""
@@ -8785,6 +8530,217 @@ msgstr ""
 #: ../xmlsnippets/src/plugin.c:45
 msgid "Autocompletes XML/HTML tags using snippets."
 msgstr ""
+
+#~ msgid "_Monitor repository for changes"
+#~ msgstr "_Surveiller les changements du dépôt"
+
+#~ msgid ""
+#~ "Whether to automatically update the diff in order to maintain it up to "
+#~ "date when the underlying Git repository changes.  This should generally "
+#~ "be enabled for optimal user experience."
+#~ msgstr ""
+#~ "Choisit s'il faut mettre le diff à jour automatiquement de façon à le "
+#~ "garder à jour lorsque le dépôt Git change.  Ceci devrait généralement "
+#~ "être activé pour une expérience utilisateur optimale."
+
+#~ msgid "_Added lines:"
+#~ msgstr "Lignes _ajoutées :"
+
+#~ msgid "_Changed lines:"
+#~ msgstr "Lignes _modifiées :"
+
+#~ msgid "_Removed lines:"
+#~ msgstr "Lignes supp_rimées :"
+
+#~ msgid "Colors"
+#~ msgstr "Couleurs"
+
+#~ msgid ""
+#~ "The amount to zoom the overview sidebar. This should probably negative if "
+#~ "you want the sidebar zoomed out."
+#~ msgstr ""
+#~ "Combien zoomer la vue d'ensemble. Ceci devrait probablement être négatif "
+#~ "si vous voulez que la barre latérale soit dézoomée."
+
+#~ msgid "Zoom Level:"
+#~ msgstr "Niveau de zoom :"
+
+#~ msgid "The width of the overview sidebar."
+#~ msgstr "Largeur de la vue d'ensemble."
+
+#~ msgid "Width:"
+#~ msgstr "Largeur :"
+
+#~ msgid ""
+#~ "The number of lines to scroll at a time when scrolling the overview "
+#~ "sidebar."
+#~ msgstr ""
+#~ "Nombre de lignes à faire défiler en même temps lors du défilement de la "
+#~ "vue d'ensemble"
+
+#~ msgid "Scroll Lines:"
+#~ msgstr "Lignes à faire défiler :"
+
+#~ msgid "Position on left"
+#~ msgstr "Placer à gauche"
+
+#~ msgid ""
+#~ "Position the overview bar on the left rather than the right (requires "
+#~ "Geany 1.25 or greater)."
+#~ msgstr ""
+#~ "Placer la vue d'ensemble sur la gauche plutôt que la droite (nécessite "
+#~ "Geany 1.25 ou plus récent)."
+
+#~ msgid "Hide tooltip"
+#~ msgstr "Cache l'infobulle"
+
+#~ msgid ""
+#~ "Hide the tooltip that is displayed when mousing over the overview that "
+#~ "shows line, column and position information."
+#~ msgstr ""
+#~ "Cacher l'infobulle qui est affichée lorsque la souris est au dessus de la "
+#~ "vue d'ensemble et qui affiche les ligne, colonne et position."
+
+#~ msgid "Hide editor scrollbar"
+#~ msgstr "Cacher la barre de défilement de l'éditeur"
+
+#~ msgid ""
+#~ "Whether to hide Geany's regular editor scrollbar while the overview bar "
+#~ "is visible."
+#~ msgstr ""
+#~ "Choisit s'il faut cacher la barre de défilement classique de l'éditeur "
+#~ "lorsque la vue d'ensemble est visible."
+
+#~ msgid "Disable overlay"
+#~ msgstr "Désactiver l'overlay"
+
+#~ msgid ""
+#~ "Turn off drawing overlay, which shows the region of the main editor view "
+#~ "that is currently in view, ontop of the overview bar."
+#~ msgstr ""
+#~ "Désactive l'overlay qui affiche la partie actuellement visible de "
+#~ "l'éditeur par dessus la vue d'ensemble."
+
+#~ msgid ""
+#~ "The color and opacity of the overlay drawn ontop of the overlay sidebar."
+#~ msgstr ""
+#~ "Couleur et opacité de l'overlay dessiné par dessus la vue d'ensemble."
+
+#~ msgid "Color:"
+#~ msgstr "Couleur :"
+
+#~ msgid ""
+#~ "The color and opacity of the border drawn around the revealed area in the "
+#~ "overview sidebar. Set to the same as Overlay Color to disable."
+#~ msgstr ""
+#~ "Couleur et opacité de la bordure dessinée autour de la partie visible "
+#~ "dans la vue d'ensemble. Utilisez la même couleur que pour l'overlay pour "
+#~ "désactiver la bordure."
+
+#~ msgid "Outline Color:"
+#~ msgstr "Couleur de la bordure :"
+
+#~ msgid "Draw over visible area"
+#~ msgstr "Dessiner par dessus la partie visible"
+
+#~ msgid ""
+#~ "When checked it will draw the overlay ontop of the area that is visible "
+#~ "in the main editor view, when unchecked, it will do the opposite and draw "
+#~ "the overlay everywhere but the visible area, \"revealing\" the visible "
+#~ "part."
+#~ msgstr ""
+#~ "Quand activé, l'overlay sera dessiné sur la partie visible dans "
+#~ "l'éditeur.  Sinon, il sera dessiné au dessus de la partie cachée, "
+#~ "« révélant » la partie visible."
+
+#~ msgid "Overlay"
+#~ msgstr "Overlay"
+
+#~ msgid "_Translation Helper"
+#~ msgstr "Assistant de _traduction"
+
+#~ msgid "_Previous String"
+#~ msgstr "Chaîne _précédente"
+
+#~ msgid "_Next String"
+#~ msgstr "Chaîne suiva_nte"
+
+#~ msgid "Pre_vious Untranslated"
+#~ msgstr "Non-traduite pr_écédente"
+
+#~ msgid "Next _Untranslated"
+#~ msgstr "Non-traduite s_uivante"
+
+#~ msgid "Previous Fu_zzy"
+#~ msgstr "Appro_ximative précédente"
+
+#~ msgid "Next _Fuzzy"
+#~ msgstr "Approximati_ve suivante"
+
+#~ msgid "Previous Untranslated or Fuzz_y"
+#~ msgstr "Non-traduite ou _approximative précédente"
+
+#~ msgid "Next Untranslated _or Fuzzy"
+#~ msgstr "Non-traduite ou approximative _suivante"
+
+#~ msgid "_Toggle Fuzziness"
+#~ msgstr "Basculer l'état approxima_tif"
+
+#~ msgid "Paste _Message as Translation"
+#~ msgstr "Copier le _message dans la traduction"
+
+#~ msgid "Paste the original untranslated string to the translation"
+#~ msgstr "Copier la chaîne non-traduite originale dans la traduction"
+
+#~ msgid "_Reflow Translation"
+#~ msgstr "_Reformater la traduction"
+
+#~ msgid "_Show stats"
+#~ msgstr "Afficher les _statistiques"
+
+#~ msgid ""
+#~ "Whether to update the translation headers (author, revision date, ...) "
+#~ "upon file save"
+#~ msgstr ""
+#~ "Active ou désactive la mise-à-jour des en-têtes de traduction (auteur, "
+#~ "date de révision, etc.) lors de l'enregistrement du fichier"
+
+#~ msgid "Update _Headers Upon Save"
+#~ msgstr "Mettre à _jour les en-têtes lors de l'enregistrement"
+
+#~ msgid "Translation statistics"
+#~ msgstr "Statistiques de la traduction"
+
+#~ msgid "Choose a color for translated strings"
+#~ msgstr "Sélectionner une couleur pour les chaînes traduites"
+
+#~ msgid "Choose a color for fuzzily translated strings"
+#~ msgstr ""
+#~ "Sélectionner une couleur pour les chaînes traduites approximativement"
+
+#~ msgid "Choose a color for untranslated strings"
+#~ msgstr "Sélectionner une couleur pour les chaînes non-traduites"
+
+#~ msgid "Translated:"
+#~ msgstr "Traduites :"
+
+#~ msgid "Fuzzy:"
+#~ msgstr "Approximatives :"
+
+#~ msgid "Untranslated:"
+#~ msgstr "Non-traduites :"
+
+#~ msgid "Toggle Check While Typing"
+#~ msgstr "Basculer la vérification lors de la frappe"
+
+#~ msgid "Check spelling while typing"
+#~ msgstr "Vérifier l'orthographe lors de la frappe"
+
+#, c-format
+#~ msgid "%s: %u Project"
+#~ msgid_plural "%s: %u Projects"
+#~ msgstr[0] "%s : %u projet"
+#~ msgstr[1] "%s : %u projets"
 
 #~ msgid "_Save"
 #~ msgstr "_Enregistrer"

--- a/po/gl.po
+++ b/po/gl.po
@@ -6,8 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Geany-Plugins 1.30\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-29 19:41+0200\n"
+"Report-Msgid-Bugs-To: https://github.com/geany/geany/issues\n"
+"POT-Creation-Date: 2022-06-28 07:39+0200\n"
 "PO-Revision-Date: 2010-06-06 06:26+0100\n"
 "Last-Translator: José Manuel Castroagudín Silva <chavescesures@gmail.com>\n"
 "Language-Team: Galician\n"
@@ -20,27 +20,27 @@ msgstr ""
 msgid "(Empty Line)"
 msgstr "(Liña baleira)"
 
-#: ../addons/src/ao_bookmarklist.c:315
+#: ../addons/src/ao_bookmarklist.c:331
 msgid "_Remove Bookmark"
 msgstr "Elimina_r marcador"
 
 #. Translators: Number is meant at this point.
-#: ../addons/src/ao_bookmarklist.c:342
+#: ../addons/src/ao_bookmarklist.c:358
 msgid "No."
 msgstr "Núm."
 
-#: ../addons/src/ao_bookmarklist.c:350 ../devhelp/src/dhp-object.c:494
+#: ../addons/src/ao_bookmarklist.c:366 ../devhelp/src/dhp-object.c:494
 #: ../devhelp/devhelp/dh-window.c:1142
 msgid "Contents"
 msgstr "Contidos"
 
-#: ../addons/src/ao_bookmarklist.c:383 ../treebrowser/src/treebrowser.c:666
+#: ../addons/src/ao_bookmarklist.c:399 ../treebrowser/src/treebrowser.c:666
 #: ../webhelper/src/gwh-plugin.c:328
 msgid "Bookmarks"
 msgstr "Marcadores"
 
 #. complete update
-#: ../addons/src/ao_tasks.c:373 ../geanyvc/src/geanyvc.c:2679
+#: ../addons/src/ao_tasks.c:373 ../geanyvc/src/geanyvc.c:2730
 msgid "_Update"
 msgstr "Act_ualizar"
 
@@ -165,10 +165,10 @@ msgstr "Verifica a ortografía do documento actual."
 #: ../addons/src/addons.c:364 ../autoclose/src/autoclose.c:920
 #: ../codenav/src/codenavigation.c:281 ../latex/src/latex.c:208
 #: ../latex/src/latex.c:293 ../geanyprj/src/geanyprj.c:176
-#: ../geanyvc/src/geanyvc.c:2079 ../geniuspaste/src/geniuspaste.c:336
+#: ../geanyvc/src/geanyvc.c:2130 ../geniuspaste/src/geniuspaste.c:336
 #: ../lineoperations/src/lo_prefs.c:58 ../sendmail/src/sendmail.c:128
 #: ../sendmail/src/sendmail.c:293 ../spellcheck/src/scplugin.c:124
-#: ../treebrowser/src/treebrowser.c:2102
+#: ../treebrowser/src/treebrowser.c:2106
 #: ../updatechecker/src/updatechecker.c:262
 msgid "Plugin configuration directory could not be created."
 msgstr "Non foi posíbel crear o directorio de configuración do plugin."
@@ -734,7 +734,7 @@ msgstr ""
 msgid "Error loading file"
 msgstr ""
 
-#. setting asyncronous mode
+#. setting asynchronous mode
 #. setting null-stop array printing
 #. enable pretty printing
 #: ../debugger/src/dbm_gdb.c:789 ../debugger/src/dbm_gdb.c:792
@@ -1149,7 +1149,7 @@ msgid "A developers' help browser for GNOME"
 msgstr ""
 
 #. Create the current file Submenu
-#: ../devhelp/devhelp/dh-window.c:759 ../geanyvc/src/geanyvc.c:2660
+#: ../devhelp/devhelp/dh-window.c:759 ../geanyvc/src/geanyvc.c:2711
 msgid "_File"
 msgstr "_Ficheiro"
 
@@ -1184,12 +1184,12 @@ msgstr ""
 msgid "_Print…"
 msgstr ""
 
-#: ../devhelp/devhelp/dh-window.c:782 ../devhelp/devhelp/eggfindbar.c:342
+#: ../devhelp/devhelp/dh-window.c:782
 #, fuzzy
 msgid "Find Next"
 msgstr "Engadir ficheiro"
 
-#: ../devhelp/devhelp/dh-window.c:784 ../devhelp/devhelp/eggfindbar.c:329
+#: ../devhelp/devhelp/dh-window.c:784
 #, fuzzy
 msgid "Find Previous"
 msgstr "Procurar en todo o proxecto "
@@ -1391,7 +1391,7 @@ msgid ""
 "contributing to this plugin?"
 msgstr ""
 
-#: ../geanydoc/src/geanydoc.c:159 ../geanyvc/src/geanyvc.c:442
+#: ../geanydoc/src/geanydoc.c:159 ../geanyvc/src/geanyvc.c:448
 msgid "Could not parse the output of command"
 msgstr "Non foi posíbel analizar a saída da ordes"
 
@@ -1648,8 +1648,8 @@ msgstr ""
 #, c-format
 msgid "Failed to load file type \"%s\" from file \"%s\": %s"
 msgstr ""
-"Produciuse un erro ao cargar o tipo de ficheiro \"%s\" dende o ficheiro \"%s"
-"\": %s"
+"Produciuse un erro ao cargar o tipo de ficheiro \"%s\" dende o ficheiro "
+"\"%s\": %s"
 
 #: ../geanygendoc/src/ggd-plugin.c:56
 msgid "Documentation Generator"
@@ -1687,8 +1687,8 @@ msgstr ""
 #, fuzzy, c-format
 msgid "Failed to load file \"%s\": %s"
 msgstr ""
-"Produciuse un erro ao cargar o tipo de ficheiro \"%s\" dende o ficheiro \"%s"
-"\": %s"
+"Produciuse un erro ao cargar o tipo de ficheiro \"%s\" dende o ficheiro "
+"\"%s\": %s"
 
 #: ../geanygendoc/src/ggd-plugin.c:425 ../geanygendoc/src/ggd-plugin.c:436
 msgid "Insert Documentation Comment"
@@ -3111,7 +3111,7 @@ msgstr ""
 "Produciuse un erro no módulo \"%s\" na función %s():\n"
 "non hai argumentos suficientes para a orde \"%s\".\n"
 
-#: ../geanylua/glspi_sci.c:637 ../geanylua/glspi_app.c:406
+#: ../geanylua/glspi_sci.c:729 ../geanylua/glspi_app.c:406
 #, c-format
 msgid ""
 "Error in module \"%s\" at function %s():\n"
@@ -3120,7 +3120,7 @@ msgstr ""
 "Produciuse un erro no módulo \"%s\" na función %s():\n"
 "orde descoñecida \"%s\" para o argumento #1.\n"
 
-#: ../geanylua/glspi_sci.c:781
+#: ../geanylua/glspi_sci.c:924
 #, c-format
 msgid ""
 "Error in module \"%s\" at function %s():\n"
@@ -3131,7 +3131,7 @@ msgstr ""
 " táboa non válida no argumento #%d:\n"
 " marca descoñecida \"%s\" para o elemento #%d\n"
 
-#: ../geanylua/glspi_sci.c:785
+#: ../geanylua/glspi_sci.c:928
 msgid "<too large to display>"
 msgstr "<demasiado longo para mostralo>"
 
@@ -3924,7 +3924,7 @@ msgid "New _Below"
 msgstr ""
 
 #: ../geanymacro/src/geanymacro.c:1824 ../geanymacro/src/geanymacro.c:2120
-#: ../treebrowser/src/treebrowser.c:1338 ../treebrowser/src/treebrowser.c:1340
+#: ../treebrowser/src/treebrowser.c:1342 ../treebrowser/src/treebrowser.c:1344
 #, fuzzy
 msgid "_Delete"
 msgstr "Borrar"
@@ -4303,8 +4303,8 @@ msgstr ""
 msgid "a key with fingerprint"
 msgstr ""
 
-#: ../geanypg/src/verify_aux.c:66 ../spellcheck/src/gui.c:610
-#: ../spellcheck/src/gui.c:621
+#: ../geanypg/src/verify_aux.c:66 ../spellcheck/src/gui.c:607
+#: ../spellcheck/src/gui.c:618
 msgid "unknown"
 msgstr "descoñecido"
 
@@ -4608,50 +4608,50 @@ msgid ""
 "contributing to this plugin?"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:501
+#: ../geanyvc/src/geanyvc.c:507
 #, c-format
 msgid "geanyvc: s_spawn_sync error: %s"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:587
+#: ../geanyvc/src/geanyvc.c:593
 #, c-format
 msgid "File %s: action %s executed via %s."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:646 ../geanyvc/src/geanyvc.c:657
+#: ../geanyvc/src/geanyvc.c:633 ../geanyvc/src/geanyvc.c:643
 #, c-format
-msgid "geanyvc: vcdiff_file_activated: Unable to rename '%s' to '%s'"
+msgid "geanyvc: diff_external: Unable to rename '%s' to '%s'"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:683 ../geanyvc/src/geanyvc.c:733
+#: ../geanyvc/src/geanyvc.c:698 ../geanyvc/src/geanyvc.c:784
 msgid "No changes were made."
 msgstr "Non se realizaron cambios"
 
-#: ../geanyvc/src/geanyvc.c:760
+#: ../geanyvc/src/geanyvc.c:811
 #, fuzzy
 msgid "No history available"
 msgstr "Non hai historial dispoñíbel"
 
-#: ../geanyvc/src/geanyvc.c:953 ../geanyvc/src/geanyvc.c:961
+#: ../geanyvc/src/geanyvc.c:1004 ../geanyvc/src/geanyvc.c:1012
 #, c-format
 msgid "Do you really want to revert: %s?"
 msgstr "Está seguro de que desexa reverter: %s?"
 
-#: ../geanyvc/src/geanyvc.c:969
+#: ../geanyvc/src/geanyvc.c:1020
 #, c-format
 msgid "Do you really want to add: %s?"
 msgstr "Está seguro de que quere engadir: %s?"
 
-#: ../geanyvc/src/geanyvc.c:976
+#: ../geanyvc/src/geanyvc.c:1027
 #, c-format
 msgid "Do you really want to remove: %s?"
 msgstr "Está seguro de que quere eliminar: %s?"
 
-#: ../geanyvc/src/geanyvc.c:999
+#: ../geanyvc/src/geanyvc.c:1050
 msgid "Do you really want to update?"
 msgstr "Está seguro de que desexa actualizar?"
 
-#: ../geanyvc/src/geanyvc.c:1126
+#: ../geanyvc/src/geanyvc.c:1177
 msgid ""
 "The resulting differences cannot be displayed because the changes are too "
 "big to display here and would slow down the UI significantly.\n"
@@ -4660,74 +4660,74 @@ msgid ""
 "Geany directly by using the GeanyVC menu (Base Directory -> Diff)."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1280
+#: ../geanyvc/src/geanyvc.c:1331
 msgid "Commit Y/N"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1290
+#: ../geanyvc/src/geanyvc.c:1341
 msgid "Status"
 msgstr "Estado"
 
-#: ../geanyvc/src/geanyvc.c:1297
+#: ../geanyvc/src/geanyvc.c:1348
 msgid "Path"
 msgstr "Ruta"
 
-#: ../geanyvc/src/geanyvc.c:1414
+#: ../geanyvc/src/geanyvc.c:1465
 msgid "Choose a previous commit message"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1476
+#: ../geanyvc/src/geanyvc.c:1527
 #, c-format
 msgid "Line: %d Column: %d"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1523
+#: ../geanyvc/src/geanyvc.c:1574
 msgid "Commit"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1564
+#: ../geanyvc/src/geanyvc.c:1615
 msgid "_De-/select all files"
 msgstr "(_De)Seleccionar tódolos ficheiros"
 
-#: ../geanyvc/src/geanyvc.c:1608
+#: ../geanyvc/src/geanyvc.c:1659
 msgid "<b>Commit message:</b>"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1632
+#: ../geanyvc/src/geanyvc.c:1683
 msgid "C_ommit"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1740
+#: ../geanyvc/src/geanyvc.c:1791
 #, fuzzy
 msgid "Nothing to commit."
 msgstr "Non hai nada que <commit>"
 
-#: ../geanyvc/src/geanyvc.c:1788
+#: ../geanyvc/src/geanyvc.c:1839
 #, fuzzy, c-format
 msgid ""
 "Error initializing GeanyVC spell checking: %s. Check your configuration."
 msgstr "Produciuse un erro ao iniciar a corrección ortográfica: %s"
 
-#: ../geanyvc/src/geanyvc.c:1823
+#: ../geanyvc/src/geanyvc.c:1874
 #, c-format
 msgid "Commit failed (status: %d, error: %s)."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1824
+#: ../geanyvc/src/geanyvc.c:1875
 #, fuzzy
 msgid "Commit failed; see status in the Message window."
 msgstr "Mostrar tarefas dispoñíbeis na xanela de mensaxes"
 
-#: ../geanyvc/src/geanyvc.c:1829
+#: ../geanyvc/src/geanyvc.c:1880
 #, fuzzy
 msgid "Changes committed."
 msgstr "Non hai nada que <commit>"
 
-#: ../geanyvc/src/geanyvc.c:2151
+#: ../geanyvc/src/geanyvc.c:2202
 msgid "Set Changed-flag for document tabs created by the plugin"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2154
+#: ../geanyvc/src/geanyvc.c:2205
 msgid ""
 "If this option is activated, every new by the VC-plugin created document tab "
 "will be marked as changed. Even this option is useful in some cases, it "
@@ -4738,266 +4738,266 @@ msgstr ""
 "opción ñe útil nalgúns casos, pode causar un gran número de diálogos do tipo "
 "\"Quere gardar... ?\"."
 
-#: ../geanyvc/src/geanyvc.c:2162
+#: ../geanyvc/src/geanyvc.c:2213
 msgid "Confirm adding new files to a VCS"
 msgstr ""
 "Confirmar a adición de novos ficheiros a un sistema de control de versións"
 
-#: ../geanyvc/src/geanyvc.c:2165
+#: ../geanyvc/src/geanyvc.c:2216
 msgid "Shows a confirmation dialog on adding a new (created) file to VCS."
 msgstr ""
 "Mostra un diálogo de confirmación ao engadir un ficheiro novo (creado) a un "
 "sistema de control de versións."
 
-#: ../geanyvc/src/geanyvc.c:2171
+#: ../geanyvc/src/geanyvc.c:2222
 msgid "Maximize commit dialog"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2172
+#: ../geanyvc/src/geanyvc.c:2223
 msgid "Show commit dialog maximize."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2178
+#: ../geanyvc/src/geanyvc.c:2229
 msgid "Use external diff viewer"
 msgstr "Uar un visor de diff externo"
 
-#: ../geanyvc/src/geanyvc.c:2180
+#: ../geanyvc/src/geanyvc.c:2231
 msgid "Use external diff viewer for file diff."
 msgstr "Usar un visor externo de diff para diffs de ficheiros."
 
-#: ../geanyvc/src/geanyvc.c:2186
+#: ../geanyvc/src/geanyvc.c:2237
 msgid "Show VC entries at editor menu"
 msgstr "Mostrar entradas de control de versións no menú do editor"
 
-#: ../geanyvc/src/geanyvc.c:2188
+#: ../geanyvc/src/geanyvc.c:2239
 msgid "Show entries for VC functions inside editor menu"
 msgstr ""
 "Mostra entradas para as funcións de control de versións dentro do menú do "
 "editor"
 
-#: ../geanyvc/src/geanyvc.c:2193
+#: ../geanyvc/src/geanyvc.c:2244
 msgid "Attach menu to menubar"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2195
+#: ../geanyvc/src/geanyvc.c:2246
 msgid ""
 "Whether menu for this plugin are getting placed either inside tools menu or "
 "directly inside Geany's menubar. Will take in account after next start of "
 "GeanyVC"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2203
+#: ../geanyvc/src/geanyvc.c:2254
 msgid "Enable CVS"
 msgstr "Habilitar CVS"
 
-#: ../geanyvc/src/geanyvc.c:2208
+#: ../geanyvc/src/geanyvc.c:2259
 msgid "Enable GIT"
 msgstr "Habilitar GIT"
 
-#: ../geanyvc/src/geanyvc.c:2213
+#: ../geanyvc/src/geanyvc.c:2264
 msgid "Enable Fossil"
 msgstr "Habilitar Fossil"
 
-#: ../geanyvc/src/geanyvc.c:2218
+#: ../geanyvc/src/geanyvc.c:2269
 msgid "Enable SVN"
 msgstr "Habilitar SVN"
 
-#: ../geanyvc/src/geanyvc.c:2223
+#: ../geanyvc/src/geanyvc.c:2274
 msgid "Enable SVK"
 msgstr "Habilitar SVK"
 
-#: ../geanyvc/src/geanyvc.c:2228
+#: ../geanyvc/src/geanyvc.c:2279
 msgid "Enable Bazaar"
 msgstr "Habilitar Bazaar"
 
-#: ../geanyvc/src/geanyvc.c:2233
+#: ../geanyvc/src/geanyvc.c:2284
 msgid "Enable Mercurial"
 msgstr "Habilitar Mercurial"
 
-#: ../geanyvc/src/geanyvc.c:2239
+#: ../geanyvc/src/geanyvc.c:2290
 msgid "Spellcheck language"
 msgstr "Idioma para a revisión ortográfica"
 
 #. Diff of current file
 #. Diff of the current dir
 #. Complete diff of base directory
-#: ../geanyvc/src/geanyvc.c:2368 ../geanyvc/src/geanyvc.c:2463
-#: ../geanyvc/src/geanyvc.c:2503
+#: ../geanyvc/src/geanyvc.c:2419 ../geanyvc/src/geanyvc.c:2514
+#: ../geanyvc/src/geanyvc.c:2554
 msgid "_Diff"
 msgstr "_Diff"
 
-#: ../geanyvc/src/geanyvc.c:2371
+#: ../geanyvc/src/geanyvc.c:2422
 msgid "Make a diff from the current active file"
 msgstr "Fader un diff a partir do ficheiro activo actualmente"
 
 #. Revert current file
 #. Revert current dir
 #. Revert everything
-#: ../geanyvc/src/geanyvc.c:2376 ../geanyvc/src/geanyvc.c:2472
-#: ../geanyvc/src/geanyvc.c:2511
+#: ../geanyvc/src/geanyvc.c:2427 ../geanyvc/src/geanyvc.c:2523
+#: ../geanyvc/src/geanyvc.c:2562
 msgid "_Revert"
 msgstr "_Reverter"
 
-#: ../geanyvc/src/geanyvc.c:2379
+#: ../geanyvc/src/geanyvc.c:2430
 msgid "Restore pristine working copy file (undo local edits)."
 msgstr ""
 "Restaurar o ficheiro limpo da copia de traballo (desfacer edicións locais)."
 
 #. Blame for current file
-#: ../geanyvc/src/geanyvc.c:2388
+#: ../geanyvc/src/geanyvc.c:2439
 msgid "_Blame"
 msgstr "_Blame"
 
-#: ../geanyvc/src/geanyvc.c:2391
+#: ../geanyvc/src/geanyvc.c:2442
 msgid "Shows the changes made at one file per revision and author."
 msgstr "Mostra os cambios feitos nun ficheiro por revisión e autor."
 
 #. History/log of current file
 #. History/log of the current dir
 #. Complete History/Log of base directory
-#: ../geanyvc/src/geanyvc.c:2398 ../geanyvc/src/geanyvc.c:2482
-#: ../geanyvc/src/geanyvc.c:2523
+#: ../geanyvc/src/geanyvc.c:2449 ../geanyvc/src/geanyvc.c:2533
+#: ../geanyvc/src/geanyvc.c:2574
 msgid "_History (log)"
 msgstr "_Historial (rexistro)"
 
-#: ../geanyvc/src/geanyvc.c:2401
+#: ../geanyvc/src/geanyvc.c:2452
 msgid "Shows the log of the current file"
 msgstr "Mostra o rexistro do ficheiro actual"
 
 #. base version of the current file
-#: ../geanyvc/src/geanyvc.c:2406
+#: ../geanyvc/src/geanyvc.c:2457
 msgid "_Original"
 msgstr "_Orixinal"
 
-#: ../geanyvc/src/geanyvc.c:2409
+#: ../geanyvc/src/geanyvc.c:2460
 #, fuzzy
 msgid "Shows the original of the current file"
 msgstr "Mostra a versión orixinal do ficheiro actual"
 
 #. add current file
-#: ../geanyvc/src/geanyvc.c:2417
+#: ../geanyvc/src/geanyvc.c:2468
 msgid "_Add to Version Control"
 msgstr "Eng_adir ao control de versións"
 
-#: ../geanyvc/src/geanyvc.c:2419
+#: ../geanyvc/src/geanyvc.c:2470
 msgid "Add file to repository."
 msgstr "Engadir o ficheiro ao repositorio."
 
 #. remove current file
-#: ../geanyvc/src/geanyvc.c:2425
+#: ../geanyvc/src/geanyvc.c:2476
 msgid "_Remove from Version Control"
 msgstr "Elimina_r do control de versións"
 
-#: ../geanyvc/src/geanyvc.c:2427
+#: ../geanyvc/src/geanyvc.c:2478
 msgid "Remove file from repository."
 msgstr "Eliminar ficheiro do repositorio."
 
-#: ../geanyvc/src/geanyvc.c:2460
+#: ../geanyvc/src/geanyvc.c:2511
 msgid "_Directory"
 msgstr "_Directorio"
 
-#: ../geanyvc/src/geanyvc.c:2466
+#: ../geanyvc/src/geanyvc.c:2517
 msgid "Make a diff from the directory of the current active file"
 msgstr "Facer un diff a partir do directorio do ficheiro activo actual"
 
-#: ../geanyvc/src/geanyvc.c:2475
+#: ../geanyvc/src/geanyvc.c:2526
 msgid "Restore original files in the current folder (undo local edits)."
 msgstr ""
 "Restaurar os ficheiros orixinais no directorio actual (desfacer as edicións "
 "locais)."
 
-#: ../geanyvc/src/geanyvc.c:2485
+#: ../geanyvc/src/geanyvc.c:2536
 msgid "Shows the log of the current directory"
 msgstr "Mostra o rexistro do directorio actual"
 
-#: ../geanyvc/src/geanyvc.c:2499
+#: ../geanyvc/src/geanyvc.c:2550
 msgid "_Base Directory"
 msgstr "Directorio _base"
 
-#: ../geanyvc/src/geanyvc.c:2505
+#: ../geanyvc/src/geanyvc.c:2556
 msgid "Make a diff from the top VC directory"
 msgstr "Facer un diff a partir do directorio máis alto do control de versións"
 
-#: ../geanyvc/src/geanyvc.c:2513
+#: ../geanyvc/src/geanyvc.c:2564
 msgid "Revert any local edits."
 msgstr "REverter todas as edicións locais."
 
-#: ../geanyvc/src/geanyvc.c:2526
+#: ../geanyvc/src/geanyvc.c:2577
 msgid "Shows the log of the top VC directory"
 msgstr "Mostra o rexistro do directorio máis alto do control de versións"
 
-#: ../geanyvc/src/geanyvc.c:2543
+#: ../geanyvc/src/geanyvc.c:2594
 msgid "_VC file Actions"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2552
+#: ../geanyvc/src/geanyvc.c:2603
 msgid "VC _Commit..."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2596
+#: ../geanyvc/src/geanyvc.c:2647
 msgid "Show diff of file"
 msgstr "Mostrar o diff do ficheiro"
 
-#: ../geanyvc/src/geanyvc.c:2598
+#: ../geanyvc/src/geanyvc.c:2649
 msgid "Show diff of directory"
 msgstr "Mostrar o diff do directorio"
 
-#: ../geanyvc/src/geanyvc.c:2600
+#: ../geanyvc/src/geanyvc.c:2651
 msgid "Show diff of basedir"
 msgstr "Mostrar un diff do directorio base"
 
-#: ../geanyvc/src/geanyvc.c:2603
+#: ../geanyvc/src/geanyvc.c:2654
 msgid "Commit changes"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2605
+#: ../geanyvc/src/geanyvc.c:2656
 msgid "Show status"
 msgstr "Mostrar estado"
 
-#: ../geanyvc/src/geanyvc.c:2607
+#: ../geanyvc/src/geanyvc.c:2658
 msgid "Revert single file"
 msgstr "Reverter un único ficheiro"
 
-#: ../geanyvc/src/geanyvc.c:2609
+#: ../geanyvc/src/geanyvc.c:2660
 msgid "Revert directory"
 msgstr "Reverter o directorio"
 
-#: ../geanyvc/src/geanyvc.c:2611
+#: ../geanyvc/src/geanyvc.c:2662
 msgid "Revert base directory"
 msgstr "Reverter o directorio base"
 
-#: ../geanyvc/src/geanyvc.c:2613
+#: ../geanyvc/src/geanyvc.c:2664
 msgid "Update file"
 msgstr "Actualizar o ficheiro"
 
-#: ../geanyvc/src/geanyvc.c:2643
+#: ../geanyvc/src/geanyvc.c:2694
 msgid "_VC"
 msgstr "C_V"
 
-#: ../geanyvc/src/geanyvc.c:2650
+#: ../geanyvc/src/geanyvc.c:2701
 #, fuzzy
 msgid "_Version Control"
 msgstr "Eng_adir ao control de versións"
 
 #. Status of basedir
-#: ../geanyvc/src/geanyvc.c:2672
+#: ../geanyvc/src/geanyvc.c:2723
 msgid "_Status"
 msgstr "E_stado"
 
-#: ../geanyvc/src/geanyvc.c:2674
+#: ../geanyvc/src/geanyvc.c:2725
 msgid "Show status."
 msgstr "Mostrar estado."
 
-#: ../geanyvc/src/geanyvc.c:2681
+#: ../geanyvc/src/geanyvc.c:2732
 msgid "Update from remote repository."
 msgstr "Actualizar dende o repositorio remoto."
 
 #. Commit all changes
-#: ../geanyvc/src/geanyvc.c:2686
+#: ../geanyvc/src/geanyvc.c:2737
 msgid "_Commit..."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2688
+#: ../geanyvc/src/geanyvc.c:2739
 msgid "Commit changes."
 msgstr ""
 
@@ -5114,34 +5114,6 @@ msgstr ""
 
 #: ../geniuspaste/src/geniuspaste.c:959
 msgid "_Paste it!"
-msgstr ""
-
-#: ../git-changebar/data/prefs.ui.h:1
-msgid "_Monitor repository for changes"
-msgstr ""
-
-#: ../git-changebar/data/prefs.ui.h:2
-msgid ""
-"Whether to automatically update the diff in order to maintain it up to date "
-"when the underlying Git repository changes.  This should generally be "
-"enabled for optimal user experience."
-msgstr ""
-
-#: ../git-changebar/data/prefs.ui.h:3
-msgid "_Added lines:"
-msgstr ""
-
-#: ../git-changebar/data/prefs.ui.h:4
-msgid "_Changed lines:"
-msgstr ""
-
-#: ../git-changebar/data/prefs.ui.h:5
-#, fuzzy
-msgid "_Removed lines:"
-msgstr "Eliminar ficheiro"
-
-#: ../git-changebar/data/prefs.ui.h:6
-msgid "Colors"
 msgstr ""
 
 #: ../git-changebar/src/gcb-plugin.c:62
@@ -5334,8 +5306,8 @@ msgstr ""
 #: ../lipsum/src/lipsum.c:184 ../sendmail/src/sendmail.c:396
 #, c-format
 msgid ""
-"Your configuration directory has been successfully moved from \"%s\" to \"%s"
-"\"."
+"Your configuration directory has been successfully moved from \"%s\" to "
+"\"%s\"."
 msgstr ""
 
 #: ../lipsum/src/lipsum.c:199
@@ -5430,8 +5402,8 @@ msgstr "Engadir ficheiro"
 #, fuzzy, c-format
 msgid "Failed to export Markdown HTML to file '%s': %s"
 msgstr ""
-"Produciuse un erro ao cargar o tipo de ficheiro \"%s\" dende o ficheiro \"%s"
-"\": %s"
+"Produciuse un erro ao cargar o tipo de ficheiro \"%s\" dende o ficheiro "
+"\"%s\": %s"
 
 #: ../multiterm/src/config.vala:47
 #, fuzzy, c-format
@@ -5515,7 +5487,7 @@ msgstr "Produciuse un erro ao cargar a configuración: %s"
 msgid "Unable to read value for '%s' key: %s"
 msgstr "Produciuse un erro ao gardar a configuración: %s"
 
-#: ../multiterm/src/tab-label.vala:62 ../treebrowser/src/treebrowser.c:2132
+#: ../multiterm/src/tab-label.vala:62 ../treebrowser/src/treebrowser.c:2137
 #, fuzzy
 msgid "Terminal"
 msgstr "Terminado"
@@ -5556,116 +5528,6 @@ msgstr ""
 msgid "Show Overview"
 msgstr "Executar nun terminal"
 
-#: ../overview/data/prefs.ui.h:1
-msgid ""
-"The amount to zoom the overview sidebar. This should probably negative if "
-"you want the sidebar zoomed out."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:2
-msgid "Zoom Level:"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:3
-msgid "The width of the overview sidebar."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:4
-msgid "Width:"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:5
-msgid ""
-"The number of lines to scroll at a time when scrolling the overview sidebar."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:6
-msgid "Scroll Lines:"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:7
-#, fuzzy
-msgid "Position on left"
-msgstr "Nome da posición"
-
-#: ../overview/data/prefs.ui.h:8
-msgid ""
-"Position the overview bar on the left rather than the right (requires Geany "
-"1.25 or greater)."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:9
-#, fuzzy
-msgid "Hide tooltip"
-msgstr "Mostrar as indicacións."
-
-#: ../overview/data/prefs.ui.h:10
-msgid ""
-"Hide the tooltip that is displayed when mousing over the overview that shows "
-"line, column and position information."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:11
-msgid "Hide editor scrollbar"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:12
-msgid ""
-"Whether to hide Geany's regular editor scrollbar while the overview bar is "
-"visible."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:13
-msgid "Disable overlay"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:14
-msgid ""
-"Turn off drawing overlay, which shows the region of the main editor view "
-"that is currently in view, ontop of the overview bar."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:15 ../scope/data/scope.glade.h:130
-#: ../scope/data/scope_gtk3.glade.h:130
-#, fuzzy
-msgid "Options"
-msgstr "_Opcións"
-
-#: ../overview/data/prefs.ui.h:16
-msgid ""
-"The color and opacity of the overlay drawn ontop of the overlay sidebar."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:17
-msgid "Color:"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:18
-msgid ""
-"The color and opacity of the border drawn around the revealed area in the "
-"overview sidebar. Set to the same as Overlay Color to disable."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:19
-#, fuzzy
-msgid "Outline Color:"
-msgstr "Seleccionar a cor"
-
-#: ../overview/data/prefs.ui.h:20
-msgid "Draw over visible area"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:21
-msgid ""
-"When checked it will draw the overlay ontop of the area that is visible in "
-"the main editor view, when unchecked, it will do the opposite and draw the "
-"overlay everywhere but the visible area, \"revealing\" the visible part."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:22
-msgid "Overlay"
-msgstr ""
-
 #: ../pairtaghighlighter/src/pair_tag_highlighter.c:43
 msgid "Pair Tag Highlighter"
 msgstr ""
@@ -5693,150 +5555,6 @@ msgstr "Seleccionar ata a _chave correspondente"
 #, fuzzy
 msgid "Select To Matching Tag"
 msgstr "Seleccionar ata a _chave correspondente"
-
-#: ../pohelper/data/menus.ui.h:1
-msgid "_Translation Helper"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:2
-msgid "_Previous String"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:3 ../pohelper/src/gph-plugin.c:1590
-#, fuzzy
-msgid "Go to previous string"
-msgstr "Volver ó diálogo anterior"
-
-#: ../pohelper/data/menus.ui.h:4
-msgid "_Next String"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:5 ../pohelper/src/gph-plugin.c:1593
-#, fuzzy
-msgid "Go to next string"
-msgstr "Pasar á liña seguinte"
-
-#: ../pohelper/data/menus.ui.h:6
-msgid "Pre_vious Untranslated"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:7 ../pohelper/src/gph-plugin.c:1596
-msgid "Go to previous untranslated string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:8
-msgid "Next _Untranslated"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:9 ../pohelper/src/gph-plugin.c:1599
-msgid "Go to next untranslated string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:10
-msgid "Previous Fu_zzy"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:11 ../pohelper/src/gph-plugin.c:1602
-msgid "Go to previous fuzzily translated string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:12
-msgid "Next _Fuzzy"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:13 ../pohelper/src/gph-plugin.c:1605
-msgid "Go to next fuzzily translated string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:14
-msgid "Previous Untranslated or Fuzz_y"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:15 ../pohelper/src/gph-plugin.c:1608
-msgid "Go to previous untranslated or fuzzy string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:16
-msgid "Next Untranslated _or Fuzzy"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:17 ../pohelper/src/gph-plugin.c:1612
-msgid "Go to next untranslated or fuzzy string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:18 ../pohelper/src/gph-plugin.c:1623
-#, fuzzy
-msgid "Toggle current translation fuzziness"
-msgstr "Tipo de documentación"
-
-#: ../pohelper/data/menus.ui.h:19
-msgid "_Toggle Fuzziness"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:20
-msgid "Paste _Message as Translation"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:21
-msgid "Paste the original untranslated string to the translation"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:22 ../pohelper/src/gph-plugin.c:1620
-msgid "Reflow the current translation string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:23
-msgid "_Reflow Translation"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:24 ../pohelper/src/gph-plugin.c:1626
-#, fuzzy
-msgid "Show statistics of the current document"
-msgstr "Verifica a ortografía do documento actual."
-
-#: ../pohelper/data/menus.ui.h:25
-#, fuzzy
-msgid "_Show stats"
-msgstr "Mostrar estado"
-
-#: ../pohelper/data/menus.ui.h:26
-msgid ""
-"Whether to update the translation headers (author, revision date, ...) upon "
-"file save"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:27
-msgid "Update _Headers Upon Save"
-msgstr ""
-
-#: ../pohelper/data/stats.ui.h:1
-msgid "Translation statistics"
-msgstr ""
-
-#: ../pohelper/data/stats.ui.h:2
-msgid "Choose a color for translated strings"
-msgstr ""
-
-#: ../pohelper/data/stats.ui.h:3
-msgid "Choose a color for fuzzily translated strings"
-msgstr ""
-
-#: ../pohelper/data/stats.ui.h:4
-msgid "Choose a color for untranslated strings"
-msgstr ""
-
-#: ../pohelper/data/stats.ui.h:5
-#, fuzzy
-msgid "Translated:"
-msgstr "Modelo:"
-
-#: ../pohelper/data/stats.ui.h:6
-msgid "Fuzzy:"
-msgstr ""
-
-#: ../pohelper/data/stats.ui.h:7
-msgid "Untranslated:"
-msgstr ""
 
 #: ../pohelper/src/gph-plugin.c:40
 msgid "Translation Helper"
@@ -5866,9 +5584,57 @@ msgstr ""
 msgid "%u (%.3g%%)"
 msgstr ""
 
+#: ../pohelper/src/gph-plugin.c:1590
+#, fuzzy
+msgid "Go to previous string"
+msgstr "Volver ó diálogo anterior"
+
+#: ../pohelper/src/gph-plugin.c:1593
+#, fuzzy
+msgid "Go to next string"
+msgstr "Pasar á liña seguinte"
+
+#: ../pohelper/src/gph-plugin.c:1596
+msgid "Go to previous untranslated string"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1599
+msgid "Go to next untranslated string"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1602
+msgid "Go to previous fuzzily translated string"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1605
+msgid "Go to next fuzzily translated string"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1608
+msgid "Go to previous untranslated or fuzzy string"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1612
+msgid "Go to next untranslated or fuzzy string"
+msgstr ""
+
 #: ../pohelper/src/gph-plugin.c:1616
 msgid "Paste original untranslated string to translation"
 msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1620
+msgid "Reflow the current translation string"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1623
+#, fuzzy
+msgid "Toggle current translation fuzziness"
+msgstr "Tipo de documentación"
+
+#: ../pohelper/src/gph-plugin.c:1626
+#, fuzzy
+msgid "Show statistics of the current document"
+msgstr "Verifica a ortografía do documento actual."
 
 #: ../pohelper/src/gph-plugin.c:1833
 #, c-format
@@ -6149,7 +5915,7 @@ msgid "Add"
 msgstr "Engadidos"
 
 #: ../projectorganizer/src/prjorg-sidebar.c:390
-#: ../treebrowser/src/treebrowser.c:2356
+#: ../treebrowser/src/treebrowser.c:2361
 #, fuzzy
 msgid "New File"
 msgstr "NovoFicheiro"
@@ -6827,6 +6593,11 @@ msgstr "Mostrar as indicacións."
 msgid "<b>Others</b>"
 msgstr ""
 
+#: ../scope/data/scope.glade.h:130 ../scope/data/scope_gtk3.glade.h:130
+#, fuzzy
+msgid "Options"
+msgstr "_Opcións"
+
 #: ../scope/data/scope.glade.h:131 ../scope/data/scope_gtk3.glade.h:131
 #, fuzzy
 msgid "_Import"
@@ -7104,8 +6875,8 @@ msgstr ""
 #, fuzzy, c-format
 msgid "Could not load debug settings file %s: %s."
 msgstr ""
-"Produciuse un erro ao cargar o tipo de ficheiro \"%s\" dende o ficheiro \"%s"
-"\": %s"
+"Produciuse un erro ao cargar o tipo de ficheiro \"%s\" dende o ficheiro "
+"\"%s\": %s"
 
 #: ../scope/src/program.c:387
 #, fuzzy, c-format
@@ -7454,12 +7225,14 @@ msgid "Checks the spelling of the current document."
 msgstr "Verifica a ortografía do documento actual."
 
 #: ../spellcheck/src/scplugin.c:225
-msgid "Run Spell Check"
+#, fuzzy
+msgid "Run spell check once"
 msgstr "Executar a verificación ortográfica"
 
-#: ../spellcheck/src/scplugin.c:228
-msgid "Toggle Check While Typing"
-msgstr "Intercambiar a verificación mentres se escribe"
+#: ../spellcheck/src/scplugin.c:228 ../spellcheck/src/scplugin.c:333
+#, fuzzy
+msgid "Toggle spell check"
+msgstr "Verificación ortográfica"
 
 #. initialise the dialog
 #: ../spellcheck/src/scplugin.c:239
@@ -7489,10 +7262,6 @@ msgstr "Imprimir os erros ortográficos e suxestións na xanela de mensaxes"
 #: ../spellcheck/src/scplugin.c:325
 msgid "<b>Interface</b>"
 msgstr ""
-
-#: ../spellcheck/src/scplugin.c:333
-msgid "Check spelling while typing"
-msgstr "Verificar a ortografía mentres se escribe"
 
 #: ../spellcheck/src/scplugin.c:336
 #, fuzzy
@@ -7528,32 +7297,32 @@ msgstr ""
 msgid "<b>Behavior</b>"
 msgstr ""
 
-#: ../spellcheck/src/gui.c:76
+#: ../spellcheck/src/gui.c:88
 msgid "Spell checking while typing is now enabled"
 msgstr "A verificación ortográfica mentres se escribe está agora habilitada"
 
-#: ../spellcheck/src/gui.c:78
+#: ../spellcheck/src/gui.c:90
 msgid "Spell checking while typing is now disabled"
 msgstr "A verificación ortográfica mentres se escribe está agora deshabilitada"
 
-#: ../spellcheck/src/gui.c:326
+#: ../spellcheck/src/gui.c:323
 msgid "More..."
 msgstr "Máis..."
 
-#: ../spellcheck/src/gui.c:347
+#: ../spellcheck/src/gui.c:344
 msgid "(No Suggestions)"
 msgstr "(Non hai recomendacións)"
 
-#: ../spellcheck/src/gui.c:360
+#: ../spellcheck/src/gui.c:357
 #, c-format
 msgid "Add \"%s\" to Dictionary"
 msgstr "Engadir \"%s\" ó Diccionario"
 
-#: ../spellcheck/src/gui.c:368
+#: ../spellcheck/src/gui.c:365
 msgid "Ignore All"
 msgstr "Ignorar Todo"
 
-#: ../spellcheck/src/gui.c:441
+#: ../spellcheck/src/gui.c:438
 msgid ""
 "Search term is too long to provide\n"
 "spelling suggestions in the editor menu."
@@ -7561,23 +7330,23 @@ msgstr ""
 "O termo de busca é demasiado longo para fornecer\n"
 "suxestións ortográficas no menú do editor."
 
-#: ../spellcheck/src/gui.c:447
+#: ../spellcheck/src/gui.c:444
 msgid "Perform Spell Check"
 msgstr "Efectuar a verificación ortográfica"
 
-#: ../spellcheck/src/gui.c:609
+#: ../spellcheck/src/gui.c:606
 #, c-format
 msgid "Default (%s)"
 msgstr "Predeterminado (%s)"
 
-#: ../spellcheck/src/gui.c:620
-#, c-format
-msgid "Toggle spell check while typing (current language: %s)"
+#: ../spellcheck/src/gui.c:617
+#, fuzzy, c-format
+msgid "Toggle spell check (current language: %s)"
 msgstr ""
 "Intercambiar a verificación ortográfica mentres se escribe (o idioma actual "
 "é: %s)"
 
-#: ../spellcheck/src/gui.c:698
+#: ../spellcheck/src/gui.c:695
 msgid "Spelling Suggestions"
 msgstr "Recomendacións de Ortografía"
 
@@ -7673,145 +7442,145 @@ msgstr "Baleiro"
 msgid "Could not execute configured external command '%s' (%s)."
 msgstr "Non foi posíbel executar a orde externa configurada '%s' (%s)"
 
-#: ../treebrowser/src/treebrowser.c:1089
+#: ../treebrowser/src/treebrowser.c:1093
 msgid "NewDirectory"
 msgstr "NovoDirectorio"
 
-#: ../treebrowser/src/treebrowser.c:1091
+#: ../treebrowser/src/treebrowser.c:1095
 msgid "NewFile"
 msgstr "NovoFicheiro"
 
-#: ../treebrowser/src/treebrowser.c:1096
+#: ../treebrowser/src/treebrowser.c:1100
 #, c-format
 msgid ""
 "Target file '%s' exists.\n"
 "Do you really want to replace it with an empty file?"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1142
+#: ../treebrowser/src/treebrowser.c:1146
 #, c-format
 msgid "Do you really want to delete '%s' ?"
 msgstr "Está seguro de que desexa borrar '%s' ?"
 
-#: ../treebrowser/src/treebrowser.c:1255 ../treebrowser/src/treebrowser.c:1257
+#: ../treebrowser/src/treebrowser.c:1259 ../treebrowser/src/treebrowser.c:1261
 msgid "Go _Up"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1263 ../treebrowser/src/treebrowser.c:1265
+#: ../treebrowser/src/treebrowser.c:1267 ../treebrowser/src/treebrowser.c:1269
 #, fuzzy
 msgid "Set _Path From Document"
 msgstr "Definir camiño a partir de documento"
 
-#: ../treebrowser/src/treebrowser.c:1271 ../treebrowser/src/treebrowser.c:1273
+#: ../treebrowser/src/treebrowser.c:1275 ../treebrowser/src/treebrowser.c:1277
 #, fuzzy
 msgid "_Open Externally"
 msgstr "Abrir externamente"
 
-#: ../treebrowser/src/treebrowser.c:1279
+#: ../treebrowser/src/treebrowser.c:1283
 #, fuzzy
 msgid "Open _Terminal"
 msgstr "Abrir terminal"
 
-#: ../treebrowser/src/treebrowser.c:1284 ../treebrowser/src/treebrowser.c:1286
+#: ../treebrowser/src/treebrowser.c:1288 ../treebrowser/src/treebrowser.c:1290
 #, fuzzy
 msgid "Set as _Root"
 msgstr "Definir como raíz"
 
-#: ../treebrowser/src/treebrowser.c:1293 ../treebrowser/src/treebrowser.c:1295
+#: ../treebrowser/src/treebrowser.c:1297 ../treebrowser/src/treebrowser.c:1299
 #, fuzzy
 msgid "Refres_h"
 msgstr "Actualizar"
 
-#: ../treebrowser/src/treebrowser.c:1301 ../treebrowser/src/treebrowser.c:1303
+#: ../treebrowser/src/treebrowser.c:1305 ../treebrowser/src/treebrowser.c:1307
 #, fuzzy
 msgid "_Find in Files"
 msgstr "Procurar en todo o proxecto "
 
-#: ../treebrowser/src/treebrowser.c:1313 ../treebrowser/src/treebrowser.c:1315
+#: ../treebrowser/src/treebrowser.c:1317 ../treebrowser/src/treebrowser.c:1319
 #, fuzzy
 msgid "N_ew Folder"
 msgstr "Seleccionar a cor"
 
-#: ../treebrowser/src/treebrowser.c:1321 ../treebrowser/src/treebrowser.c:1323
+#: ../treebrowser/src/treebrowser.c:1325 ../treebrowser/src/treebrowser.c:1327
 #, fuzzy
 msgid "_New File"
 msgstr "NovoFicheiro"
 
-#: ../treebrowser/src/treebrowser.c:1329 ../treebrowser/src/treebrowser.c:1331
+#: ../treebrowser/src/treebrowser.c:1333 ../treebrowser/src/treebrowser.c:1335
 #, fuzzy
 msgid "Rena_me"
 msgstr "Renomear"
 
-#: ../treebrowser/src/treebrowser.c:1350 ../treebrowser/src/treebrowser.c:1352
+#: ../treebrowser/src/treebrowser.c:1354 ../treebrowser/src/treebrowser.c:1356
 #, c-format
 msgid "Close: %s"
 msgstr "Pechar: %s"
 
-#: ../treebrowser/src/treebrowser.c:1359 ../treebrowser/src/treebrowser.c:1361
+#: ../treebrowser/src/treebrowser.c:1363 ../treebrowser/src/treebrowser.c:1365
 #, fuzzy, c-format
 msgid "Clo_se Child Documents "
 msgstr "Pec_har os outros documentos"
 
-#: ../treebrowser/src/treebrowser.c:1368 ../treebrowser/src/treebrowser.c:1370
+#: ../treebrowser/src/treebrowser.c:1372 ../treebrowser/src/treebrowser.c:1374
 #, fuzzy
 msgid "_Copy Full Path to Clipboard"
 msgstr "Copiar o camiño completo"
 
-#: ../treebrowser/src/treebrowser.c:1381 ../treebrowser/src/treebrowser.c:1383
+#: ../treebrowser/src/treebrowser.c:1385 ../treebrowser/src/treebrowser.c:1387
 #, fuzzy
 msgid "E_xpand All"
 msgstr "Expandir todos"
 
-#: ../treebrowser/src/treebrowser.c:1389 ../treebrowser/src/treebrowser.c:1391
+#: ../treebrowser/src/treebrowser.c:1393 ../treebrowser/src/treebrowser.c:1395
 #, fuzzy
 msgid "Coll_apse All"
 msgstr "Contraer todos"
 
-#: ../treebrowser/src/treebrowser.c:1399
+#: ../treebrowser/src/treebrowser.c:1403
 #, fuzzy
 msgid "Show Boo_kmarks"
 msgstr "Mostrar marcadores"
 
-#: ../treebrowser/src/treebrowser.c:1404
+#: ../treebrowser/src/treebrowser.c:1408
 #, fuzzy
 msgid "Sho_w Hidden Files"
 msgstr "Mostrar os ficheiros ocultos"
 
-#: ../treebrowser/src/treebrowser.c:1409
+#: ../treebrowser/src/treebrowser.c:1413
 #, fuzzy
 msgid "Show Tool_bars"
 msgstr "Mostrar barras"
 
-#: ../treebrowser/src/treebrowser.c:1747
+#: ../treebrowser/src/treebrowser.c:1751
 #, c-format
 msgid "Target file '%s' exists, do you really want to replace it?"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1883
+#: ../treebrowser/src/treebrowser.c:1887
 msgid "Go up"
 msgstr "Subir"
 
-#: ../treebrowser/src/treebrowser.c:1893 ../treebrowser/src/treebrowser.c:2360
+#: ../treebrowser/src/treebrowser.c:1897 ../treebrowser/src/treebrowser.c:2365
 msgid "Refresh"
 msgstr "Actualizar"
 
-#: ../treebrowser/src/treebrowser.c:1903
+#: ../treebrowser/src/treebrowser.c:1907
 msgid "Home"
 msgstr "Inicio"
 
-#: ../treebrowser/src/treebrowser.c:1913
+#: ../treebrowser/src/treebrowser.c:1917
 msgid "Set path from document"
 msgstr "Definir camiño a partir de documento"
 
-#: ../treebrowser/src/treebrowser.c:1923
+#: ../treebrowser/src/treebrowser.c:1927
 msgid "Track path"
 msgstr "RExistrar camiño"
 
-#: ../treebrowser/src/treebrowser.c:1933
+#: ../treebrowser/src/treebrowser.c:1937
 msgid "Hide bars"
 msgstr "Ocultar barras"
 
-#: ../treebrowser/src/treebrowser.c:1943
+#: ../treebrowser/src/treebrowser.c:1947
 msgid ""
 "Filter (*.c;*.h;*.cpp), and if you want temporary filter using the '!' "
 "reverse try for example this '!;*.c;*.h;*.cpp'"
@@ -7819,20 +7588,20 @@ msgstr ""
 "Filtrar (*.c;*.h;*.cpp), e se quere filtrar temporalmente usando o '!' "
 "inverso. Por exemplo pode probar o seguinte: '!;*.c;*.h;*.cpp'"
 
-#: ../treebrowser/src/treebrowser.c:1948
+#: ../treebrowser/src/treebrowser.c:1952
 msgid "Addressbar for example '/projects/my-project'"
 msgstr "Barra de enderezo, por exemplo '/proxectos/o-meu-proxecto'"
 
-#: ../treebrowser/src/treebrowser.c:1973
+#: ../treebrowser/src/treebrowser.c:1977
 msgid "Tree Browser"
 msgstr "Explorador en árbore"
 
-#: ../treebrowser/src/treebrowser.c:2114
+#: ../treebrowser/src/treebrowser.c:2118
 msgid "External open command"
 msgstr "Orde externa para abrir"
 
-#: ../treebrowser/src/treebrowser.c:2124
-#, c-format
+#: ../treebrowser/src/treebrowser.c:2129
+#, no-c-format
 msgid ""
 "The command to execute when using \"Open with\". You can use %f and %d "
 "wildcards.\n"
@@ -7845,65 +7614,65 @@ msgstr ""
 "%f substituirase polo nome do ficheiro incluíndo o camiño completo\n"
 "%d substiruirase polo camiño ao ficheiro seleccionado, sen o nome de ficheiro"
 
-#: ../treebrowser/src/treebrowser.c:2143
+#: ../treebrowser/src/treebrowser.c:2148
 msgid "The terminal to use with the command \"Open Terminal\""
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2149
+#: ../treebrowser/src/treebrowser.c:2154
 msgid "Toolbar"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2151
+#: ../treebrowser/src/treebrowser.c:2156
 msgid "Hidden"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2152
+#: ../treebrowser/src/treebrowser.c:2157
 msgid "Top"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2153
+#: ../treebrowser/src/treebrowser.c:2158
 msgid "Bottom"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2158
+#: ../treebrowser/src/treebrowser.c:2163
 #, fuzzy
 msgid "If position is changed, the option require plugin restart."
 msgstr "Mostrar barras no alto (require o reinicio do complemento)"
 
-#: ../treebrowser/src/treebrowser.c:2162
+#: ../treebrowser/src/treebrowser.c:2167
 #, fuzzy
 msgid "Show icons"
 msgstr "Mostrar iconas."
 
-#: ../treebrowser/src/treebrowser.c:2164
+#: ../treebrowser/src/treebrowser.c:2169
 msgid "None"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2165
+#: ../treebrowser/src/treebrowser.c:2170
 #, fuzzy
 msgid "Base"
 msgstr "_Base:"
 
-#: ../treebrowser/src/treebrowser.c:2166
+#: ../treebrowser/src/treebrowser.c:2171
 #, fuzzy
 msgid "Content-type"
 msgstr "Contidos"
 
-#: ../treebrowser/src/treebrowser.c:2172
+#: ../treebrowser/src/treebrowser.c:2177
 msgid "Show hidden files"
 msgstr "Mostrar os ficheiros ocultos"
 
-#: ../treebrowser/src/treebrowser.c:2181
+#: ../treebrowser/src/treebrowser.c:2186
 msgid "On Windows, this just hide files that are prefixed with '.' (dot)"
 msgstr ""
 "En windows, isto simplemente oculta os ficheiros que leven por prefixo un "
 "punto ('.')"
 
-#: ../treebrowser/src/treebrowser.c:2183
+#: ../treebrowser/src/treebrowser.c:2188
 msgid "Hide object files"
 msgstr "Ocultar ficheiros obxecto"
 
-#: ../treebrowser/src/treebrowser.c:2192
+#: ../treebrowser/src/treebrowser.c:2197
 msgid ""
 "Don't show generated object files in the file browser, this includes *.o, *."
 "obj. *.so, *.dll, *.a, *.lib"
@@ -7911,63 +7680,63 @@ msgstr ""
 "Non mostrar ficheiros obxecto no navegador de ficheiros. Isto inclúe *.o, *."
 "obj. *.so, *.dll, *.a, *.lib"
 
-#: ../treebrowser/src/treebrowser.c:2194
+#: ../treebrowser/src/treebrowser.c:2199
 msgid "Reverse filter"
 msgstr "Inverter o filtro"
 
-#: ../treebrowser/src/treebrowser.c:2203
+#: ../treebrowser/src/treebrowser.c:2208
 msgid "Follow current document"
 msgstr "Seguir o documento actual"
 
-#: ../treebrowser/src/treebrowser.c:2212
+#: ../treebrowser/src/treebrowser.c:2217
 msgid "Single click, open document and focus it"
 msgstr "Un só click abre o documento e enfñocase nel"
 
-#: ../treebrowser/src/treebrowser.c:2221
+#: ../treebrowser/src/treebrowser.c:2226
 msgid "Double click open directory"
 msgstr "Premer dúas veces para abrir directorio"
 
-#: ../treebrowser/src/treebrowser.c:2230
+#: ../treebrowser/src/treebrowser.c:2235
 msgid "On delete file, close it if is opened"
 msgstr "Ao borrar un ficheiro, pechalo se está aberto"
 
-#: ../treebrowser/src/treebrowser.c:2239
+#: ../treebrowser/src/treebrowser.c:2244
 msgid "Focus editor on file open"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2248
+#: ../treebrowser/src/treebrowser.c:2253
 msgid "Show tree lines"
 msgstr "Mostrar as liñas da árbore"
 
-#: ../treebrowser/src/treebrowser.c:2257
+#: ../treebrowser/src/treebrowser.c:2262
 msgid "Show bookmarks"
 msgstr "Mostrar marcadores"
 
-#: ../treebrowser/src/treebrowser.c:2266
+#: ../treebrowser/src/treebrowser.c:2271
 #, fuzzy
 msgid "Open new files"
 msgstr "Abrir ficheiro"
 
-#: ../treebrowser/src/treebrowser.c:2350
+#: ../treebrowser/src/treebrowser.c:2355
 #, fuzzy
 msgid "Focus File List"
 msgstr "Enfocar na lista de tarefas"
 
-#: ../treebrowser/src/treebrowser.c:2352
+#: ../treebrowser/src/treebrowser.c:2357
 msgid "Focus Path Entry"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2354
+#: ../treebrowser/src/treebrowser.c:2359
 #, fuzzy
 msgid "Rename Object"
 msgstr "Renomear"
 
-#: ../treebrowser/src/treebrowser.c:2358
+#: ../treebrowser/src/treebrowser.c:2363
 #, fuzzy
 msgid "New Folder"
 msgstr "Seleccionar a cor"
 
-#: ../treebrowser/src/treebrowser.c:2362
+#: ../treebrowser/src/treebrowser.c:2367
 #, fuzzy
 msgid "Track Current"
 msgstr "RExistrar camiño"
@@ -8429,16 +8198,16 @@ msgstr "Crear un ficheiro novo"
 #, fuzzy, c-format
 msgid "Could not open workbench file: %s"
 msgstr ""
-"Produciuse un erro ao cargar o tipo de ficheiro \"%s\" dende o ficheiro \"%s"
-"\": %s"
+"Produciuse un erro ao cargar o tipo de ficheiro \"%s\" dende o ficheiro "
+"\"%s\": %s"
 
 #: ../workbench/src/menu.c:155 ../workbench/src/popup_menu.c:265
 #: ../workbench/src/search_projects.c:188
 #, fuzzy, c-format
 msgid "Could not save workbench file: %s"
 msgstr ""
-"Produciuse un erro ao cargar o tipo de ficheiro \"%s\" dende o ficheiro \"%s"
-"\": %s"
+"Produciuse un erro ao cargar o tipo de ficheiro \"%s\" dende o ficheiro "
+"\"%s\": %s"
 
 #. Set metadata
 #: ../workbench/src/menu.c:207 ../workbench/src/plugin_main.c:132
@@ -8488,8 +8257,8 @@ msgstr ""
 #, fuzzy, c-format
 msgid "Could not add project file: %s"
 msgstr ""
-"Produciuse un erro ao cargar o tipo de ficheiro \"%s\" dende o ficheiro \"%s"
-"\": %s"
+"Produciuse un erro ao cargar o tipo de ficheiro \"%s\" dende o ficheiro "
+"\"%s\": %s"
 
 #: ../workbench/src/popup_menu.c:602
 #, fuzzy, c-format
@@ -8680,13 +8449,6 @@ msgstr "NovoDirectorio"
 msgid "No workbench opened."
 msgstr ""
 
-#: ../workbench/src/sidebar.c:875
-#, fuzzy, c-format
-msgid "%s: %u Project"
-msgid_plural "%s: %u Projects"
-msgstr[0] "Proxecto"
-msgstr[1] "Proxecto"
-
 #: ../workbench/src/sidebar.c:886
 msgid ""
 "Add a project using the context menu\n"
@@ -8796,6 +8558,42 @@ msgstr ""
 #: ../xmlsnippets/src/plugin.c:45
 msgid "Autocompletes XML/HTML tags using snippets."
 msgstr ""
+
+#, fuzzy
+#~ msgid "_Removed lines:"
+#~ msgstr "Eliminar ficheiro"
+
+#, fuzzy
+#~ msgid "Position on left"
+#~ msgstr "Nome da posición"
+
+#, fuzzy
+#~ msgid "Hide tooltip"
+#~ msgstr "Mostrar as indicacións."
+
+#, fuzzy
+#~ msgid "Outline Color:"
+#~ msgstr "Seleccionar a cor"
+
+#, fuzzy
+#~ msgid "_Show stats"
+#~ msgstr "Mostrar estado"
+
+#, fuzzy
+#~ msgid "Translated:"
+#~ msgstr "Modelo:"
+
+#~ msgid "Toggle Check While Typing"
+#~ msgstr "Intercambiar a verificación mentres se escribe"
+
+#~ msgid "Check spelling while typing"
+#~ msgstr "Verificar a ortografía mentres se escribe"
+
+#, fuzzy, c-format
+#~ msgid "%s: %u Project"
+#~ msgid_plural "%s: %u Projects"
+#~ msgstr[0] "Proxecto"
+#~ msgstr[1] "Proxecto"
 
 #~ msgid "GeanyLaTeX"
 #~ msgstr "GeanyLaTeX"

--- a/po/it.po
+++ b/po/it.po
@@ -6,8 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Geany-Plugins 1.30\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-29 19:41+0200\n"
+"Report-Msgid-Bugs-To: https://github.com/geany/geany/issues\n"
+"POT-Creation-Date: 2022-06-28 07:39+0200\n"
 "PO-Revision-Date: 2014-04-09 07:23+0200\n"
 "Last-Translator: Federico Reghenzani <federico.dev@reghe.net>\n"
 "Language-Team: Italian\n"
@@ -21,27 +21,27 @@ msgstr ""
 msgid "(Empty Line)"
 msgstr "(Linea vuota)"
 
-#: ../addons/src/ao_bookmarklist.c:315
+#: ../addons/src/ao_bookmarklist.c:331
 msgid "_Remove Bookmark"
 msgstr "_Rimuovi segnalibro"
 
 #. Translators: Number is meant at this point.
-#: ../addons/src/ao_bookmarklist.c:342
+#: ../addons/src/ao_bookmarklist.c:358
 msgid "No."
 msgstr "N°"
 
-#: ../addons/src/ao_bookmarklist.c:350 ../devhelp/src/dhp-object.c:494
+#: ../addons/src/ao_bookmarklist.c:366 ../devhelp/src/dhp-object.c:494
 #: ../devhelp/devhelp/dh-window.c:1142
 msgid "Contents"
 msgstr "Contenuti"
 
-#: ../addons/src/ao_bookmarklist.c:383 ../treebrowser/src/treebrowser.c:666
+#: ../addons/src/ao_bookmarklist.c:399 ../treebrowser/src/treebrowser.c:666
 #: ../webhelper/src/gwh-plugin.c:328
 msgid "Bookmarks"
 msgstr "Segnalibri"
 
 #. complete update
-#: ../addons/src/ao_tasks.c:373 ../geanyvc/src/geanyvc.c:2679
+#: ../addons/src/ao_tasks.c:373 ../geanyvc/src/geanyvc.c:2730
 msgid "_Update"
 msgstr "_Aggiorna"
 
@@ -164,10 +164,10 @@ msgstr "Controlla l'ortografia del documento corrente."
 #: ../addons/src/addons.c:364 ../autoclose/src/autoclose.c:920
 #: ../codenav/src/codenavigation.c:281 ../latex/src/latex.c:208
 #: ../latex/src/latex.c:293 ../geanyprj/src/geanyprj.c:176
-#: ../geanyvc/src/geanyvc.c:2079 ../geniuspaste/src/geniuspaste.c:336
+#: ../geanyvc/src/geanyvc.c:2130 ../geniuspaste/src/geniuspaste.c:336
 #: ../lineoperations/src/lo_prefs.c:58 ../sendmail/src/sendmail.c:128
 #: ../sendmail/src/sendmail.c:293 ../spellcheck/src/scplugin.c:124
-#: ../treebrowser/src/treebrowser.c:2102
+#: ../treebrowser/src/treebrowser.c:2106
 #: ../updatechecker/src/updatechecker.c:262
 msgid "Plugin configuration directory could not be created."
 msgstr "La cartella della configurazione dei plugin non può essere creata."
@@ -723,7 +723,7 @@ msgstr "~\"Caricamento file target.\\n\""
 msgid "Error loading file"
 msgstr "Impossibile caricare il file"
 
-#. setting asyncronous mode
+#. setting asynchronous mode
 #. setting null-stop array printing
 #. enable pretty printing
 #: ../debugger/src/dbm_gdb.c:789 ../debugger/src/dbm_gdb.c:792
@@ -1125,7 +1125,7 @@ msgid "A developers' help browser for GNOME"
 msgstr "Un help-browser degli sviluppatori per GNOME"
 
 #. Create the current file Submenu
-#: ../devhelp/devhelp/dh-window.c:759 ../geanyvc/src/geanyvc.c:2660
+#: ../devhelp/devhelp/dh-window.c:759 ../geanyvc/src/geanyvc.c:2711
 msgid "_File"
 msgstr "_File"
 
@@ -1159,11 +1159,11 @@ msgstr "Nuovo _Tab"
 msgid "_Print…"
 msgstr "_Stampa"
 
-#: ../devhelp/devhelp/dh-window.c:782 ../devhelp/devhelp/eggfindbar.c:342
+#: ../devhelp/devhelp/dh-window.c:782
 msgid "Find Next"
 msgstr "Trova successivo"
 
-#: ../devhelp/devhelp/dh-window.c:784 ../devhelp/devhelp/eggfindbar.c:329
+#: ../devhelp/devhelp/dh-window.c:784
 msgid "Find Previous"
 msgstr "Trova precedente"
 
@@ -1357,7 +1357,7 @@ msgid ""
 "contributing to this plugin?"
 msgstr ""
 
-#: ../geanydoc/src/geanydoc.c:159 ../geanyvc/src/geanyvc.c:442
+#: ../geanydoc/src/geanydoc.c:159 ../geanyvc/src/geanyvc.c:448
 msgid "Could not parse the output of command"
 msgstr "Impossibile analizzare l'output del comando"
 
@@ -3075,7 +3075,7 @@ msgstr ""
 "Errore nel modulo \"%s\" alla funzione %s():\n"
 "parametri non sufficienti per il comando \"%s\".\n"
 
-#: ../geanylua/glspi_sci.c:637 ../geanylua/glspi_app.c:406
+#: ../geanylua/glspi_sci.c:729 ../geanylua/glspi_app.c:406
 #, c-format
 msgid ""
 "Error in module \"%s\" at function %s():\n"
@@ -3084,7 +3084,7 @@ msgstr ""
 "Errore nel modulo \"%s\" alla funzione %s():\n"
 "comando sconosciuto \"%s\" per l'argomento #1.\n"
 
-#: ../geanylua/glspi_sci.c:781
+#: ../geanylua/glspi_sci.c:924
 #, c-format
 msgid ""
 "Error in module \"%s\" at function %s():\n"
@@ -3095,7 +3095,7 @@ msgstr ""
 " tabella non valida nell'argomento #%d:\n"
 " flag \"%s\" sconosciuto per l'elemento #%d\n"
 
-#: ../geanylua/glspi_sci.c:785
+#: ../geanylua/glspi_sci.c:928
 msgid "<too large to display>"
 msgstr "<troppo grande da visualizzare>"
 
@@ -3888,7 +3888,7 @@ msgid "New _Below"
 msgstr "Nuovo So_tto"
 
 #: ../geanymacro/src/geanymacro.c:1824 ../geanymacro/src/geanymacro.c:2120
-#: ../treebrowser/src/treebrowser.c:1338 ../treebrowser/src/treebrowser.c:1340
+#: ../treebrowser/src/treebrowser.c:1342 ../treebrowser/src/treebrowser.c:1344
 msgid "_Delete"
 msgstr "_Elimina"
 
@@ -4301,8 +4301,8 @@ msgstr ""
 msgid "a key with fingerprint"
 msgstr "una chiave con fingerprint"
 
-#: ../geanypg/src/verify_aux.c:66 ../spellcheck/src/gui.c:610
-#: ../spellcheck/src/gui.c:621
+#: ../geanypg/src/verify_aux.c:66 ../spellcheck/src/gui.c:607
+#: ../spellcheck/src/gui.c:618
 msgid "unknown"
 msgstr "sconosciuto"
 
@@ -4611,49 +4611,49 @@ msgid ""
 "contributing to this plugin?"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:501
+#: ../geanyvc/src/geanyvc.c:507
 #, c-format
 msgid "geanyvc: s_spawn_sync error: %s"
 msgstr "geanyvc: errore s_spawn_sync: %s"
 
-#: ../geanyvc/src/geanyvc.c:587
+#: ../geanyvc/src/geanyvc.c:593
 #, c-format
 msgid "File %s: action %s executed via %s."
 msgstr "File %s: azioni %s eseguiti da %s."
 
-#: ../geanyvc/src/geanyvc.c:646 ../geanyvc/src/geanyvc.c:657
-#, c-format
-msgid "geanyvc: vcdiff_file_activated: Unable to rename '%s' to '%s'"
+#: ../geanyvc/src/geanyvc.c:633 ../geanyvc/src/geanyvc.c:643
+#, fuzzy, c-format
+msgid "geanyvc: diff_external: Unable to rename '%s' to '%s'"
 msgstr "geanyvc: vcdiff_file_activated: Impossibile rinonimare '%s' in '%s'"
 
-#: ../geanyvc/src/geanyvc.c:683 ../geanyvc/src/geanyvc.c:733
+#: ../geanyvc/src/geanyvc.c:698 ../geanyvc/src/geanyvc.c:784
 msgid "No changes were made."
 msgstr "Nessuna modifica effettuata."
 
-#: ../geanyvc/src/geanyvc.c:760
+#: ../geanyvc/src/geanyvc.c:811
 msgid "No history available"
 msgstr "Cronologia non disponibile"
 
-#: ../geanyvc/src/geanyvc.c:953 ../geanyvc/src/geanyvc.c:961
+#: ../geanyvc/src/geanyvc.c:1004 ../geanyvc/src/geanyvc.c:1012
 #, c-format
 msgid "Do you really want to revert: %s?"
 msgstr "Vuoi davvero ripristinare: %s?"
 
-#: ../geanyvc/src/geanyvc.c:969
+#: ../geanyvc/src/geanyvc.c:1020
 #, c-format
 msgid "Do you really want to add: %s?"
 msgstr "Vuoi davvero aggiungere: %s?"
 
-#: ../geanyvc/src/geanyvc.c:976
+#: ../geanyvc/src/geanyvc.c:1027
 #, c-format
 msgid "Do you really want to remove: %s?"
 msgstr "Vuoi davvero rimuovere: %s?"
 
-#: ../geanyvc/src/geanyvc.c:999
+#: ../geanyvc/src/geanyvc.c:1050
 msgid "Do you really want to update?"
 msgstr "Vuoi davvero aggiornare: %s?"
 
-#: ../geanyvc/src/geanyvc.c:1126
+#: ../geanyvc/src/geanyvc.c:1177
 msgid ""
 "The resulting differences cannot be displayed because the changes are too "
 "big to display here and would slow down the UI significantly.\n"
@@ -4668,73 +4668,73 @@ msgstr ""
 "Per vedere le differenze, chiudere questa finestra ed aprirle in Geany "
 "tramite in menu GeanyVC (Directory Base -> Diff)."
 
-#: ../geanyvc/src/geanyvc.c:1280
+#: ../geanyvc/src/geanyvc.c:1331
 msgid "Commit Y/N"
 msgstr "Commit S/N"
 
-#: ../geanyvc/src/geanyvc.c:1290
+#: ../geanyvc/src/geanyvc.c:1341
 msgid "Status"
 msgstr "Stato"
 
-#: ../geanyvc/src/geanyvc.c:1297
+#: ../geanyvc/src/geanyvc.c:1348
 msgid "Path"
 msgstr "Percorso"
 
-#: ../geanyvc/src/geanyvc.c:1414
+#: ../geanyvc/src/geanyvc.c:1465
 msgid "Choose a previous commit message"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1476
+#: ../geanyvc/src/geanyvc.c:1527
 #, c-format
 msgid "Line: %d Column: %d"
 msgstr "Linea: %d Colonna: %d"
 
-#: ../geanyvc/src/geanyvc.c:1523
+#: ../geanyvc/src/geanyvc.c:1574
 msgid "Commit"
 msgstr "Commit"
 
-#: ../geanyvc/src/geanyvc.c:1564
+#: ../geanyvc/src/geanyvc.c:1615
 msgid "_De-/select all files"
 msgstr "_De-/seleziona tutti i file"
 
-#: ../geanyvc/src/geanyvc.c:1608
+#: ../geanyvc/src/geanyvc.c:1659
 msgid "<b>Commit message:</b>"
 msgstr "<b>Messaggio commit:</b>"
 
-#: ../geanyvc/src/geanyvc.c:1632
+#: ../geanyvc/src/geanyvc.c:1683
 msgid "C_ommit"
 msgstr "C_ommit"
 
-#: ../geanyvc/src/geanyvc.c:1740
+#: ../geanyvc/src/geanyvc.c:1791
 msgid "Nothing to commit."
 msgstr "Niente da committare."
 
-#: ../geanyvc/src/geanyvc.c:1788
+#: ../geanyvc/src/geanyvc.c:1839
 #, fuzzy, c-format
 msgid ""
 "Error initializing GeanyVC spell checking: %s. Check your configuration."
 msgstr "Errore nell'inizializzazione del controllo ortografia: %s"
 
-#: ../geanyvc/src/geanyvc.c:1823
+#: ../geanyvc/src/geanyvc.c:1874
 #, c-format
 msgid "Commit failed (status: %d, error: %s)."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1824
+#: ../geanyvc/src/geanyvc.c:1875
 #, fuzzy
 msgid "Commit failed; see status in the Message window."
 msgstr "Visualizza i Task disponibili nella finestra Messaggi"
 
-#: ../geanyvc/src/geanyvc.c:1829
+#: ../geanyvc/src/geanyvc.c:1880
 #, fuzzy
 msgid "Changes committed."
 msgstr "Niente da committare."
 
-#: ../geanyvc/src/geanyvc.c:2151
+#: ../geanyvc/src/geanyvc.c:2202
 msgid "Set Changed-flag for document tabs created by the plugin"
 msgstr "Imposta flag-modificato per i tabs documenti creati dal plugin"
 
-#: ../geanyvc/src/geanyvc.c:2154
+#: ../geanyvc/src/geanyvc.c:2205
 msgid ""
 "If this option is activated, every new by the VC-plugin created document tab "
 "will be marked as changed. Even this option is useful in some cases, it "
@@ -4745,45 +4745,45 @@ msgstr ""
 "alcuni casi, potrebbe produrre un noioso grande numero di finestre \"Vuoi "
 "salvare il file?\""
 
-#: ../geanyvc/src/geanyvc.c:2162
+#: ../geanyvc/src/geanyvc.c:2213
 msgid "Confirm adding new files to a VCS"
 msgstr "Conferma aggiunta nuovo file to VCS"
 
-#: ../geanyvc/src/geanyvc.c:2165
+#: ../geanyvc/src/geanyvc.c:2216
 msgid "Shows a confirmation dialog on adding a new (created) file to VCS."
 msgstr ""
 "Visualizza un dialogo di conferma per aggiungere un nuovo (creato) file al "
 "VCS."
 
-#: ../geanyvc/src/geanyvc.c:2171
+#: ../geanyvc/src/geanyvc.c:2222
 msgid "Maximize commit dialog"
 msgstr "Ingrandisci dialogo commit"
 
-#: ../geanyvc/src/geanyvc.c:2172
+#: ../geanyvc/src/geanyvc.c:2223
 msgid "Show commit dialog maximize."
 msgstr "Visualizza dialogo commit ingrandito."
 
-#: ../geanyvc/src/geanyvc.c:2178
+#: ../geanyvc/src/geanyvc.c:2229
 msgid "Use external diff viewer"
 msgstr "Usa editor diff esterno"
 
-#: ../geanyvc/src/geanyvc.c:2180
+#: ../geanyvc/src/geanyvc.c:2231
 msgid "Use external diff viewer for file diff."
 msgstr "Usa editor diff esterno per differenze."
 
-#: ../geanyvc/src/geanyvc.c:2186
+#: ../geanyvc/src/geanyvc.c:2237
 msgid "Show VC entries at editor menu"
 msgstr "Visualizza voci VC nel menu editor"
 
-#: ../geanyvc/src/geanyvc.c:2188
+#: ../geanyvc/src/geanyvc.c:2239
 msgid "Show entries for VC functions inside editor menu"
 msgstr "Visualizza voci per le funzioni VC all'interno del menu editor"
 
-#: ../geanyvc/src/geanyvc.c:2193
+#: ../geanyvc/src/geanyvc.c:2244
 msgid "Attach menu to menubar"
 msgstr "Poni menu nella menubar"
 
-#: ../geanyvc/src/geanyvc.c:2195
+#: ../geanyvc/src/geanyvc.c:2246
 msgid ""
 "Whether menu for this plugin are getting placed either inside tools menu or "
 "directly inside Geany's menubar. Will take in account after next start of "
@@ -4793,214 +4793,214 @@ msgstr ""
 "menu strumenti o direttamente nella toolbar di Geany. La modifica sarà "
 "visibile dopo il riavvio di Geany."
 
-#: ../geanyvc/src/geanyvc.c:2203
+#: ../geanyvc/src/geanyvc.c:2254
 msgid "Enable CVS"
 msgstr "Abilita CVS"
 
-#: ../geanyvc/src/geanyvc.c:2208
+#: ../geanyvc/src/geanyvc.c:2259
 msgid "Enable GIT"
 msgstr "Abilita GIT"
 
-#: ../geanyvc/src/geanyvc.c:2213
+#: ../geanyvc/src/geanyvc.c:2264
 msgid "Enable Fossil"
 msgstr "Abilita Fossil"
 
-#: ../geanyvc/src/geanyvc.c:2218
+#: ../geanyvc/src/geanyvc.c:2269
 msgid "Enable SVN"
 msgstr "Abilita SVN"
 
-#: ../geanyvc/src/geanyvc.c:2223
+#: ../geanyvc/src/geanyvc.c:2274
 msgid "Enable SVK"
 msgstr "Abilita SVK"
 
-#: ../geanyvc/src/geanyvc.c:2228
+#: ../geanyvc/src/geanyvc.c:2279
 msgid "Enable Bazaar"
 msgstr "Abilita Bazaar"
 
-#: ../geanyvc/src/geanyvc.c:2233
+#: ../geanyvc/src/geanyvc.c:2284
 msgid "Enable Mercurial"
 msgstr "Abilita Mercurial"
 
-#: ../geanyvc/src/geanyvc.c:2239
+#: ../geanyvc/src/geanyvc.c:2290
 msgid "Spellcheck language"
 msgstr "Lingua controllo ortografia"
 
 #. Diff of current file
 #. Diff of the current dir
 #. Complete diff of base directory
-#: ../geanyvc/src/geanyvc.c:2368 ../geanyvc/src/geanyvc.c:2463
-#: ../geanyvc/src/geanyvc.c:2503
+#: ../geanyvc/src/geanyvc.c:2419 ../geanyvc/src/geanyvc.c:2514
+#: ../geanyvc/src/geanyvc.c:2554
 msgid "_Diff"
 msgstr "_Diff"
 
-#: ../geanyvc/src/geanyvc.c:2371
+#: ../geanyvc/src/geanyvc.c:2422
 msgid "Make a diff from the current active file"
 msgstr "Crea un diff dal file attivo corrente"
 
 #. Revert current file
 #. Revert current dir
 #. Revert everything
-#: ../geanyvc/src/geanyvc.c:2376 ../geanyvc/src/geanyvc.c:2472
-#: ../geanyvc/src/geanyvc.c:2511
+#: ../geanyvc/src/geanyvc.c:2427 ../geanyvc/src/geanyvc.c:2523
+#: ../geanyvc/src/geanyvc.c:2562
 msgid "_Revert"
 msgstr "_Ripristina (revert)"
 
-#: ../geanyvc/src/geanyvc.c:2379
+#: ../geanyvc/src/geanyvc.c:2430
 msgid "Restore pristine working copy file (undo local edits)."
 msgstr "Ripristina una versione originale del file (annulla modifiche locali)."
 
 #. Blame for current file
-#: ../geanyvc/src/geanyvc.c:2388
+#: ../geanyvc/src/geanyvc.c:2439
 msgid "_Blame"
 msgstr "_Responsabilità"
 
-#: ../geanyvc/src/geanyvc.c:2391
+#: ../geanyvc/src/geanyvc.c:2442
 msgid "Shows the changes made at one file per revision and author."
 msgstr "Visualizza le modifiche fatte a un file per revisione e autore."
 
 #. History/log of current file
 #. History/log of the current dir
 #. Complete History/Log of base directory
-#: ../geanyvc/src/geanyvc.c:2398 ../geanyvc/src/geanyvc.c:2482
-#: ../geanyvc/src/geanyvc.c:2523
+#: ../geanyvc/src/geanyvc.c:2449 ../geanyvc/src/geanyvc.c:2533
+#: ../geanyvc/src/geanyvc.c:2574
 msgid "_History (log)"
 msgstr "_Cronologia (log)"
 
-#: ../geanyvc/src/geanyvc.c:2401
+#: ../geanyvc/src/geanyvc.c:2452
 msgid "Shows the log of the current file"
 msgstr "Visualizza i log del file corrente"
 
 #. base version of the current file
-#: ../geanyvc/src/geanyvc.c:2406
+#: ../geanyvc/src/geanyvc.c:2457
 msgid "_Original"
 msgstr "_Originale"
 
-#: ../geanyvc/src/geanyvc.c:2409
+#: ../geanyvc/src/geanyvc.c:2460
 msgid "Shows the original of the current file"
 msgstr "Visualizza l'originale del file corrente"
 
 #. add current file
-#: ../geanyvc/src/geanyvc.c:2417
+#: ../geanyvc/src/geanyvc.c:2468
 msgid "_Add to Version Control"
 msgstr "_Aggiungi a Controllo Versione"
 
-#: ../geanyvc/src/geanyvc.c:2419
+#: ../geanyvc/src/geanyvc.c:2470
 msgid "Add file to repository."
 msgstr "Aggiungi file al repository."
 
 #. remove current file
-#: ../geanyvc/src/geanyvc.c:2425
+#: ../geanyvc/src/geanyvc.c:2476
 msgid "_Remove from Version Control"
 msgstr "_Rimuovi da Controllo Versione"
 
-#: ../geanyvc/src/geanyvc.c:2427
+#: ../geanyvc/src/geanyvc.c:2478
 msgid "Remove file from repository."
 msgstr "Rimuovi file da repository."
 
-#: ../geanyvc/src/geanyvc.c:2460
+#: ../geanyvc/src/geanyvc.c:2511
 msgid "_Directory"
 msgstr "_Directory"
 
-#: ../geanyvc/src/geanyvc.c:2466
+#: ../geanyvc/src/geanyvc.c:2517
 msgid "Make a diff from the directory of the current active file"
 msgstr "Crea una diff dalla directory del file attivo corrente"
 
-#: ../geanyvc/src/geanyvc.c:2475
+#: ../geanyvc/src/geanyvc.c:2526
 msgid "Restore original files in the current folder (undo local edits)."
 msgstr ""
 "Ripristina file originali nella cartella corrente (annulla modifiche locali)"
 
-#: ../geanyvc/src/geanyvc.c:2485
+#: ../geanyvc/src/geanyvc.c:2536
 msgid "Shows the log of the current directory"
 msgstr "Visualizza log directory corrente"
 
-#: ../geanyvc/src/geanyvc.c:2499
+#: ../geanyvc/src/geanyvc.c:2550
 msgid "_Base Directory"
 msgstr "_Base Directory"
 
-#: ../geanyvc/src/geanyvc.c:2505
+#: ../geanyvc/src/geanyvc.c:2556
 msgid "Make a diff from the top VC directory"
 msgstr "Crea diff dalla directory VC primaria"
 
-#: ../geanyvc/src/geanyvc.c:2513
+#: ../geanyvc/src/geanyvc.c:2564
 msgid "Revert any local edits."
 msgstr "Annulla qualsiasi modifica locale."
 
-#: ../geanyvc/src/geanyvc.c:2526
+#: ../geanyvc/src/geanyvc.c:2577
 msgid "Shows the log of the top VC directory"
 msgstr "Visualizza log della directory VC primaria"
 
-#: ../geanyvc/src/geanyvc.c:2543
+#: ../geanyvc/src/geanyvc.c:2594
 msgid "_VC file Actions"
 msgstr "_VC file azioni"
 
-#: ../geanyvc/src/geanyvc.c:2552
+#: ../geanyvc/src/geanyvc.c:2603
 msgid "VC _Commit..."
 msgstr "VC _Commit..."
 
-#: ../geanyvc/src/geanyvc.c:2596
+#: ../geanyvc/src/geanyvc.c:2647
 msgid "Show diff of file"
 msgstr "Visualizza diff del file"
 
-#: ../geanyvc/src/geanyvc.c:2598
+#: ../geanyvc/src/geanyvc.c:2649
 msgid "Show diff of directory"
 msgstr "Visualizza diff della directory"
 
-#: ../geanyvc/src/geanyvc.c:2600
+#: ../geanyvc/src/geanyvc.c:2651
 msgid "Show diff of basedir"
 msgstr "Visualizza diff della basedir"
 
-#: ../geanyvc/src/geanyvc.c:2603
+#: ../geanyvc/src/geanyvc.c:2654
 msgid "Commit changes"
 msgstr "Commit cambiamenti"
 
-#: ../geanyvc/src/geanyvc.c:2605
+#: ../geanyvc/src/geanyvc.c:2656
 msgid "Show status"
 msgstr "Visualizza status"
 
-#: ../geanyvc/src/geanyvc.c:2607
+#: ../geanyvc/src/geanyvc.c:2658
 msgid "Revert single file"
 msgstr "Ripristina singolo file"
 
-#: ../geanyvc/src/geanyvc.c:2609
+#: ../geanyvc/src/geanyvc.c:2660
 msgid "Revert directory"
 msgstr "Ripristina directory"
 
-#: ../geanyvc/src/geanyvc.c:2611
+#: ../geanyvc/src/geanyvc.c:2662
 msgid "Revert base directory"
 msgstr "Ripristina directory base"
 
-#: ../geanyvc/src/geanyvc.c:2613
+#: ../geanyvc/src/geanyvc.c:2664
 msgid "Update file"
 msgstr "Aggiorna file"
 
-#: ../geanyvc/src/geanyvc.c:2643
+#: ../geanyvc/src/geanyvc.c:2694
 msgid "_VC"
 msgstr "_VC"
 
-#: ../geanyvc/src/geanyvc.c:2650
+#: ../geanyvc/src/geanyvc.c:2701
 msgid "_Version Control"
 msgstr "_Version Control"
 
 #. Status of basedir
-#: ../geanyvc/src/geanyvc.c:2672
+#: ../geanyvc/src/geanyvc.c:2723
 msgid "_Status"
 msgstr "_Status"
 
-#: ../geanyvc/src/geanyvc.c:2674
+#: ../geanyvc/src/geanyvc.c:2725
 msgid "Show status."
 msgstr "Visualizza status."
 
-#: ../geanyvc/src/geanyvc.c:2681
+#: ../geanyvc/src/geanyvc.c:2732
 msgid "Update from remote repository."
 msgstr "Aggiorna dal repository remoto."
 
 #. Commit all changes
-#: ../geanyvc/src/geanyvc.c:2686
+#: ../geanyvc/src/geanyvc.c:2737
 msgid "_Commit..."
 msgstr "_Commit..."
 
-#: ../geanyvc/src/geanyvc.c:2688
+#: ../geanyvc/src/geanyvc.c:2739
 msgid "Commit changes."
 msgstr "Commit modifiche."
 
@@ -5118,35 +5118,6 @@ msgstr "Visualizza i tuoi appunti in un nuovo tab del browser"
 #: ../geniuspaste/src/geniuspaste.c:959
 msgid "_Paste it!"
 msgstr "_Incollalo!"
-
-#: ../git-changebar/data/prefs.ui.h:1
-msgid "_Monitor repository for changes"
-msgstr ""
-
-#: ../git-changebar/data/prefs.ui.h:2
-msgid ""
-"Whether to automatically update the diff in order to maintain it up to date "
-"when the underlying Git repository changes.  This should generally be "
-"enabled for optimal user experience."
-msgstr ""
-
-#: ../git-changebar/data/prefs.ui.h:3
-msgid "_Added lines:"
-msgstr ""
-
-#: ../git-changebar/data/prefs.ui.h:4
-msgid "_Changed lines:"
-msgstr ""
-
-#: ../git-changebar/data/prefs.ui.h:5
-#, fuzzy
-msgid "_Removed lines:"
-msgstr "Rimuovi file"
-
-#: ../git-changebar/data/prefs.ui.h:6
-#, fuzzy
-msgid "Colors"
-msgstr "Colore sfondo:"
 
 #: ../git-changebar/src/gcb-plugin.c:62
 msgid "Git Change Bar"
@@ -5337,8 +5308,8 @@ msgstr ""
 #: ../lipsum/src/lipsum.c:184 ../sendmail/src/sendmail.c:396
 #, c-format
 msgid ""
-"Your configuration directory has been successfully moved from \"%s\" to \"%s"
-"\"."
+"Your configuration directory has been successfully moved from \"%s\" to "
+"\"%s\"."
 msgstr ""
 
 #: ../lipsum/src/lipsum.c:199
@@ -5513,7 +5484,7 @@ msgstr "Impossibile scrivere la configurazione di default: %s"
 msgid "Unable to read value for '%s' key: %s"
 msgstr "Impossibile creare la directory di configurazione '%s'"
 
-#: ../multiterm/src/tab-label.vala:62 ../treebrowser/src/treebrowser.c:2132
+#: ../multiterm/src/tab-label.vala:62 ../treebrowser/src/treebrowser.c:2137
 #, fuzzy
 msgid "Terminal"
 msgstr "Terminale"
@@ -5554,117 +5525,6 @@ msgstr ""
 msgid "Show Overview"
 msgstr "Visualizza terminale"
 
-#: ../overview/data/prefs.ui.h:1
-msgid ""
-"The amount to zoom the overview sidebar. This should probably negative if "
-"you want the sidebar zoomed out."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:2
-#, fuzzy
-msgid "Zoom Level:"
-msgstr "Zoom finestra in"
-
-#: ../overview/data/prefs.ui.h:3
-msgid "The width of the overview sidebar."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:4
-msgid "Width:"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:5
-msgid ""
-"The number of lines to scroll at a time when scrolling the overview sidebar."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:6
-msgid "Scroll Lines:"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:7
-#, fuzzy
-msgid "Position on left"
-msgstr "nome posizione"
-
-#: ../overview/data/prefs.ui.h:8
-msgid ""
-"Position the overview bar on the left rather than the right (requires Geany "
-"1.25 or greater)."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:9
-#, fuzzy
-msgid "Hide tooltip"
-msgstr "Visualizza suggerimen_ti"
-
-#: ../overview/data/prefs.ui.h:10
-msgid ""
-"Hide the tooltip that is displayed when mousing over the overview that shows "
-"line, column and position information."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:11
-msgid "Hide editor scrollbar"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:12
-msgid ""
-"Whether to hide Geany's regular editor scrollbar while the overview bar is "
-"visible."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:13
-msgid "Disable overlay"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:14
-msgid ""
-"Turn off drawing overlay, which shows the region of the main editor view "
-"that is currently in view, ontop of the overview bar."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:15 ../scope/data/scope.glade.h:130
-#: ../scope/data/scope_gtk3.glade.h:130
-msgid "Options"
-msgstr "Opzioni"
-
-#: ../overview/data/prefs.ui.h:16
-msgid ""
-"The color and opacity of the overlay drawn ontop of the overlay sidebar."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:17
-#, fuzzy
-msgid "Color:"
-msgstr "Colore sfondo:"
-
-#: ../overview/data/prefs.ui.h:18
-msgid ""
-"The color and opacity of the border drawn around the revealed area in the "
-"overview sidebar. Set to the same as Overlay Color to disable."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:19
-#, fuzzy
-msgid "Outline Color:"
-msgstr "Selezione colore"
-
-#: ../overview/data/prefs.ui.h:20
-msgid "Draw over visible area"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:21
-msgid ""
-"When checked it will draw the overlay ontop of the area that is visible in "
-"the main editor view, when unchecked, it will do the opposite and draw the "
-"overlay everywhere but the visible area, \"revealing\" the visible part."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:22
-msgid "Overlay"
-msgstr ""
-
 #: ../pairtaghighlighter/src/pair_tag_highlighter.c:43
 msgid "Pair Tag Highlighter"
 msgstr "Coppia tag Highlighter"
@@ -5692,154 +5552,6 @@ msgstr "Seleziona alla _parentesi corrispondente"
 #, fuzzy
 msgid "Select To Matching Tag"
 msgstr "Seleziona alla _parentesi corrispondente"
-
-#: ../pohelper/data/menus.ui.h:1
-msgid "_Translation Helper"
-msgstr "Aiuto _Traduzione"
-
-#: ../pohelper/data/menus.ui.h:2
-msgid "_Previous String"
-msgstr "Stringa _Precedente"
-
-#: ../pohelper/data/menus.ui.h:3 ../pohelper/src/gph-plugin.c:1590
-msgid "Go to previous string"
-msgstr "Vai alla stringa precedente"
-
-#: ../pohelper/data/menus.ui.h:4
-msgid "_Next String"
-msgstr "Stringa _Successiva"
-
-#: ../pohelper/data/menus.ui.h:5 ../pohelper/src/gph-plugin.c:1593
-msgid "Go to next string"
-msgstr "Vai a stringa successiva"
-
-#: ../pohelper/data/menus.ui.h:6
-msgid "Pre_vious Untranslated"
-msgstr "Traduzione mancante p_rec."
-
-#: ../pohelper/data/menus.ui.h:7 ../pohelper/src/gph-plugin.c:1596
-msgid "Go to previous untranslated string"
-msgstr "Vai alla traduzione mancante precedente"
-
-#: ../pohelper/data/menus.ui.h:8
-msgid "Next _Untranslated"
-msgstr "Traduzione mancante s_ucc."
-
-#: ../pohelper/data/menus.ui.h:9 ../pohelper/src/gph-plugin.c:1599
-msgid "Go to next untranslated string"
-msgstr "Vai alla traduzione mancante successiva"
-
-#: ../pohelper/data/menus.ui.h:10
-msgid "Previous Fu_zzy"
-msgstr "Fu_zzy precedente"
-
-#: ../pohelper/data/menus.ui.h:11 ../pohelper/src/gph-plugin.c:1602
-msgid "Go to previous fuzzily translated string"
-msgstr "Vai alla precedente stringa 'fuzzy'"
-
-#: ../pohelper/data/menus.ui.h:12
-msgid "Next _Fuzzy"
-msgstr "_Fuzzy successiva"
-
-#: ../pohelper/data/menus.ui.h:13 ../pohelper/src/gph-plugin.c:1605
-msgid "Go to next fuzzily translated string"
-msgstr "Vai alla successiva stringa 'fuzzy'"
-
-#: ../pohelper/data/menus.ui.h:14
-msgid "Previous Untranslated or Fuzz_y"
-msgstr "Non tradotta o Fuzz_y precedente"
-
-#: ../pohelper/data/menus.ui.h:15 ../pohelper/src/gph-plugin.c:1608
-msgid "Go to previous untranslated or fuzzy string"
-msgstr "Vai alla precedente stringa non tradotta o 'fuzzy'"
-
-#: ../pohelper/data/menus.ui.h:16
-msgid "Next Untranslated _or Fuzzy"
-msgstr "Non tradotta o Fuzz_y successiva"
-
-#: ../pohelper/data/menus.ui.h:17 ../pohelper/src/gph-plugin.c:1612
-msgid "Go to next untranslated or fuzzy string"
-msgstr "Vai alla successiva stringa non tradotta o 'fuzzy'"
-
-#: ../pohelper/data/menus.ui.h:18 ../pohelper/src/gph-plugin.c:1623
-msgid "Toggle current translation fuzziness"
-msgstr "Dis-/Attiva 'fuzzy' per la traduzione corrente"
-
-#: ../pohelper/data/menus.ui.h:19
-msgid "_Toggle Fuzziness"
-msgstr "Dis-/A_ttiva 'fuzzy'"
-
-#: ../pohelper/data/menus.ui.h:20
-msgid "Paste _Message as Translation"
-msgstr "Incolla _Messaggio come Traduzione"
-
-#: ../pohelper/data/menus.ui.h:21
-msgid "Paste the original untranslated string to the translation"
-msgstr "Incolla la stringa non tradotta originale come traduzione "
-
-#: ../pohelper/data/menus.ui.h:22 ../pohelper/src/gph-plugin.c:1620
-msgid "Reflow the current translation string"
-msgstr "Riordina la stringa di traduzione corrente"
-
-#: ../pohelper/data/menus.ui.h:23
-msgid "_Reflow Translation"
-msgstr "_Riordina traduzione"
-
-#: ../pohelper/data/menus.ui.h:24 ../pohelper/src/gph-plugin.c:1626
-#, fuzzy
-msgid "Show statistics of the current document"
-msgstr "Controlla l'ortografia del documento corrente."
-
-#: ../pohelper/data/menus.ui.h:25
-#, fuzzy
-msgid "_Show stats"
-msgstr "Visualizza status"
-
-#: ../pohelper/data/menus.ui.h:26
-msgid ""
-"Whether to update the translation headers (author, revision date, ...) upon "
-"file save"
-msgstr ""
-"Aggiorna le intestazioni della traduzione (autore, revision, data, ...) "
-"quando il file viene salvato"
-
-#: ../pohelper/data/menus.ui.h:27
-msgid "Update _Headers Upon Save"
-msgstr "Aggiorna _Intestazione quando salvi"
-
-#: ../pohelper/data/stats.ui.h:1
-#, fuzzy
-msgid "Translation statistics"
-msgstr "Translation Helper"
-
-#: ../pohelper/data/stats.ui.h:2
-#, fuzzy
-msgid "Choose a color for translated strings"
-msgstr "Vai alla traduzione mancante successiva"
-
-#: ../pohelper/data/stats.ui.h:3
-#, fuzzy
-msgid "Choose a color for fuzzily translated strings"
-msgstr "Vai alla successiva stringa 'fuzzy'"
-
-#: ../pohelper/data/stats.ui.h:4
-#, fuzzy
-msgid "Choose a color for untranslated strings"
-msgstr "Vai alla traduzione mancante successiva"
-
-#: ../pohelper/data/stats.ui.h:5
-#, fuzzy
-msgid "Translated:"
-msgstr "Traduzione mancante s_ucc."
-
-#: ../pohelper/data/stats.ui.h:6
-msgid "Fuzzy:"
-msgstr ""
-
-#: ../pohelper/data/stats.ui.h:7
-#, fuzzy
-msgid "Untranslated:"
-msgstr "Traduzione mancante s_ucc."
 
 #: ../pohelper/src/gph-plugin.c:40
 msgid "Translation Helper"
@@ -5869,9 +5581,54 @@ msgstr ""
 msgid "%u (%.3g%%)"
 msgstr ""
 
+#: ../pohelper/src/gph-plugin.c:1590
+msgid "Go to previous string"
+msgstr "Vai alla stringa precedente"
+
+#: ../pohelper/src/gph-plugin.c:1593
+msgid "Go to next string"
+msgstr "Vai a stringa successiva"
+
+#: ../pohelper/src/gph-plugin.c:1596
+msgid "Go to previous untranslated string"
+msgstr "Vai alla traduzione mancante precedente"
+
+#: ../pohelper/src/gph-plugin.c:1599
+msgid "Go to next untranslated string"
+msgstr "Vai alla traduzione mancante successiva"
+
+#: ../pohelper/src/gph-plugin.c:1602
+msgid "Go to previous fuzzily translated string"
+msgstr "Vai alla precedente stringa 'fuzzy'"
+
+#: ../pohelper/src/gph-plugin.c:1605
+msgid "Go to next fuzzily translated string"
+msgstr "Vai alla successiva stringa 'fuzzy'"
+
+#: ../pohelper/src/gph-plugin.c:1608
+msgid "Go to previous untranslated or fuzzy string"
+msgstr "Vai alla precedente stringa non tradotta o 'fuzzy'"
+
+#: ../pohelper/src/gph-plugin.c:1612
+msgid "Go to next untranslated or fuzzy string"
+msgstr "Vai alla successiva stringa non tradotta o 'fuzzy'"
+
 #: ../pohelper/src/gph-plugin.c:1616
 msgid "Paste original untranslated string to translation"
 msgstr "Incolla stringa non tradotta originale alla traduzione"
+
+#: ../pohelper/src/gph-plugin.c:1620
+msgid "Reflow the current translation string"
+msgstr "Riordina la stringa di traduzione corrente"
+
+#: ../pohelper/src/gph-plugin.c:1623
+msgid "Toggle current translation fuzziness"
+msgstr "Dis-/Attiva 'fuzzy' per la traduzione corrente"
+
+#: ../pohelper/src/gph-plugin.c:1626
+#, fuzzy
+msgid "Show statistics of the current document"
+msgstr "Controlla l'ortografia del documento corrente."
 
 #: ../pohelper/src/gph-plugin.c:1833
 #, c-format
@@ -6167,7 +5924,7 @@ msgid "Add"
 msgstr "Addons"
 
 #: ../projectorganizer/src/prjorg-sidebar.c:390
-#: ../treebrowser/src/treebrowser.c:2356
+#: ../treebrowser/src/treebrowser.c:2361
 #, fuzzy
 msgid "New File"
 msgstr "Nuovo File"
@@ -6801,6 +6558,10 @@ msgstr "Visualizza suggerimen_ti"
 msgid "<b>Others</b>"
 msgstr "<b>Altri</b>"
 
+#: ../scope/data/scope.glade.h:130 ../scope/data/scope_gtk3.glade.h:130
+msgid "Options"
+msgstr "Opzioni"
+
 #: ../scope/data/scope.glade.h:131 ../scope/data/scope_gtk3.glade.h:131
 msgid "_Import"
 msgstr "_Importa"
@@ -7380,12 +7141,14 @@ msgid "Checks the spelling of the current document."
 msgstr "Controlla l'ortografia del documento corrente."
 
 #: ../spellcheck/src/scplugin.c:225
-msgid "Run Spell Check"
+#, fuzzy
+msgid "Run spell check once"
 msgstr "Esegui controllo ortografia"
 
-#: ../spellcheck/src/scplugin.c:228
-msgid "Toggle Check While Typing"
-msgstr "Attiva/Disattiva controllo mentre scrivi"
+#: ../spellcheck/src/scplugin.c:228 ../spellcheck/src/scplugin.c:333
+#, fuzzy
+msgid "Toggle spell check"
+msgstr "Controllo ortografia"
 
 #. initialise the dialog
 #: ../spellcheck/src/scplugin.c:239
@@ -7415,10 +7178,6 @@ msgstr "Stampa parole errate e suggerimento nella finestra messaggi"
 #, fuzzy
 msgid "<b>Interface</b>"
 msgstr "<b>Inspeziona</b>"
-
-#: ../spellcheck/src/scplugin.c:333
-msgid "Check spelling while typing"
-msgstr "Controllo ortografico mentre scrivi"
 
 #: ../spellcheck/src/scplugin.c:336
 #, fuzzy
@@ -7455,32 +7214,32 @@ msgstr ""
 msgid "<b>Behavior</b>"
 msgstr "<b>Altri</b>"
 
-#: ../spellcheck/src/gui.c:76
+#: ../spellcheck/src/gui.c:88
 msgid "Spell checking while typing is now enabled"
 msgstr "Controllo ortografia mentre scrivi è ora attivo"
 
-#: ../spellcheck/src/gui.c:78
+#: ../spellcheck/src/gui.c:90
 msgid "Spell checking while typing is now disabled"
 msgstr "Controllo ortografia mentre scrivi è ora disattivato"
 
-#: ../spellcheck/src/gui.c:326
+#: ../spellcheck/src/gui.c:323
 msgid "More..."
 msgstr "Altro..."
 
-#: ../spellcheck/src/gui.c:347
+#: ../spellcheck/src/gui.c:344
 msgid "(No Suggestions)"
 msgstr "(Nessun suggerimento)"
 
-#: ../spellcheck/src/gui.c:360
+#: ../spellcheck/src/gui.c:357
 #, c-format
 msgid "Add \"%s\" to Dictionary"
 msgstr "Aggiungi \"%s\" al dizionario"
 
-#: ../spellcheck/src/gui.c:368
+#: ../spellcheck/src/gui.c:365
 msgid "Ignore All"
 msgstr "Ignora tutti"
 
-#: ../spellcheck/src/gui.c:441
+#: ../spellcheck/src/gui.c:438
 msgid ""
 "Search term is too long to provide\n"
 "spelling suggestions in the editor menu."
@@ -7488,22 +7247,22 @@ msgstr ""
 "Il termine di ricerca è troppo lungo per\n"
 "fornire suggerimenti nel menu editor."
 
-#: ../spellcheck/src/gui.c:447
+#: ../spellcheck/src/gui.c:444
 msgid "Perform Spell Check"
 msgstr "Esegui contrllo ortografia"
 
-#: ../spellcheck/src/gui.c:609
+#: ../spellcheck/src/gui.c:606
 #, c-format
 msgid "Default (%s)"
 msgstr "Default (%s)"
 
-#: ../spellcheck/src/gui.c:620
-#, c-format
-msgid "Toggle spell check while typing (current language: %s)"
+#: ../spellcheck/src/gui.c:617
+#, fuzzy, c-format
+msgid "Toggle spell check (current language: %s)"
 msgstr ""
 "Attiva/Disattiva controllo ortografico mentre scrivi (lingua corrente: %s)"
 
-#: ../spellcheck/src/gui.c:698
+#: ../spellcheck/src/gui.c:695
 msgid "Spelling Suggestions"
 msgstr "Suggerimento ortografici"
 
@@ -7600,15 +7359,15 @@ msgstr "(Vuoto)"
 msgid "Could not execute configured external command '%s' (%s)."
 msgstr "Impossibile eseguire il comando esterno configurato '%s' (%s)."
 
-#: ../treebrowser/src/treebrowser.c:1089
+#: ../treebrowser/src/treebrowser.c:1093
 msgid "NewDirectory"
 msgstr "Nuova Directory"
 
-#: ../treebrowser/src/treebrowser.c:1091
+#: ../treebrowser/src/treebrowser.c:1095
 msgid "NewFile"
 msgstr "Nuovo File"
 
-#: ../treebrowser/src/treebrowser.c:1096
+#: ../treebrowser/src/treebrowser.c:1100
 #, fuzzy, c-format
 msgid ""
 "Target file '%s' exists.\n"
@@ -7617,132 +7376,132 @@ msgstr ""
 "File di destinazione '%s' esiste\n"
 ", vuoi davvero sostituirlo con un file vuoto?"
 
-#: ../treebrowser/src/treebrowser.c:1142
+#: ../treebrowser/src/treebrowser.c:1146
 #, c-format
 msgid "Do you really want to delete '%s' ?"
 msgstr "Vuoi davvero eliminare '%s' ?"
 
-#: ../treebrowser/src/treebrowser.c:1255 ../treebrowser/src/treebrowser.c:1257
+#: ../treebrowser/src/treebrowser.c:1259 ../treebrowser/src/treebrowser.c:1261
 #, fuzzy
 msgid "Go _Up"
 msgstr "Sposta _Su"
 
-#: ../treebrowser/src/treebrowser.c:1263 ../treebrowser/src/treebrowser.c:1265
+#: ../treebrowser/src/treebrowser.c:1267 ../treebrowser/src/treebrowser.c:1269
 #, fuzzy
 msgid "Set _Path From Document"
 msgstr "Imposta percorso dal documento"
 
-#: ../treebrowser/src/treebrowser.c:1271 ../treebrowser/src/treebrowser.c:1273
+#: ../treebrowser/src/treebrowser.c:1275 ../treebrowser/src/treebrowser.c:1277
 #, fuzzy
 msgid "_Open Externally"
 msgstr "_Apri esternamente"
 
-#: ../treebrowser/src/treebrowser.c:1279
+#: ../treebrowser/src/treebrowser.c:1283
 #, fuzzy
 msgid "Open _Terminal"
 msgstr "Apri terminale"
 
-#: ../treebrowser/src/treebrowser.c:1284 ../treebrowser/src/treebrowser.c:1286
+#: ../treebrowser/src/treebrowser.c:1288 ../treebrowser/src/treebrowser.c:1290
 #, fuzzy
 msgid "Set as _Root"
 msgstr "Imposta come radice"
 
-#: ../treebrowser/src/treebrowser.c:1293 ../treebrowser/src/treebrowser.c:1295
+#: ../treebrowser/src/treebrowser.c:1297 ../treebrowser/src/treebrowser.c:1299
 #, fuzzy
 msgid "Refres_h"
 msgstr "Aggiorna"
 
-#: ../treebrowser/src/treebrowser.c:1301 ../treebrowser/src/treebrowser.c:1303
+#: ../treebrowser/src/treebrowser.c:1305 ../treebrowser/src/treebrowser.c:1307
 msgid "_Find in Files"
 msgstr "Cerca nei _File"
 
-#: ../treebrowser/src/treebrowser.c:1313 ../treebrowser/src/treebrowser.c:1315
+#: ../treebrowser/src/treebrowser.c:1317 ../treebrowser/src/treebrowser.c:1319
 #, fuzzy
 msgid "N_ew Folder"
 msgstr "Seleziona Cartella"
 
-#: ../treebrowser/src/treebrowser.c:1321 ../treebrowser/src/treebrowser.c:1323
+#: ../treebrowser/src/treebrowser.c:1325 ../treebrowser/src/treebrowser.c:1327
 #, fuzzy
 msgid "_New File"
 msgstr "Nuovo File"
 
-#: ../treebrowser/src/treebrowser.c:1329 ../treebrowser/src/treebrowser.c:1331
+#: ../treebrowser/src/treebrowser.c:1333 ../treebrowser/src/treebrowser.c:1335
 #, fuzzy
 msgid "Rena_me"
 msgstr "Rinonima"
 
-#: ../treebrowser/src/treebrowser.c:1350 ../treebrowser/src/treebrowser.c:1352
+#: ../treebrowser/src/treebrowser.c:1354 ../treebrowser/src/treebrowser.c:1356
 #, c-format
 msgid "Close: %s"
 msgstr "Chiudi: %s"
 
-#: ../treebrowser/src/treebrowser.c:1359 ../treebrowser/src/treebrowser.c:1361
+#: ../treebrowser/src/treebrowser.c:1363 ../treebrowser/src/treebrowser.c:1365
 #, fuzzy, c-format
 msgid "Clo_se Child Documents "
 msgstr "Chiudi documenti figlio "
 
-#: ../treebrowser/src/treebrowser.c:1368 ../treebrowser/src/treebrowser.c:1370
+#: ../treebrowser/src/treebrowser.c:1372 ../treebrowser/src/treebrowser.c:1374
 #, fuzzy
 msgid "_Copy Full Path to Clipboard"
 msgstr "_Copia percorso completo negli appunti"
 
-#: ../treebrowser/src/treebrowser.c:1381 ../treebrowser/src/treebrowser.c:1383
+#: ../treebrowser/src/treebrowser.c:1385 ../treebrowser/src/treebrowser.c:1387
 #, fuzzy
 msgid "E_xpand All"
 msgstr "Espandi tutto"
 
-#: ../treebrowser/src/treebrowser.c:1389 ../treebrowser/src/treebrowser.c:1391
+#: ../treebrowser/src/treebrowser.c:1393 ../treebrowser/src/treebrowser.c:1395
 #, fuzzy
 msgid "Coll_apse All"
 msgstr "Collassa tutto"
 
-#: ../treebrowser/src/treebrowser.c:1399
+#: ../treebrowser/src/treebrowser.c:1403
 #, fuzzy
 msgid "Show Boo_kmarks"
 msgstr "Visualizza segnalibri"
 
-#: ../treebrowser/src/treebrowser.c:1404
+#: ../treebrowser/src/treebrowser.c:1408
 #, fuzzy
 msgid "Sho_w Hidden Files"
 msgstr "Visualizza file nascosti"
 
-#: ../treebrowser/src/treebrowser.c:1409
+#: ../treebrowser/src/treebrowser.c:1413
 #, fuzzy
 msgid "Show Tool_bars"
 msgstr "Visualizza le toolbar"
 
-#: ../treebrowser/src/treebrowser.c:1747
+#: ../treebrowser/src/treebrowser.c:1751
 #, c-format
 msgid "Target file '%s' exists, do you really want to replace it?"
 msgstr "Il file obiettivo '%s' esiste, vuoi davvero sostituirlo?"
 
-#: ../treebrowser/src/treebrowser.c:1883
+#: ../treebrowser/src/treebrowser.c:1887
 msgid "Go up"
 msgstr "Vai su"
 
-#: ../treebrowser/src/treebrowser.c:1893 ../treebrowser/src/treebrowser.c:2360
+#: ../treebrowser/src/treebrowser.c:1897 ../treebrowser/src/treebrowser.c:2365
 msgid "Refresh"
 msgstr "Aggiorna"
 
-#: ../treebrowser/src/treebrowser.c:1903
+#: ../treebrowser/src/treebrowser.c:1907
 msgid "Home"
 msgstr "Home"
 
-#: ../treebrowser/src/treebrowser.c:1913
+#: ../treebrowser/src/treebrowser.c:1917
 msgid "Set path from document"
 msgstr "Imposta percorso dal documento"
 
-#: ../treebrowser/src/treebrowser.c:1923
+#: ../treebrowser/src/treebrowser.c:1927
 #, fuzzy
 msgid "Track path"
 msgstr "Traccia percorso"
 
-#: ../treebrowser/src/treebrowser.c:1933
+#: ../treebrowser/src/treebrowser.c:1937
 #, fuzzy
 msgid "Hide bars"
 msgstr "Nascondi barre"
 
-#: ../treebrowser/src/treebrowser.c:1943
+#: ../treebrowser/src/treebrowser.c:1947
 #, fuzzy
 msgid ""
 "Filter (*.c;*.h;*.cpp), and if you want temporary filter using the '!' "
@@ -7751,20 +7510,20 @@ msgstr ""
 "Filtro (*.c;*.h;*.cpp) e se vuoi un filtro temporaneo usando '!' inverti, "
 "per esemprio '!;*.c;*.h;*.cpp'"
 
-#: ../treebrowser/src/treebrowser.c:1948
+#: ../treebrowser/src/treebrowser.c:1952
 msgid "Addressbar for example '/projects/my-project'"
 msgstr "Barra indirizzo per esempio '/progetti/mio-progetto'"
 
-#: ../treebrowser/src/treebrowser.c:1973
+#: ../treebrowser/src/treebrowser.c:1977
 msgid "Tree Browser"
 msgstr "Tree Browser"
 
-#: ../treebrowser/src/treebrowser.c:2114
+#: ../treebrowser/src/treebrowser.c:2118
 msgid "External open command"
 msgstr "Apri comando esterno"
 
-#: ../treebrowser/src/treebrowser.c:2124
-#, c-format
+#: ../treebrowser/src/treebrowser.c:2129
+#, no-c-format
 msgid ""
 "The command to execute when using \"Open with\". You can use %f and %d "
 "wildcards.\n"
@@ -7776,60 +7535,60 @@ msgstr ""
 "%f sarà sostituito dal nome del file includo il percorso completo\n"
 "%d sarà sostituito dal percorso del file selezionato senza il nome del file"
 
-#: ../treebrowser/src/treebrowser.c:2143
+#: ../treebrowser/src/treebrowser.c:2148
 msgid "The terminal to use with the command \"Open Terminal\""
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2149
+#: ../treebrowser/src/treebrowser.c:2154
 msgid "Toolbar"
 msgstr "Barra degli strumenti"
 
-#: ../treebrowser/src/treebrowser.c:2151
+#: ../treebrowser/src/treebrowser.c:2156
 msgid "Hidden"
 msgstr "Nascosto"
 
-#: ../treebrowser/src/treebrowser.c:2152
+#: ../treebrowser/src/treebrowser.c:2157
 msgid "Top"
 msgstr "Sopra"
 
-#: ../treebrowser/src/treebrowser.c:2153
+#: ../treebrowser/src/treebrowser.c:2158
 msgid "Bottom"
 msgstr "Sotto"
 
-#: ../treebrowser/src/treebrowser.c:2158
+#: ../treebrowser/src/treebrowser.c:2163
 msgid "If position is changed, the option require plugin restart."
 msgstr "Se la posizione è cambiata, l'opzione richiedi il riavvio del plugin."
 
-#: ../treebrowser/src/treebrowser.c:2162
+#: ../treebrowser/src/treebrowser.c:2167
 msgid "Show icons"
 msgstr "Visualizza icone"
 
-#: ../treebrowser/src/treebrowser.c:2164
+#: ../treebrowser/src/treebrowser.c:2169
 msgid "None"
 msgstr "Nessuno"
 
-#: ../treebrowser/src/treebrowser.c:2165
+#: ../treebrowser/src/treebrowser.c:2170
 msgid "Base"
 msgstr "Base"
 
-#: ../treebrowser/src/treebrowser.c:2166
+#: ../treebrowser/src/treebrowser.c:2171
 msgid "Content-type"
 msgstr "Content-type"
 
-#: ../treebrowser/src/treebrowser.c:2172
+#: ../treebrowser/src/treebrowser.c:2177
 msgid "Show hidden files"
 msgstr "Visualizza file nascosti"
 
-#: ../treebrowser/src/treebrowser.c:2181
+#: ../treebrowser/src/treebrowser.c:2186
 msgid "On Windows, this just hide files that are prefixed with '.' (dot)"
 msgstr ""
 "In Windows, questa nasconde tutti i file che sono preceduti da '.' (punto)"
 
-#: ../treebrowser/src/treebrowser.c:2183
+#: ../treebrowser/src/treebrowser.c:2188
 msgid "Hide object files"
 msgstr "Nascondi i file oggetto"
 
-#: ../treebrowser/src/treebrowser.c:2192
+#: ../treebrowser/src/treebrowser.c:2197
 msgid ""
 "Don't show generated object files in the file browser, this includes *.o, *."
 "obj. *.so, *.dll, *.a, *.lib"
@@ -7837,60 +7596,60 @@ msgstr ""
 "Non visualizzare i file oggetto generati nel file browser, questo include *."
 "o *.obj, *.so, *.dll, *.a, *.lib"
 
-#: ../treebrowser/src/treebrowser.c:2194
+#: ../treebrowser/src/treebrowser.c:2199
 msgid "Reverse filter"
 msgstr "Inverti filtro"
 
-#: ../treebrowser/src/treebrowser.c:2203
+#: ../treebrowser/src/treebrowser.c:2208
 msgid "Follow current document"
 msgstr "Segui il documento corrente"
 
-#: ../treebrowser/src/treebrowser.c:2212
+#: ../treebrowser/src/treebrowser.c:2217
 msgid "Single click, open document and focus it"
 msgstr "Click singolo, apri il documento e dagli il focus"
 
-#: ../treebrowser/src/treebrowser.c:2221
+#: ../treebrowser/src/treebrowser.c:2226
 msgid "Double click open directory"
 msgstr "Doppio click per aprire la cartella"
 
-#: ../treebrowser/src/treebrowser.c:2230
+#: ../treebrowser/src/treebrowser.c:2235
 msgid "On delete file, close it if is opened"
 msgstr "Quando un file viene eliminato, chiudilo se aperto"
 
-#: ../treebrowser/src/treebrowser.c:2239
+#: ../treebrowser/src/treebrowser.c:2244
 msgid "Focus editor on file open"
 msgstr "Porta il focus sull'editor quando un file viene aperto"
 
-#: ../treebrowser/src/treebrowser.c:2248
+#: ../treebrowser/src/treebrowser.c:2253
 msgid "Show tree lines"
 msgstr "Visualizza linee dell'albero"
 
-#: ../treebrowser/src/treebrowser.c:2257
+#: ../treebrowser/src/treebrowser.c:2262
 msgid "Show bookmarks"
 msgstr "Visualizza segnalibri"
 
-#: ../treebrowser/src/treebrowser.c:2266
+#: ../treebrowser/src/treebrowser.c:2271
 msgid "Open new files"
 msgstr "Apri nuovi file"
 
-#: ../treebrowser/src/treebrowser.c:2350
+#: ../treebrowser/src/treebrowser.c:2355
 msgid "Focus File List"
 msgstr "Focus lista file"
 
-#: ../treebrowser/src/treebrowser.c:2352
+#: ../treebrowser/src/treebrowser.c:2357
 msgid "Focus Path Entry"
 msgstr "Focus inserimento percorso"
 
-#: ../treebrowser/src/treebrowser.c:2354
+#: ../treebrowser/src/treebrowser.c:2359
 msgid "Rename Object"
 msgstr "Rinonima oggetto"
 
-#: ../treebrowser/src/treebrowser.c:2358
+#: ../treebrowser/src/treebrowser.c:2363
 #, fuzzy
 msgid "New Folder"
 msgstr "Seleziona Cartella"
 
-#: ../treebrowser/src/treebrowser.c:2362
+#: ../treebrowser/src/treebrowser.c:2367
 #, fuzzy
 msgid "Track Current"
 msgstr "Traccia percorso"
@@ -8610,13 +8369,6 @@ msgstr "Nuova Directory"
 msgid "No workbench opened."
 msgstr ""
 
-#: ../workbench/src/sidebar.c:875
-#, fuzzy, c-format
-msgid "%s: %u Project"
-msgid_plural "%s: %u Projects"
-msgstr[0] "Progetto"
-msgstr[1] "Progetto"
-
 #: ../workbench/src/sidebar.c:886
 msgid ""
 "Add a project using the context menu\n"
@@ -8724,6 +8476,123 @@ msgstr "Frammenti XML"
 #: ../xmlsnippets/src/plugin.c:45
 msgid "Autocompletes XML/HTML tags using snippets."
 msgstr "Autocompleta i tag XML/HTML usando i frammenti."
+
+#, fuzzy
+#~ msgid "_Removed lines:"
+#~ msgstr "Rimuovi file"
+
+#, fuzzy
+#~ msgid "Colors"
+#~ msgstr "Colore sfondo:"
+
+#, fuzzy
+#~ msgid "Zoom Level:"
+#~ msgstr "Zoom finestra in"
+
+#, fuzzy
+#~ msgid "Position on left"
+#~ msgstr "nome posizione"
+
+#, fuzzy
+#~ msgid "Hide tooltip"
+#~ msgstr "Visualizza suggerimen_ti"
+
+#, fuzzy
+#~ msgid "Color:"
+#~ msgstr "Colore sfondo:"
+
+#, fuzzy
+#~ msgid "Outline Color:"
+#~ msgstr "Selezione colore"
+
+#~ msgid "_Translation Helper"
+#~ msgstr "Aiuto _Traduzione"
+
+#~ msgid "_Previous String"
+#~ msgstr "Stringa _Precedente"
+
+#~ msgid "_Next String"
+#~ msgstr "Stringa _Successiva"
+
+#~ msgid "Pre_vious Untranslated"
+#~ msgstr "Traduzione mancante p_rec."
+
+#~ msgid "Next _Untranslated"
+#~ msgstr "Traduzione mancante s_ucc."
+
+#~ msgid "Previous Fu_zzy"
+#~ msgstr "Fu_zzy precedente"
+
+#~ msgid "Next _Fuzzy"
+#~ msgstr "_Fuzzy successiva"
+
+#~ msgid "Previous Untranslated or Fuzz_y"
+#~ msgstr "Non tradotta o Fuzz_y precedente"
+
+#~ msgid "Next Untranslated _or Fuzzy"
+#~ msgstr "Non tradotta o Fuzz_y successiva"
+
+#~ msgid "_Toggle Fuzziness"
+#~ msgstr "Dis-/A_ttiva 'fuzzy'"
+
+#~ msgid "Paste _Message as Translation"
+#~ msgstr "Incolla _Messaggio come Traduzione"
+
+#~ msgid "Paste the original untranslated string to the translation"
+#~ msgstr "Incolla la stringa non tradotta originale come traduzione "
+
+#~ msgid "_Reflow Translation"
+#~ msgstr "_Riordina traduzione"
+
+#, fuzzy
+#~ msgid "_Show stats"
+#~ msgstr "Visualizza status"
+
+#~ msgid ""
+#~ "Whether to update the translation headers (author, revision date, ...) "
+#~ "upon file save"
+#~ msgstr ""
+#~ "Aggiorna le intestazioni della traduzione (autore, revision, data, ...) "
+#~ "quando il file viene salvato"
+
+#~ msgid "Update _Headers Upon Save"
+#~ msgstr "Aggiorna _Intestazione quando salvi"
+
+#, fuzzy
+#~ msgid "Translation statistics"
+#~ msgstr "Translation Helper"
+
+#, fuzzy
+#~ msgid "Choose a color for translated strings"
+#~ msgstr "Vai alla traduzione mancante successiva"
+
+#, fuzzy
+#~ msgid "Choose a color for fuzzily translated strings"
+#~ msgstr "Vai alla successiva stringa 'fuzzy'"
+
+#, fuzzy
+#~ msgid "Choose a color for untranslated strings"
+#~ msgstr "Vai alla traduzione mancante successiva"
+
+#, fuzzy
+#~ msgid "Translated:"
+#~ msgstr "Traduzione mancante s_ucc."
+
+#, fuzzy
+#~ msgid "Untranslated:"
+#~ msgstr "Traduzione mancante s_ucc."
+
+#~ msgid "Toggle Check While Typing"
+#~ msgstr "Attiva/Disattiva controllo mentre scrivi"
+
+#~ msgid "Check spelling while typing"
+#~ msgstr "Controllo ortografico mentre scrivi"
+
+#, fuzzy, c-format
+#~ msgid "%s: %u Project"
+#~ msgid_plural "%s: %u Projects"
+#~ msgstr[0] "Progetto"
+#~ msgstr[1] "Progetto"
 
 #~ msgid "GeanyLaTeX"
 #~ msgstr "GeanyLaTeX"

--- a/po/ja.po
+++ b/po/ja.po
@@ -6,8 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Geany-Plugins 1.30\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-29 19:41+0200\n"
+"Report-Msgid-Bugs-To: https://github.com/geany/geany/issues\n"
+"POT-Creation-Date: 2022-06-28 07:39+0200\n"
 "PO-Revision-Date: 2011-10-21 14:08+0100\n"
 "Last-Translator: Masami Chikahiro <cmasa.z321@gmail.com>\n"
 "Language-Team: Japanese\n"
@@ -22,27 +22,27 @@ msgstr ""
 msgid "(Empty Line)"
 msgstr "(空行)"
 
-#: ../addons/src/ao_bookmarklist.c:315
+#: ../addons/src/ao_bookmarklist.c:331
 msgid "_Remove Bookmark"
 msgstr "ブックマークを削除(_R)"
 
 #. Translators: Number is meant at this point.
-#: ../addons/src/ao_bookmarklist.c:342
+#: ../addons/src/ao_bookmarklist.c:358
 msgid "No."
 msgstr "番号"
 
-#: ../addons/src/ao_bookmarklist.c:350 ../devhelp/src/dhp-object.c:494
+#: ../addons/src/ao_bookmarklist.c:366 ../devhelp/src/dhp-object.c:494
 #: ../devhelp/devhelp/dh-window.c:1142
 msgid "Contents"
 msgstr "内容"
 
-#: ../addons/src/ao_bookmarklist.c:383 ../treebrowser/src/treebrowser.c:666
+#: ../addons/src/ao_bookmarklist.c:399 ../treebrowser/src/treebrowser.c:666
 #: ../webhelper/src/gwh-plugin.c:328
 msgid "Bookmarks"
 msgstr "ブックマーク"
 
 #. complete update
-#: ../addons/src/ao_tasks.c:373 ../geanyvc/src/geanyvc.c:2679
+#: ../addons/src/ao_tasks.c:373 ../geanyvc/src/geanyvc.c:2730
 msgid "_Update"
 msgstr "更新(_U)"
 
@@ -164,10 +164,10 @@ msgstr "現在の文書の綴りを検査"
 #: ../addons/src/addons.c:364 ../autoclose/src/autoclose.c:920
 #: ../codenav/src/codenavigation.c:281 ../latex/src/latex.c:208
 #: ../latex/src/latex.c:293 ../geanyprj/src/geanyprj.c:176
-#: ../geanyvc/src/geanyvc.c:2079 ../geniuspaste/src/geniuspaste.c:336
+#: ../geanyvc/src/geanyvc.c:2130 ../geniuspaste/src/geniuspaste.c:336
 #: ../lineoperations/src/lo_prefs.c:58 ../sendmail/src/sendmail.c:128
 #: ../sendmail/src/sendmail.c:293 ../spellcheck/src/scplugin.c:124
-#: ../treebrowser/src/treebrowser.c:2102
+#: ../treebrowser/src/treebrowser.c:2106
 #: ../updatechecker/src/updatechecker.c:262
 msgid "Plugin configuration directory could not be created."
 msgstr "プラグイン設定ディレクトリを作成できません。"
@@ -721,7 +721,7 @@ msgstr "~\"対象ファイルを読み込み中\\n\""
 msgid "Error loading file"
 msgstr "ファイル読み込みエラー"
 
-#. setting asyncronous mode
+#. setting asynchronous mode
 #. setting null-stop array printing
 #. enable pretty printing
 #: ../debugger/src/dbm_gdb.c:789 ../debugger/src/dbm_gdb.c:792
@@ -1116,7 +1116,7 @@ msgid "A developers' help browser for GNOME"
 msgstr "GNOMEの開発者向けヘルプブラウザ"
 
 #. Create the current file Submenu
-#: ../devhelp/devhelp/dh-window.c:759 ../geanyvc/src/geanyvc.c:2660
+#: ../devhelp/devhelp/dh-window.c:759 ../geanyvc/src/geanyvc.c:2711
 msgid "_File"
 msgstr "ファイル(_F)"
 
@@ -1150,11 +1150,11 @@ msgstr "新しいタブ(_T)"
 msgid "_Print…"
 msgstr "印刷...(_P)"
 
-#: ../devhelp/devhelp/dh-window.c:782 ../devhelp/devhelp/eggfindbar.c:342
+#: ../devhelp/devhelp/dh-window.c:782
 msgid "Find Next"
 msgstr "次を検索"
 
-#: ../devhelp/devhelp/dh-window.c:784 ../devhelp/devhelp/eggfindbar.c:329
+#: ../devhelp/devhelp/dh-window.c:784
 msgid "Find Previous"
 msgstr "前を検索"
 
@@ -1348,7 +1348,7 @@ msgid ""
 "contributing to this plugin?"
 msgstr ""
 
-#: ../geanydoc/src/geanydoc.c:159 ../geanyvc/src/geanyvc.c:442
+#: ../geanydoc/src/geanydoc.c:159 ../geanyvc/src/geanyvc.c:448
 msgid "Could not parse the output of command"
 msgstr "コマンド出力を解析できません"
 
@@ -3044,7 +3044,7 @@ msgstr ""
 "モジュール \"%s\" が関数 %s() でエラー:\n"
 "コマンド \"%s\"の引数が不足しています。\n"
 
-#: ../geanylua/glspi_sci.c:637 ../geanylua/glspi_app.c:406
+#: ../geanylua/glspi_sci.c:729 ../geanylua/glspi_app.c:406
 #, c-format
 msgid ""
 "Error in module \"%s\" at function %s():\n"
@@ -3053,7 +3053,7 @@ msgstr ""
 "モジュール \"%s\" が関数 %s() でエラー:\n"
 "不明なコマンド \"%s\" (引数 #1)\n"
 
-#: ../geanylua/glspi_sci.c:781
+#: ../geanylua/glspi_sci.c:924
 #, c-format
 msgid ""
 "Error in module \"%s\" at function %s():\n"
@@ -3064,7 +3064,7 @@ msgstr ""
 " 引数 #%d で無効なテーブル:\n"
 "  不明なフラグ \"%s\" (要素 #%d)\n"
 
-#: ../geanylua/glspi_sci.c:785
+#: ../geanylua/glspi_sci.c:928
 msgid "<too large to display>"
 msgstr "<大きすぎて表示できません>"
 
@@ -3848,7 +3848,7 @@ msgid "New _Below"
 msgstr "下に追加(_B)"
 
 #: ../geanymacro/src/geanymacro.c:1824 ../geanymacro/src/geanymacro.c:2120
-#: ../treebrowser/src/treebrowser.c:1338 ../treebrowser/src/treebrowser.c:1340
+#: ../treebrowser/src/treebrowser.c:1342 ../treebrowser/src/treebrowser.c:1344
 msgid "_Delete"
 msgstr "削除(_D)"
 
@@ -4230,8 +4230,8 @@ msgstr ""
 msgid "a key with fingerprint"
 msgstr "フィンガープリントを使用したキー"
 
-#: ../geanypg/src/verify_aux.c:66 ../spellcheck/src/gui.c:610
-#: ../spellcheck/src/gui.c:621
+#: ../geanypg/src/verify_aux.c:66 ../spellcheck/src/gui.c:607
+#: ../spellcheck/src/gui.c:618
 msgid "unknown"
 msgstr "不明"
 
@@ -4541,49 +4541,49 @@ msgid ""
 "contributing to this plugin?"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:501
+#: ../geanyvc/src/geanyvc.c:507
 #, c-format
 msgid "geanyvc: s_spawn_sync error: %s"
 msgstr "geanyvc: s_spawn_sync エラー: %s"
 
-#: ../geanyvc/src/geanyvc.c:587
+#: ../geanyvc/src/geanyvc.c:593
 #, c-format
 msgid "File %s: action %s executed via %s."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:646 ../geanyvc/src/geanyvc.c:657
-#, c-format
-msgid "geanyvc: vcdiff_file_activated: Unable to rename '%s' to '%s'"
+#: ../geanyvc/src/geanyvc.c:633 ../geanyvc/src/geanyvc.c:643
+#, fuzzy, c-format
+msgid "geanyvc: diff_external: Unable to rename '%s' to '%s'"
 msgstr "geanyvc: vcdiff_file_activated:  '%s' から '%s' に名前変更できません。"
 
-#: ../geanyvc/src/geanyvc.c:683 ../geanyvc/src/geanyvc.c:733
+#: ../geanyvc/src/geanyvc.c:698 ../geanyvc/src/geanyvc.c:784
 msgid "No changes were made."
 msgstr "変更されたものはありません。"
 
-#: ../geanyvc/src/geanyvc.c:760
+#: ../geanyvc/src/geanyvc.c:811
 msgid "No history available"
 msgstr "履歴が利用できません"
 
-#: ../geanyvc/src/geanyvc.c:953 ../geanyvc/src/geanyvc.c:961
+#: ../geanyvc/src/geanyvc.c:1004 ../geanyvc/src/geanyvc.c:1012
 #, c-format
 msgid "Do you really want to revert: %s?"
 msgstr "変更を取り消してもよいですか: %s?"
 
-#: ../geanyvc/src/geanyvc.c:969
+#: ../geanyvc/src/geanyvc.c:1020
 #, c-format
 msgid "Do you really want to add: %s?"
 msgstr "ファイルを追加してもよいですか: %s?"
 
-#: ../geanyvc/src/geanyvc.c:976
+#: ../geanyvc/src/geanyvc.c:1027
 #, c-format
 msgid "Do you really want to remove: %s?"
 msgstr "ファイルを削除してもよいですか: %s?"
 
-#: ../geanyvc/src/geanyvc.c:999
+#: ../geanyvc/src/geanyvc.c:1050
 msgid "Do you really want to update?"
 msgstr "リポジトリから更新してもよいですか?"
 
-#: ../geanyvc/src/geanyvc.c:1126
+#: ../geanyvc/src/geanyvc.c:1177
 msgid ""
 "The resulting differences cannot be displayed because the changes are too "
 "big to display here and would slow down the UI significantly.\n"
@@ -4592,73 +4592,73 @@ msgid ""
 "Geany directly by using the GeanyVC menu (Base Directory -> Diff)."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1280
+#: ../geanyvc/src/geanyvc.c:1331
 msgid "Commit Y/N"
 msgstr "リポジトリに反映してもよいですか Y/N"
 
-#: ../geanyvc/src/geanyvc.c:1290
+#: ../geanyvc/src/geanyvc.c:1341
 msgid "Status"
 msgstr "状態"
 
-#: ../geanyvc/src/geanyvc.c:1297
+#: ../geanyvc/src/geanyvc.c:1348
 msgid "Path"
 msgstr "パス"
 
-#: ../geanyvc/src/geanyvc.c:1414
+#: ../geanyvc/src/geanyvc.c:1465
 msgid "Choose a previous commit message"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1476
+#: ../geanyvc/src/geanyvc.c:1527
 #, c-format
 msgid "Line: %d Column: %d"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1523
+#: ../geanyvc/src/geanyvc.c:1574
 msgid "Commit"
 msgstr "コミット"
 
-#: ../geanyvc/src/geanyvc.c:1564
+#: ../geanyvc/src/geanyvc.c:1615
 msgid "_De-/select all files"
 msgstr "すべてのファイルを選択/解除(_D)"
 
-#: ../geanyvc/src/geanyvc.c:1608
+#: ../geanyvc/src/geanyvc.c:1659
 msgid "<b>Commit message:</b>"
 msgstr "<b>コミット メッセージ:</b>"
 
-#: ../geanyvc/src/geanyvc.c:1632
+#: ../geanyvc/src/geanyvc.c:1683
 msgid "C_ommit"
 msgstr "コミット(_O)"
 
-#: ../geanyvc/src/geanyvc.c:1740
+#: ../geanyvc/src/geanyvc.c:1791
 msgid "Nothing to commit."
 msgstr "反映させるものはありません。"
 
-#: ../geanyvc/src/geanyvc.c:1788
+#: ../geanyvc/src/geanyvc.c:1839
 #, fuzzy, c-format
 msgid ""
 "Error initializing GeanyVC spell checking: %s. Check your configuration."
 msgstr "スペルチェッカ初期化エラー: %s"
 
-#: ../geanyvc/src/geanyvc.c:1823
+#: ../geanyvc/src/geanyvc.c:1874
 #, c-format
 msgid "Commit failed (status: %d, error: %s)."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1824
+#: ../geanyvc/src/geanyvc.c:1875
 #, fuzzy
 msgid "Commit failed; see status in the Message window."
 msgstr "メッセージウィンドウに利用可能なタスクを表示"
 
-#: ../geanyvc/src/geanyvc.c:1829
+#: ../geanyvc/src/geanyvc.c:1880
 #, fuzzy
 msgid "Changes committed."
 msgstr "反映させるものはありません。"
 
-#: ../geanyvc/src/geanyvc.c:2151
+#: ../geanyvc/src/geanyvc.c:2202
 msgid "Set Changed-flag for document tabs created by the plugin"
 msgstr "プラグインによって文書タブに作成された変更フラグを設定"
 
-#: ../geanyvc/src/geanyvc.c:2154
+#: ../geanyvc/src/geanyvc.c:2205
 msgid ""
 "If this option is activated, every new by the VC-plugin created document tab "
 "will be marked as changed. Even this option is useful in some cases, it "
@@ -4668,44 +4668,44 @@ msgstr ""
 "更ありにマークされます。このオプションが便利な場合もありますが、多くの文書に"
 "対して逐一「保存しますか」ダイアログが表示される原因にもなります。"
 
-#: ../geanyvc/src/geanyvc.c:2162
+#: ../geanyvc/src/geanyvc.c:2213
 msgid "Confirm adding new files to a VCS"
 msgstr "新規ファイルをVCSに追加するかどうか確認"
 
-#: ../geanyvc/src/geanyvc.c:2165
+#: ../geanyvc/src/geanyvc.c:2216
 msgid "Shows a confirmation dialog on adding a new (created) file to VCS."
 msgstr ""
 "新規に作成されたファイルをVCSに追加するかどうか確認ダイアログを表示します。"
 
-#: ../geanyvc/src/geanyvc.c:2171
+#: ../geanyvc/src/geanyvc.c:2222
 msgid "Maximize commit dialog"
 msgstr "コミットダイアログを最大化"
 
-#: ../geanyvc/src/geanyvc.c:2172
+#: ../geanyvc/src/geanyvc.c:2223
 msgid "Show commit dialog maximize."
 msgstr "コミットダイアログを最大化して表示します。"
 
-#: ../geanyvc/src/geanyvc.c:2178
+#: ../geanyvc/src/geanyvc.c:2229
 msgid "Use external diff viewer"
 msgstr "外部diffビューアを使用"
 
-#: ../geanyvc/src/geanyvc.c:2180
+#: ../geanyvc/src/geanyvc.c:2231
 msgid "Use external diff viewer for file diff."
 msgstr "ファイルの差分を表示するのに外部のdiffビューアを使用します。"
 
-#: ../geanyvc/src/geanyvc.c:2186
+#: ../geanyvc/src/geanyvc.c:2237
 msgid "Show VC entries at editor menu"
 msgstr "'VCエントリー'をエディタのメニューに追加"
 
-#: ../geanyvc/src/geanyvc.c:2188
+#: ../geanyvc/src/geanyvc.c:2239
 msgid "Show entries for VC functions inside editor menu"
 msgstr "エディタメニュー内にVCの機能を表示"
 
-#: ../geanyvc/src/geanyvc.c:2193
+#: ../geanyvc/src/geanyvc.c:2244
 msgid "Attach menu to menubar"
 msgstr "メニューをメニューバーに追加"
 
-#: ../geanyvc/src/geanyvc.c:2195
+#: ../geanyvc/src/geanyvc.c:2246
 msgid ""
 "Whether menu for this plugin are getting placed either inside tools menu or "
 "directly inside Geany's menubar. Will take in account after next start of "
@@ -4714,213 +4714,213 @@ msgstr ""
 "このプラグインのメニューがツールメニューの中に表示されるかGeanyのメニューバー"
 "に追加されるかを指定。GeanyVCの次回起動時に有効になります。"
 
-#: ../geanyvc/src/geanyvc.c:2203
+#: ../geanyvc/src/geanyvc.c:2254
 msgid "Enable CVS"
 msgstr "CVSを有効"
 
-#: ../geanyvc/src/geanyvc.c:2208
+#: ../geanyvc/src/geanyvc.c:2259
 msgid "Enable GIT"
 msgstr "GITを有効"
 
-#: ../geanyvc/src/geanyvc.c:2213
+#: ../geanyvc/src/geanyvc.c:2264
 msgid "Enable Fossil"
 msgstr "Fossilを有効"
 
-#: ../geanyvc/src/geanyvc.c:2218
+#: ../geanyvc/src/geanyvc.c:2269
 msgid "Enable SVN"
 msgstr "SVNを有効"
 
-#: ../geanyvc/src/geanyvc.c:2223
+#: ../geanyvc/src/geanyvc.c:2274
 msgid "Enable SVK"
 msgstr "SVKを有効"
 
-#: ../geanyvc/src/geanyvc.c:2228
+#: ../geanyvc/src/geanyvc.c:2279
 msgid "Enable Bazaar"
 msgstr "Bazaarを有効"
 
-#: ../geanyvc/src/geanyvc.c:2233
+#: ../geanyvc/src/geanyvc.c:2284
 msgid "Enable Mercurial"
 msgstr "Mercurialを有効"
 
-#: ../geanyvc/src/geanyvc.c:2239
+#: ../geanyvc/src/geanyvc.c:2290
 msgid "Spellcheck language"
 msgstr "スペルチェック言語"
 
 #. Diff of current file
 #. Diff of the current dir
 #. Complete diff of base directory
-#: ../geanyvc/src/geanyvc.c:2368 ../geanyvc/src/geanyvc.c:2463
-#: ../geanyvc/src/geanyvc.c:2503
+#: ../geanyvc/src/geanyvc.c:2419 ../geanyvc/src/geanyvc.c:2514
+#: ../geanyvc/src/geanyvc.c:2554
 msgid "_Diff"
 msgstr "差分(_D)"
 
-#: ../geanyvc/src/geanyvc.c:2371
+#: ../geanyvc/src/geanyvc.c:2422
 msgid "Make a diff from the current active file"
 msgstr "現在のファイルとレポジトリのファイルの差分を作成します。"
 
 #. Revert current file
 #. Revert current dir
 #. Revert everything
-#: ../geanyvc/src/geanyvc.c:2376 ../geanyvc/src/geanyvc.c:2472
-#: ../geanyvc/src/geanyvc.c:2511
+#: ../geanyvc/src/geanyvc.c:2427 ../geanyvc/src/geanyvc.c:2523
+#: ../geanyvc/src/geanyvc.c:2562
 msgid "_Revert"
 msgstr "取り消し(_R)"
 
-#: ../geanyvc/src/geanyvc.c:2379
+#: ../geanyvc/src/geanyvc.c:2430
 msgid "Restore pristine working copy file (undo local edits)."
 msgstr "作業コピーのファイルを最初の状態に戻す(ローカルな編集を破棄)."
 
 #. Blame for current file
-#: ../geanyvc/src/geanyvc.c:2388
+#: ../geanyvc/src/geanyvc.c:2439
 msgid "_Blame"
 msgstr "履歴を追跡(_B)"
 
-#: ../geanyvc/src/geanyvc.c:2391
+#: ../geanyvc/src/geanyvc.c:2442
 msgid "Shows the changes made at one file per revision and author."
 msgstr "ファイルの変更履歴を版ごと修正者ごとに表示"
 
 #. History/log of current file
 #. History/log of the current dir
 #. Complete History/Log of base directory
-#: ../geanyvc/src/geanyvc.c:2398 ../geanyvc/src/geanyvc.c:2482
-#: ../geanyvc/src/geanyvc.c:2523
+#: ../geanyvc/src/geanyvc.c:2449 ../geanyvc/src/geanyvc.c:2533
+#: ../geanyvc/src/geanyvc.c:2574
 msgid "_History (log)"
 msgstr "履歴ログ(_H)"
 
-#: ../geanyvc/src/geanyvc.c:2401
+#: ../geanyvc/src/geanyvc.c:2452
 msgid "Shows the log of the current file"
 msgstr "現在のファイルのログを表示"
 
 #. base version of the current file
-#: ../geanyvc/src/geanyvc.c:2406
+#: ../geanyvc/src/geanyvc.c:2457
 msgid "_Original"
 msgstr "オリジナル(_O)"
 
-#: ../geanyvc/src/geanyvc.c:2409
+#: ../geanyvc/src/geanyvc.c:2460
 msgid "Shows the original of the current file"
 msgstr "現在のファイルのオリジナルを表示"
 
 #. add current file
-#: ../geanyvc/src/geanyvc.c:2417
+#: ../geanyvc/src/geanyvc.c:2468
 msgid "_Add to Version Control"
 msgstr "バージョン管理に追加(_A)"
 
-#: ../geanyvc/src/geanyvc.c:2419
+#: ../geanyvc/src/geanyvc.c:2470
 msgid "Add file to repository."
 msgstr "ファイルをレポジトリに追加"
 
 #. remove current file
-#: ../geanyvc/src/geanyvc.c:2425
+#: ../geanyvc/src/geanyvc.c:2476
 msgid "_Remove from Version Control"
 msgstr "バージョン管理から削除(_R)"
 
-#: ../geanyvc/src/geanyvc.c:2427
+#: ../geanyvc/src/geanyvc.c:2478
 msgid "Remove file from repository."
 msgstr "レポジトリからファイルを削除"
 
-#: ../geanyvc/src/geanyvc.c:2460
+#: ../geanyvc/src/geanyvc.c:2511
 msgid "_Directory"
 msgstr "ディレクトリ(_D)"
 
-#: ../geanyvc/src/geanyvc.c:2466
+#: ../geanyvc/src/geanyvc.c:2517
 msgid "Make a diff from the directory of the current active file"
 msgstr "現在のファイルのディレクトリから差分を作成"
 
-#: ../geanyvc/src/geanyvc.c:2475
+#: ../geanyvc/src/geanyvc.c:2526
 msgid "Restore original files in the current folder (undo local edits)."
 msgstr "現在のディレクトリの元のファイルを復元(ローカルな編集を破棄)"
 
-#: ../geanyvc/src/geanyvc.c:2485
+#: ../geanyvc/src/geanyvc.c:2536
 msgid "Shows the log of the current directory"
 msgstr "現在のディレクトリのログを表示"
 
-#: ../geanyvc/src/geanyvc.c:2499
+#: ../geanyvc/src/geanyvc.c:2550
 msgid "_Base Directory"
 msgstr "_BASE ディレクトリ"
 
-#: ../geanyvc/src/geanyvc.c:2505
+#: ../geanyvc/src/geanyvc.c:2556
 msgid "Make a diff from the top VC directory"
 msgstr "バージョン管理ディレクトリから diff を作成"
 
-#: ../geanyvc/src/geanyvc.c:2513
+#: ../geanyvc/src/geanyvc.c:2564
 msgid "Revert any local edits."
 msgstr "ローカルな編集を元に戻す"
 
-#: ../geanyvc/src/geanyvc.c:2526
+#: ../geanyvc/src/geanyvc.c:2577
 msgid "Shows the log of the top VC directory"
 msgstr "バージョン管理ディレクトリのログを表示"
 
-#: ../geanyvc/src/geanyvc.c:2543
+#: ../geanyvc/src/geanyvc.c:2594
 msgid "_VC file Actions"
 msgstr "_VC ファイル アクション"
 
-#: ../geanyvc/src/geanyvc.c:2552
+#: ../geanyvc/src/geanyvc.c:2603
 msgid "VC _Commit..."
 msgstr "VC コミット...(_C)"
 
-#: ../geanyvc/src/geanyvc.c:2596
+#: ../geanyvc/src/geanyvc.c:2647
 msgid "Show diff of file"
 msgstr "ファイルの差分を表示"
 
-#: ../geanyvc/src/geanyvc.c:2598
+#: ../geanyvc/src/geanyvc.c:2649
 msgid "Show diff of directory"
 msgstr "ディレクトリの差分を表示"
 
-#: ../geanyvc/src/geanyvc.c:2600
+#: ../geanyvc/src/geanyvc.c:2651
 msgid "Show diff of basedir"
 msgstr "BASEディレクトリの差分を表示"
 
-#: ../geanyvc/src/geanyvc.c:2603
+#: ../geanyvc/src/geanyvc.c:2654
 msgid "Commit changes"
 msgstr "変更を反映"
 
-#: ../geanyvc/src/geanyvc.c:2605
+#: ../geanyvc/src/geanyvc.c:2656
 msgid "Show status"
 msgstr "状態を表示"
 
-#: ../geanyvc/src/geanyvc.c:2607
+#: ../geanyvc/src/geanyvc.c:2658
 msgid "Revert single file"
 msgstr "1つのファイルを元に戻す"
 
-#: ../geanyvc/src/geanyvc.c:2609
+#: ../geanyvc/src/geanyvc.c:2660
 msgid "Revert directory"
 msgstr "ディレクトリを元に戻す"
 
-#: ../geanyvc/src/geanyvc.c:2611
+#: ../geanyvc/src/geanyvc.c:2662
 msgid "Revert base directory"
 msgstr "BASE ディレクトリに戻す"
 
-#: ../geanyvc/src/geanyvc.c:2613
+#: ../geanyvc/src/geanyvc.c:2664
 msgid "Update file"
 msgstr "ファイルを更新"
 
-#: ../geanyvc/src/geanyvc.c:2643
+#: ../geanyvc/src/geanyvc.c:2694
 msgid "_VC"
 msgstr "_VC"
 
-#: ../geanyvc/src/geanyvc.c:2650
+#: ../geanyvc/src/geanyvc.c:2701
 msgid "_Version Control"
 msgstr "バージョン管理(_V)"
 
 #. Status of basedir
-#: ../geanyvc/src/geanyvc.c:2672
+#: ../geanyvc/src/geanyvc.c:2723
 msgid "_Status"
 msgstr "状態(_S)"
 
-#: ../geanyvc/src/geanyvc.c:2674
+#: ../geanyvc/src/geanyvc.c:2725
 msgid "Show status."
 msgstr "状態を表示"
 
-#: ../geanyvc/src/geanyvc.c:2681
+#: ../geanyvc/src/geanyvc.c:2732
 msgid "Update from remote repository."
 msgstr "外部のレポジトリから更新"
 
 #. Commit all changes
-#: ../geanyvc/src/geanyvc.c:2686
+#: ../geanyvc/src/geanyvc.c:2737
 msgid "_Commit..."
 msgstr "コミット...(_C)"
 
-#: ../geanyvc/src/geanyvc.c:2688
+#: ../geanyvc/src/geanyvc.c:2739
 msgid "Commit changes."
 msgstr "変更を反映"
 
@@ -5038,35 +5038,6 @@ msgstr "新しいブラウザタブに貼りつけたものを表示"
 #: ../geniuspaste/src/geniuspaste.c:959
 msgid "_Paste it!"
 msgstr "貼り付け!(_P)"
-
-#: ../git-changebar/data/prefs.ui.h:1
-msgid "_Monitor repository for changes"
-msgstr ""
-
-#: ../git-changebar/data/prefs.ui.h:2
-msgid ""
-"Whether to automatically update the diff in order to maintain it up to date "
-"when the underlying Git repository changes.  This should generally be "
-"enabled for optimal user experience."
-msgstr ""
-
-#: ../git-changebar/data/prefs.ui.h:3
-msgid "_Added lines:"
-msgstr ""
-
-#: ../git-changebar/data/prefs.ui.h:4
-msgid "_Changed lines:"
-msgstr ""
-
-#: ../git-changebar/data/prefs.ui.h:5
-#, fuzzy
-msgid "_Removed lines:"
-msgstr "ファイルを削除"
-
-#: ../git-changebar/data/prefs.ui.h:6
-#, fuzzy
-msgid "Colors"
-msgstr "背景色:"
 
 #: ../git-changebar/src/gcb-plugin.c:62
 msgid "Git Change Bar"
@@ -5257,8 +5228,8 @@ msgstr ""
 #: ../lipsum/src/lipsum.c:184 ../sendmail/src/sendmail.c:396
 #, c-format
 msgid ""
-"Your configuration directory has been successfully moved from \"%s\" to \"%s"
-"\"."
+"Your configuration directory has been successfully moved from \"%s\" to "
+"\"%s\"."
 msgstr ""
 
 #: ../lipsum/src/lipsum.c:199
@@ -5432,7 +5403,7 @@ msgstr "既定の設定の保存に失敗: %s"
 msgid "Unable to read value for '%s' key: %s"
 msgstr "設定ディレクトリを '%s' に作成できません"
 
-#: ../multiterm/src/tab-label.vala:62 ../treebrowser/src/treebrowser.c:2132
+#: ../multiterm/src/tab-label.vala:62 ../treebrowser/src/treebrowser.c:2137
 #, fuzzy
 msgid "Terminal"
 msgstr "終了"
@@ -5473,117 +5444,6 @@ msgstr ""
 msgid "Show Overview"
 msgstr "端末を表示"
 
-#: ../overview/data/prefs.ui.h:1
-msgid ""
-"The amount to zoom the overview sidebar. This should probably negative if "
-"you want the sidebar zoomed out."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:2
-#, fuzzy
-msgid "Zoom Level:"
-msgstr "拡大表示"
-
-#: ../overview/data/prefs.ui.h:3
-msgid "The width of the overview sidebar."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:4
-msgid "Width:"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:5
-msgid ""
-"The number of lines to scroll at a time when scrolling the overview sidebar."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:6
-msgid "Scroll Lines:"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:7
-#, fuzzy
-msgid "Position on left"
-msgstr "場所の名前"
-
-#: ../overview/data/prefs.ui.h:8
-msgid ""
-"Position the overview bar on the left rather than the right (requires Geany "
-"1.25 or greater)."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:9
-#, fuzzy
-msgid "Hide tooltip"
-msgstr "ツールチップを表示(_T)"
-
-#: ../overview/data/prefs.ui.h:10
-msgid ""
-"Hide the tooltip that is displayed when mousing over the overview that shows "
-"line, column and position information."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:11
-msgid "Hide editor scrollbar"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:12
-msgid ""
-"Whether to hide Geany's regular editor scrollbar while the overview bar is "
-"visible."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:13
-msgid "Disable overlay"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:14
-msgid ""
-"Turn off drawing overlay, which shows the region of the main editor view "
-"that is currently in view, ontop of the overview bar."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:15 ../scope/data/scope.glade.h:130
-#: ../scope/data/scope_gtk3.glade.h:130
-msgid "Options"
-msgstr "オプション"
-
-#: ../overview/data/prefs.ui.h:16
-msgid ""
-"The color and opacity of the overlay drawn ontop of the overlay sidebar."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:17
-#, fuzzy
-msgid "Color:"
-msgstr "背景色:"
-
-#: ../overview/data/prefs.ui.h:18
-msgid ""
-"The color and opacity of the border drawn around the revealed area in the "
-"overview sidebar. Set to the same as Overlay Color to disable."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:19
-#, fuzzy
-msgid "Outline Color:"
-msgstr "色を選択"
-
-#: ../overview/data/prefs.ui.h:20
-msgid "Draw over visible area"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:21
-msgid ""
-"When checked it will draw the overlay ontop of the area that is visible in "
-"the main editor view, when unchecked, it will do the opposite and draw the "
-"overlay everywhere but the visible area, \"revealing\" the visible part."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:22
-msgid "Overlay"
-msgstr ""
-
 #: ../pairtaghighlighter/src/pair_tag_highlighter.c:43
 msgid "Pair Tag Highlighter"
 msgstr ""
@@ -5611,151 +5471,6 @@ msgstr "対応する括弧で選択(_B)"
 #, fuzzy
 msgid "Select To Matching Tag"
 msgstr "対応する括弧で選択(_B)"
-
-#: ../pohelper/data/menus.ui.h:1
-msgid "_Translation Helper"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:2
-msgid "_Previous String"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:3 ../pohelper/src/gph-plugin.c:1590
-#, fuzzy
-msgid "Go to previous string"
-msgstr "前の頁に移動"
-
-#: ../pohelper/data/menus.ui.h:4
-msgid "_Next String"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:5 ../pohelper/src/gph-plugin.c:1593
-#, fuzzy
-msgid "Go to next string"
-msgstr "次の頁に移動"
-
-#: ../pohelper/data/menus.ui.h:6
-msgid "Pre_vious Untranslated"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:7 ../pohelper/src/gph-plugin.c:1596
-msgid "Go to previous untranslated string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:8
-msgid "Next _Untranslated"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:9 ../pohelper/src/gph-plugin.c:1599
-msgid "Go to next untranslated string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:10
-msgid "Previous Fu_zzy"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:11 ../pohelper/src/gph-plugin.c:1602
-msgid "Go to previous fuzzily translated string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:12
-msgid "Next _Fuzzy"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:13 ../pohelper/src/gph-plugin.c:1605
-msgid "Go to next fuzzily translated string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:14
-msgid "Previous Untranslated or Fuzz_y"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:15 ../pohelper/src/gph-plugin.c:1608
-msgid "Go to previous untranslated or fuzzy string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:16
-msgid "Next Untranslated _or Fuzzy"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:17 ../pohelper/src/gph-plugin.c:1612
-msgid "Go to next untranslated or fuzzy string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:18 ../pohelper/src/gph-plugin.c:1623
-#, fuzzy
-msgid "Toggle current translation fuzziness"
-msgstr "文書タブを切り替え"
-
-#: ../pohelper/data/menus.ui.h:19
-msgid "_Toggle Fuzziness"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:20
-msgid "Paste _Message as Translation"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:21
-msgid "Paste the original untranslated string to the translation"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:22 ../pohelper/src/gph-plugin.c:1620
-msgid "Reflow the current translation string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:23
-msgid "_Reflow Translation"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:24 ../pohelper/src/gph-plugin.c:1626
-#, fuzzy
-msgid "Show statistics of the current document"
-msgstr "現在の文書の綴りを検査"
-
-#: ../pohelper/data/menus.ui.h:25
-#, fuzzy
-msgid "_Show stats"
-msgstr "状態を表示"
-
-#: ../pohelper/data/menus.ui.h:26
-msgid ""
-"Whether to update the translation headers (author, revision date, ...) upon "
-"file save"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:27
-msgid "Update _Headers Upon Save"
-msgstr ""
-
-#: ../pohelper/data/stats.ui.h:1
-msgid "Translation statistics"
-msgstr ""
-
-#: ../pohelper/data/stats.ui.h:2
-msgid "Choose a color for translated strings"
-msgstr ""
-
-#: ../pohelper/data/stats.ui.h:3
-msgid "Choose a color for fuzzily translated strings"
-msgstr ""
-
-#: ../pohelper/data/stats.ui.h:4
-msgid "Choose a color for untranslated strings"
-msgstr ""
-
-#: ../pohelper/data/stats.ui.h:5
-#, fuzzy
-msgid "Translated:"
-msgstr "translator_credits"
-
-#: ../pohelper/data/stats.ui.h:6
-msgid "Fuzzy:"
-msgstr ""
-
-#: ../pohelper/data/stats.ui.h:7
-#, fuzzy
-msgid "Untranslated:"
-msgstr "translator_credits"
 
 #: ../pohelper/src/gph-plugin.c:40
 msgid "Translation Helper"
@@ -5785,9 +5500,57 @@ msgstr ""
 msgid "%u (%.3g%%)"
 msgstr ""
 
+#: ../pohelper/src/gph-plugin.c:1590
+#, fuzzy
+msgid "Go to previous string"
+msgstr "前の頁に移動"
+
+#: ../pohelper/src/gph-plugin.c:1593
+#, fuzzy
+msgid "Go to next string"
+msgstr "次の頁に移動"
+
+#: ../pohelper/src/gph-plugin.c:1596
+msgid "Go to previous untranslated string"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1599
+msgid "Go to next untranslated string"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1602
+msgid "Go to previous fuzzily translated string"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1605
+msgid "Go to next fuzzily translated string"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1608
+msgid "Go to previous untranslated or fuzzy string"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1612
+msgid "Go to next untranslated or fuzzy string"
+msgstr ""
+
 #: ../pohelper/src/gph-plugin.c:1616
 msgid "Paste original untranslated string to translation"
 msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1620
+msgid "Reflow the current translation string"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1623
+#, fuzzy
+msgid "Toggle current translation fuzziness"
+msgstr "文書タブを切り替え"
+
+#: ../pohelper/src/gph-plugin.c:1626
+#, fuzzy
+msgid "Show statistics of the current document"
+msgstr "現在の文書の綴りを検査"
 
 #: ../pohelper/src/gph-plugin.c:1833
 #, c-format
@@ -6080,7 +5843,7 @@ msgid "Add"
 msgstr "アドオン"
 
 #: ../projectorganizer/src/prjorg-sidebar.c:390
-#: ../treebrowser/src/treebrowser.c:2356
+#: ../treebrowser/src/treebrowser.c:2361
 #, fuzzy
 msgid "New File"
 msgstr "新規ファイル"
@@ -6715,6 +6478,10 @@ msgstr "ツールチップを表示(_T)"
 msgid "<b>Others</b>"
 msgstr "<b>その他</b>"
 
+#: ../scope/data/scope.glade.h:130 ../scope/data/scope_gtk3.glade.h:130
+msgid "Options"
+msgstr "オプション"
+
 #: ../scope/data/scope.glade.h:131 ../scope/data/scope_gtk3.glade.h:131
 msgid "_Import"
 msgstr "読み込み(_I)"
@@ -7300,12 +7067,14 @@ msgid "Checks the spelling of the current document."
 msgstr "現在の文書の綴りを検査"
 
 #: ../spellcheck/src/scplugin.c:225
-msgid "Run Spell Check"
+#, fuzzy
+msgid "Run spell check once"
 msgstr "スペルチェックを実行"
 
-#: ../spellcheck/src/scplugin.c:228
-msgid "Toggle Check While Typing"
-msgstr "入力中のチェックを有効/無効"
+#: ../spellcheck/src/scplugin.c:228 ../spellcheck/src/scplugin.c:333
+#, fuzzy
+msgid "Toggle spell check"
+msgstr "スペルチェック"
 
 #. initialise the dialog
 #: ../spellcheck/src/scplugin.c:239
@@ -7333,10 +7102,6 @@ msgstr "メッセージウィンドウに間違った単語と修正候補を表
 #, fuzzy
 msgid "<b>Interface</b>"
 msgstr "<b>検査</b>"
-
-#: ../spellcheck/src/scplugin.c:333
-msgid "Check spelling while typing"
-msgstr "入力中にスペルチェックを行う"
 
 #: ../spellcheck/src/scplugin.c:336
 #, fuzzy
@@ -7373,32 +7138,32 @@ msgstr ""
 msgid "<b>Behavior</b>"
 msgstr "<b>その他</b>"
 
-#: ../spellcheck/src/gui.c:76
+#: ../spellcheck/src/gui.c:88
 msgid "Spell checking while typing is now enabled"
 msgstr "入力中のスペルチェックは有効です"
 
-#: ../spellcheck/src/gui.c:78
+#: ../spellcheck/src/gui.c:90
 msgid "Spell checking while typing is now disabled"
 msgstr "入力中のスペルチェックは無効です"
 
-#: ../spellcheck/src/gui.c:326
+#: ../spellcheck/src/gui.c:323
 msgid "More..."
 msgstr "さらに..."
 
-#: ../spellcheck/src/gui.c:347
+#: ../spellcheck/src/gui.c:344
 msgid "(No Suggestions)"
 msgstr "(候補なし)"
 
-#: ../spellcheck/src/gui.c:360
+#: ../spellcheck/src/gui.c:357
 #, c-format
 msgid "Add \"%s\" to Dictionary"
 msgstr "\"%s\" を辞書に追加"
 
-#: ../spellcheck/src/gui.c:368
+#: ../spellcheck/src/gui.c:365
 msgid "Ignore All"
 msgstr "すべて無視"
 
-#: ../spellcheck/src/gui.c:441
+#: ../spellcheck/src/gui.c:438
 msgid ""
 "Search term is too long to provide\n"
 "spelling suggestions in the editor menu."
@@ -7406,21 +7171,21 @@ msgstr ""
 "エディタメニューに修正候補を表示するには\n"
 "検索する言葉が長すぎます"
 
-#: ../spellcheck/src/gui.c:447
+#: ../spellcheck/src/gui.c:444
 msgid "Perform Spell Check"
 msgstr "スペルチェックを実行"
 
-#: ../spellcheck/src/gui.c:609
+#: ../spellcheck/src/gui.c:606
 #, c-format
 msgid "Default (%s)"
 msgstr "標準 (%s)"
 
-#: ../spellcheck/src/gui.c:620
-#, c-format
-msgid "Toggle spell check while typing (current language: %s)"
+#: ../spellcheck/src/gui.c:617
+#, fuzzy, c-format
+msgid "Toggle spell check (current language: %s)"
 msgstr "入力中のスペルチェックを有効/無効(現在の言語: %s)"
 
-#: ../spellcheck/src/gui.c:698
+#: ../spellcheck/src/gui.c:695
 msgid "Spelling Suggestions"
 msgstr "正しい単語の候補"
 
@@ -7517,15 +7282,15 @@ msgstr "(空)"
 msgid "Could not execute configured external command '%s' (%s)."
 msgstr "設定済みの外部コマンド '%s' が実行できません (%s)."
 
-#: ../treebrowser/src/treebrowser.c:1089
+#: ../treebrowser/src/treebrowser.c:1093
 msgid "NewDirectory"
 msgstr "新規ディレクトリ"
 
-#: ../treebrowser/src/treebrowser.c:1091
+#: ../treebrowser/src/treebrowser.c:1095
 msgid "NewFile"
 msgstr "新規ファイル"
 
-#: ../treebrowser/src/treebrowser.c:1096
+#: ../treebrowser/src/treebrowser.c:1100
 #, fuzzy, c-format
 msgid ""
 "Target file '%s' exists.\n"
@@ -7534,131 +7299,131 @@ msgstr ""
 "対象ファイル '%s' が存在します。\n"
 "このファイルを空のファイルで上書きしてもいいですか?"
 
-#: ../treebrowser/src/treebrowser.c:1142
+#: ../treebrowser/src/treebrowser.c:1146
 #, c-format
 msgid "Do you really want to delete '%s' ?"
 msgstr "'%s' を削除してもよいですか?"
 
-#: ../treebrowser/src/treebrowser.c:1255 ../treebrowser/src/treebrowser.c:1257
+#: ../treebrowser/src/treebrowser.c:1259 ../treebrowser/src/treebrowser.c:1261
 #, fuzzy
 msgid "Go _Up"
 msgstr "上に移動(_U)"
 
-#: ../treebrowser/src/treebrowser.c:1263 ../treebrowser/src/treebrowser.c:1265
+#: ../treebrowser/src/treebrowser.c:1267 ../treebrowser/src/treebrowser.c:1269
 #, fuzzy
 msgid "Set _Path From Document"
 msgstr "文書からパスを設定"
 
-#: ../treebrowser/src/treebrowser.c:1271 ../treebrowser/src/treebrowser.c:1273
+#: ../treebrowser/src/treebrowser.c:1275 ../treebrowser/src/treebrowser.c:1277
 #, fuzzy
 msgid "_Open Externally"
 msgstr "外部アプリケーションで開く"
 
-#: ../treebrowser/src/treebrowser.c:1279
+#: ../treebrowser/src/treebrowser.c:1283
 #, fuzzy
 msgid "Open _Terminal"
 msgstr "端末で開く"
 
-#: ../treebrowser/src/treebrowser.c:1284 ../treebrowser/src/treebrowser.c:1286
+#: ../treebrowser/src/treebrowser.c:1288 ../treebrowser/src/treebrowser.c:1290
 #, fuzzy
 msgid "Set as _Root"
 msgstr "rootに設定"
 
-#: ../treebrowser/src/treebrowser.c:1293 ../treebrowser/src/treebrowser.c:1295
+#: ../treebrowser/src/treebrowser.c:1297 ../treebrowser/src/treebrowser.c:1299
 #, fuzzy
 msgid "Refres_h"
 msgstr "表示を更新"
 
-#: ../treebrowser/src/treebrowser.c:1301 ../treebrowser/src/treebrowser.c:1303
+#: ../treebrowser/src/treebrowser.c:1305 ../treebrowser/src/treebrowser.c:1307
 #, fuzzy
 msgid "_Find in Files"
 msgstr "複数ファイルを検索"
 
-#: ../treebrowser/src/treebrowser.c:1313 ../treebrowser/src/treebrowser.c:1315
+#: ../treebrowser/src/treebrowser.c:1317 ../treebrowser/src/treebrowser.c:1319
 #, fuzzy
 msgid "N_ew Folder"
 msgstr "フォルダを選択"
 
-#: ../treebrowser/src/treebrowser.c:1321 ../treebrowser/src/treebrowser.c:1323
+#: ../treebrowser/src/treebrowser.c:1325 ../treebrowser/src/treebrowser.c:1327
 #, fuzzy
 msgid "_New File"
 msgstr "新規ファイル"
 
-#: ../treebrowser/src/treebrowser.c:1329 ../treebrowser/src/treebrowser.c:1331
+#: ../treebrowser/src/treebrowser.c:1333 ../treebrowser/src/treebrowser.c:1335
 #, fuzzy
 msgid "Rena_me"
 msgstr "名前変更"
 
-#: ../treebrowser/src/treebrowser.c:1350 ../treebrowser/src/treebrowser.c:1352
+#: ../treebrowser/src/treebrowser.c:1354 ../treebrowser/src/treebrowser.c:1356
 #, c-format
 msgid "Close: %s"
 msgstr "閉じる: %s"
 
-#: ../treebrowser/src/treebrowser.c:1359 ../treebrowser/src/treebrowser.c:1361
+#: ../treebrowser/src/treebrowser.c:1363 ../treebrowser/src/treebrowser.c:1365
 #, fuzzy, c-format
 msgid "Clo_se Child Documents "
 msgstr "下位の文書を閉じる"
 
-#: ../treebrowser/src/treebrowser.c:1368 ../treebrowser/src/treebrowser.c:1370
+#: ../treebrowser/src/treebrowser.c:1372 ../treebrowser/src/treebrowser.c:1374
 #, fuzzy
 msgid "_Copy Full Path to Clipboard"
 msgstr "完全パスをクリップボードにコピー"
 
-#: ../treebrowser/src/treebrowser.c:1381 ../treebrowser/src/treebrowser.c:1383
+#: ../treebrowser/src/treebrowser.c:1385 ../treebrowser/src/treebrowser.c:1387
 #, fuzzy
 msgid "E_xpand All"
 msgstr "すべて展開"
 
-#: ../treebrowser/src/treebrowser.c:1389 ../treebrowser/src/treebrowser.c:1391
+#: ../treebrowser/src/treebrowser.c:1393 ../treebrowser/src/treebrowser.c:1395
 #, fuzzy
 msgid "Coll_apse All"
 msgstr "すべて閉じる"
 
-#: ../treebrowser/src/treebrowser.c:1399
+#: ../treebrowser/src/treebrowser.c:1403
 #, fuzzy
 msgid "Show Boo_kmarks"
 msgstr "ブックマークを表示"
 
-#: ../treebrowser/src/treebrowser.c:1404
+#: ../treebrowser/src/treebrowser.c:1408
 #, fuzzy
 msgid "Sho_w Hidden Files"
 msgstr "隠しファイルを表示"
 
-#: ../treebrowser/src/treebrowser.c:1409
+#: ../treebrowser/src/treebrowser.c:1413
 #, fuzzy
 msgid "Show Tool_bars"
 msgstr "ツールバーを表示"
 
-#: ../treebrowser/src/treebrowser.c:1747
+#: ../treebrowser/src/treebrowser.c:1751
 #, c-format
 msgid "Target file '%s' exists, do you really want to replace it?"
 msgstr "対象ファイル '%s' が存在します。置き換えてもいいですか?"
 
-#: ../treebrowser/src/treebrowser.c:1883
+#: ../treebrowser/src/treebrowser.c:1887
 msgid "Go up"
 msgstr "上に移動"
 
-#: ../treebrowser/src/treebrowser.c:1893 ../treebrowser/src/treebrowser.c:2360
+#: ../treebrowser/src/treebrowser.c:1897 ../treebrowser/src/treebrowser.c:2365
 msgid "Refresh"
 msgstr "表示を更新"
 
-#: ../treebrowser/src/treebrowser.c:1903
+#: ../treebrowser/src/treebrowser.c:1907
 msgid "Home"
 msgstr "ホーム"
 
-#: ../treebrowser/src/treebrowser.c:1913
+#: ../treebrowser/src/treebrowser.c:1917
 msgid "Set path from document"
 msgstr "文書からパスを設定"
 
-#: ../treebrowser/src/treebrowser.c:1923
+#: ../treebrowser/src/treebrowser.c:1927
 msgid "Track path"
 msgstr "パスを記録"
 
-#: ../treebrowser/src/treebrowser.c:1933
+#: ../treebrowser/src/treebrowser.c:1937
 msgid "Hide bars"
 msgstr "バーを隠す"
 
-#: ../treebrowser/src/treebrowser.c:1943
+#: ../treebrowser/src/treebrowser.c:1947
 msgid ""
 "Filter (*.c;*.h;*.cpp), and if you want temporary filter using the '!' "
 "reverse try for example this '!;*.c;*.h;*.cpp'"
@@ -7666,20 +7431,20 @@ msgstr ""
 "フィルタ(*.c;*.h;*.cpp)と '!' 反転を使った一時フィルタを使用するには次のよう"
 "にします '!;*.c;*.h;*.cpp'"
 
-#: ../treebrowser/src/treebrowser.c:1948
+#: ../treebrowser/src/treebrowser.c:1952
 msgid "Addressbar for example '/projects/my-project'"
 msgstr "アドレスバーの入力例 '/projects/my-project'"
 
-#: ../treebrowser/src/treebrowser.c:1973
+#: ../treebrowser/src/treebrowser.c:1977
 msgid "Tree Browser"
 msgstr "ツリーブラウザ"
 
-#: ../treebrowser/src/treebrowser.c:2114
+#: ../treebrowser/src/treebrowser.c:2118
 msgid "External open command"
 msgstr "他のプログラムで開く"
 
-#: ../treebrowser/src/treebrowser.c:2124
-#, c-format
+#: ../treebrowser/src/treebrowser.c:2129
+#, no-c-format
 msgid ""
 "The command to execute when using \"Open with\". You can use %f and %d "
 "wildcards.\n"
@@ -7692,59 +7457,59 @@ msgstr ""
 "%f は完全パスを含むファイル名に置き換えられます。\n"
 "%d は選択したファイルがあるパス名に置き換えられます。"
 
-#: ../treebrowser/src/treebrowser.c:2143
+#: ../treebrowser/src/treebrowser.c:2148
 msgid "The terminal to use with the command \"Open Terminal\""
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2149
+#: ../treebrowser/src/treebrowser.c:2154
 msgid "Toolbar"
 msgstr "ツールバー"
 
-#: ../treebrowser/src/treebrowser.c:2151
+#: ../treebrowser/src/treebrowser.c:2156
 msgid "Hidden"
 msgstr "非表示"
 
-#: ../treebrowser/src/treebrowser.c:2152
+#: ../treebrowser/src/treebrowser.c:2157
 msgid "Top"
 msgstr "上"
 
-#: ../treebrowser/src/treebrowser.c:2153
+#: ../treebrowser/src/treebrowser.c:2158
 msgid "Bottom"
 msgstr "下"
 
-#: ../treebrowser/src/treebrowser.c:2158
+#: ../treebrowser/src/treebrowser.c:2163
 msgid "If position is changed, the option require plugin restart."
 msgstr "位置を変更したときは、プラグインの再起動が必要です。"
 
-#: ../treebrowser/src/treebrowser.c:2162
+#: ../treebrowser/src/treebrowser.c:2167
 msgid "Show icons"
 msgstr "アイコンを表示"
 
-#: ../treebrowser/src/treebrowser.c:2164
+#: ../treebrowser/src/treebrowser.c:2169
 msgid "None"
 msgstr "なし"
 
-#: ../treebrowser/src/treebrowser.c:2165
+#: ../treebrowser/src/treebrowser.c:2170
 msgid "Base"
 msgstr "基本"
 
-#: ../treebrowser/src/treebrowser.c:2166
+#: ../treebrowser/src/treebrowser.c:2171
 msgid "Content-type"
 msgstr "内容"
 
-#: ../treebrowser/src/treebrowser.c:2172
+#: ../treebrowser/src/treebrowser.c:2177
 msgid "Show hidden files"
 msgstr "隠しファイルを表示"
 
-#: ../treebrowser/src/treebrowser.c:2181
+#: ../treebrowser/src/treebrowser.c:2186
 msgid "On Windows, this just hide files that are prefixed with '.' (dot)"
 msgstr "'.'(ドット)から始まるファイルを隠します"
 
-#: ../treebrowser/src/treebrowser.c:2183
+#: ../treebrowser/src/treebrowser.c:2188
 msgid "Hide object files"
 msgstr "オブジェクトファイルを表示しない"
 
-#: ../treebrowser/src/treebrowser.c:2192
+#: ../treebrowser/src/treebrowser.c:2197
 msgid ""
 "Don't show generated object files in the file browser, this includes *.o, *."
 "obj. *.so, *.dll, *.a, *.lib"
@@ -7752,61 +7517,61 @@ msgstr ""
 "ファイルブラウザにオブジェクトファイルを表示しません。除外されるファイルは *."
 "o, *.obj. *.so, *.dll, *.a, *.lib です。"
 
-#: ../treebrowser/src/treebrowser.c:2194
+#: ../treebrowser/src/treebrowser.c:2199
 msgid "Reverse filter"
 msgstr "フィルタを反転"
 
-#: ../treebrowser/src/treebrowser.c:2203
+#: ../treebrowser/src/treebrowser.c:2208
 msgid "Follow current document"
 msgstr "現在の文書のディレクトリに合わせる"
 
-#: ../treebrowser/src/treebrowser.c:2212
+#: ../treebrowser/src/treebrowser.c:2217
 msgid "Single click, open document and focus it"
 msgstr "シングルクリックで文書を表示"
 
-#: ../treebrowser/src/treebrowser.c:2221
+#: ../treebrowser/src/treebrowser.c:2226
 msgid "Double click open directory"
 msgstr "ダブルクリックでディレクトリを表示"
 
-#: ../treebrowser/src/treebrowser.c:2230
+#: ../treebrowser/src/treebrowser.c:2235
 msgid "On delete file, close it if is opened"
 msgstr "ファイル削除時に、開いていたら閉じる"
 
-#: ../treebrowser/src/treebrowser.c:2239
+#: ../treebrowser/src/treebrowser.c:2244
 msgid "Focus editor on file open"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2248
+#: ../treebrowser/src/treebrowser.c:2253
 msgid "Show tree lines"
 msgstr "ツリー行数を表示"
 
-#: ../treebrowser/src/treebrowser.c:2257
+#: ../treebrowser/src/treebrowser.c:2262
 msgid "Show bookmarks"
 msgstr "ブックマークを表示"
 
-#: ../treebrowser/src/treebrowser.c:2266
+#: ../treebrowser/src/treebrowser.c:2271
 #, fuzzy
 msgid "Open new files"
 msgstr "ファイルを開く"
 
-#: ../treebrowser/src/treebrowser.c:2350
+#: ../treebrowser/src/treebrowser.c:2355
 msgid "Focus File List"
 msgstr "ファイル覧に切り替え"
 
-#: ../treebrowser/src/treebrowser.c:2352
+#: ../treebrowser/src/treebrowser.c:2357
 msgid "Focus Path Entry"
 msgstr "パス入力に切り替え"
 
-#: ../treebrowser/src/treebrowser.c:2354
+#: ../treebrowser/src/treebrowser.c:2359
 msgid "Rename Object"
 msgstr "オブジェクトの名前変更"
 
-#: ../treebrowser/src/treebrowser.c:2358
+#: ../treebrowser/src/treebrowser.c:2363
 #, fuzzy
 msgid "New Folder"
 msgstr "フォルダを選択"
 
-#: ../treebrowser/src/treebrowser.c:2362
+#: ../treebrowser/src/treebrowser.c:2367
 #, fuzzy
 msgid "Track Current"
 msgstr "パスを記録"
@@ -8523,12 +8288,6 @@ msgstr "新規ディレクトリ"
 msgid "No workbench opened."
 msgstr ""
 
-#: ../workbench/src/sidebar.c:875
-#, fuzzy, c-format
-msgid "%s: %u Project"
-msgid_plural "%s: %u Projects"
-msgstr[0] "プロジェクト"
-
 #: ../workbench/src/sidebar.c:886
 msgid ""
 "Add a project using the context menu\n"
@@ -8636,6 +8395,57 @@ msgstr "XML スニペット"
 #: ../xmlsnippets/src/plugin.c:45
 msgid "Autocompletes XML/HTML tags using snippets."
 msgstr "スニペットを使用してXML/HTMLタグを自動補完"
+
+#, fuzzy
+#~ msgid "_Removed lines:"
+#~ msgstr "ファイルを削除"
+
+#, fuzzy
+#~ msgid "Colors"
+#~ msgstr "背景色:"
+
+#, fuzzy
+#~ msgid "Zoom Level:"
+#~ msgstr "拡大表示"
+
+#, fuzzy
+#~ msgid "Position on left"
+#~ msgstr "場所の名前"
+
+#, fuzzy
+#~ msgid "Hide tooltip"
+#~ msgstr "ツールチップを表示(_T)"
+
+#, fuzzy
+#~ msgid "Color:"
+#~ msgstr "背景色:"
+
+#, fuzzy
+#~ msgid "Outline Color:"
+#~ msgstr "色を選択"
+
+#, fuzzy
+#~ msgid "_Show stats"
+#~ msgstr "状態を表示"
+
+#, fuzzy
+#~ msgid "Translated:"
+#~ msgstr "translator_credits"
+
+#, fuzzy
+#~ msgid "Untranslated:"
+#~ msgstr "translator_credits"
+
+#~ msgid "Toggle Check While Typing"
+#~ msgstr "入力中のチェックを有効/無効"
+
+#~ msgid "Check spelling while typing"
+#~ msgstr "入力中にスペルチェックを行う"
+
+#, fuzzy, c-format
+#~ msgid "%s: %u Project"
+#~ msgid_plural "%s: %u Projects"
+#~ msgstr[0] "プロジェクト"
 
 #~ msgid "GeanyLaTeX"
 #~ msgstr "GeanyLaTeX"

--- a/po/kk.po
+++ b/po/kk.po
@@ -6,8 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Geany-Plugins 1.30\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-29 19:41+0200\n"
+"Report-Msgid-Bugs-To: https://github.com/geany/geany/issues\n"
+"POT-Creation-Date: 2022-06-28 07:39+0200\n"
 "PO-Revision-Date: 2016-10-31 09:17+0500\n"
 "Last-Translator: Baurzhan Muftakhidinov <baurthefirst@gmail.com>\n"
 "Language-Team: Kazakh <kk_KZ@googlegroups.com>\n"
@@ -22,27 +22,27 @@ msgstr ""
 msgid "(Empty Line)"
 msgstr "(Бос жол)"
 
-#: ../addons/src/ao_bookmarklist.c:315
+#: ../addons/src/ao_bookmarklist.c:331
 msgid "_Remove Bookmark"
 msgstr "Бетбелгіні ө_шіру"
 
 #. Translators: Number is meant at this point.
-#: ../addons/src/ao_bookmarklist.c:342
+#: ../addons/src/ao_bookmarklist.c:358
 msgid "No."
 msgstr "Жоқ."
 
-#: ../addons/src/ao_bookmarklist.c:350 ../devhelp/src/dhp-object.c:494
+#: ../addons/src/ao_bookmarklist.c:366 ../devhelp/src/dhp-object.c:494
 #: ../devhelp/devhelp/dh-window.c:1142
 msgid "Contents"
 msgstr "Құрамасы"
 
-#: ../addons/src/ao_bookmarklist.c:383 ../treebrowser/src/treebrowser.c:666
+#: ../addons/src/ao_bookmarklist.c:399 ../treebrowser/src/treebrowser.c:666
 #: ../webhelper/src/gwh-plugin.c:328
 msgid "Bookmarks"
 msgstr "Бетбелгілер"
 
 #. complete update
-#: ../addons/src/ao_tasks.c:373 ../geanyvc/src/geanyvc.c:2679
+#: ../addons/src/ao_tasks.c:373 ../geanyvc/src/geanyvc.c:2730
 msgid "_Update"
 msgstr "_Жаңарту"
 
@@ -162,10 +162,10 @@ msgstr ""
 #: ../addons/src/addons.c:364 ../autoclose/src/autoclose.c:920
 #: ../codenav/src/codenavigation.c:281 ../latex/src/latex.c:208
 #: ../latex/src/latex.c:293 ../geanyprj/src/geanyprj.c:176
-#: ../geanyvc/src/geanyvc.c:2079 ../geniuspaste/src/geniuspaste.c:336
+#: ../geanyvc/src/geanyvc.c:2130 ../geniuspaste/src/geniuspaste.c:336
 #: ../lineoperations/src/lo_prefs.c:58 ../sendmail/src/sendmail.c:128
 #: ../sendmail/src/sendmail.c:293 ../spellcheck/src/scplugin.c:124
-#: ../treebrowser/src/treebrowser.c:2102
+#: ../treebrowser/src/treebrowser.c:2106
 #: ../updatechecker/src/updatechecker.c:262
 msgid "Plugin configuration directory could not be created."
 msgstr "Плагиннің баптаулар бумасын жасау мүмкін емес."
@@ -704,7 +704,7 @@ msgstr ""
 msgid "Error loading file"
 msgstr ""
 
-#. setting asyncronous mode
+#. setting asynchronous mode
 #. setting null-stop array printing
 #. enable pretty printing
 #: ../debugger/src/dbm_gdb.c:789 ../debugger/src/dbm_gdb.c:792
@@ -1094,7 +1094,7 @@ msgid "A developers' help browser for GNOME"
 msgstr ""
 
 #. Create the current file Submenu
-#: ../devhelp/devhelp/dh-window.c:759 ../geanyvc/src/geanyvc.c:2660
+#: ../devhelp/devhelp/dh-window.c:759 ../geanyvc/src/geanyvc.c:2711
 msgid "_File"
 msgstr "_Файл"
 
@@ -1128,11 +1128,11 @@ msgstr "Жаңа _бет"
 msgid "_Print…"
 msgstr "Бас_паға шығару…"
 
-#: ../devhelp/devhelp/dh-window.c:782 ../devhelp/devhelp/eggfindbar.c:342
+#: ../devhelp/devhelp/dh-window.c:782
 msgid "Find Next"
 msgstr "Келесісін табу"
 
-#: ../devhelp/devhelp/dh-window.c:784 ../devhelp/devhelp/eggfindbar.c:329
+#: ../devhelp/devhelp/dh-window.c:784
 msgid "Find Previous"
 msgstr "Алдыңғысын табу"
 
@@ -1317,7 +1317,7 @@ msgid ""
 "contributing to this plugin?"
 msgstr ""
 
-#: ../geanydoc/src/geanydoc.c:159 ../geanyvc/src/geanyvc.c:442
+#: ../geanydoc/src/geanydoc.c:159 ../geanyvc/src/geanyvc.c:448
 msgid "Could not parse the output of command"
 msgstr ""
 
@@ -2961,14 +2961,14 @@ msgid ""
 "not enough arguments for command \"%s\".\n"
 msgstr ""
 
-#: ../geanylua/glspi_sci.c:637 ../geanylua/glspi_app.c:406
+#: ../geanylua/glspi_sci.c:729 ../geanylua/glspi_app.c:406
 #, c-format
 msgid ""
 "Error in module \"%s\" at function %s():\n"
 "unknown command \"%s\" given for argument #1.\n"
 msgstr ""
 
-#: ../geanylua/glspi_sci.c:781
+#: ../geanylua/glspi_sci.c:924
 #, c-format
 msgid ""
 "Error in module \"%s\" at function %s():\n"
@@ -2976,7 +2976,7 @@ msgid ""
 " unknown flag \"%s\" for element #%d\n"
 msgstr ""
 
-#: ../geanylua/glspi_sci.c:785
+#: ../geanylua/glspi_sci.c:928
 msgid "<too large to display>"
 msgstr ""
 
@@ -3697,7 +3697,7 @@ msgid "New _Below"
 msgstr ""
 
 #: ../geanymacro/src/geanymacro.c:1824 ../geanymacro/src/geanymacro.c:2120
-#: ../treebrowser/src/treebrowser.c:1338 ../treebrowser/src/treebrowser.c:1340
+#: ../treebrowser/src/treebrowser.c:1342 ../treebrowser/src/treebrowser.c:1344
 msgid "_Delete"
 msgstr "Ө_шіру"
 
@@ -4060,8 +4060,8 @@ msgstr ""
 msgid "a key with fingerprint"
 msgstr ""
 
-#: ../geanypg/src/verify_aux.c:66 ../spellcheck/src/gui.c:610
-#: ../spellcheck/src/gui.c:621
+#: ../geanypg/src/verify_aux.c:66 ../spellcheck/src/gui.c:607
+#: ../spellcheck/src/gui.c:618
 msgid "unknown"
 msgstr "белгісіз"
 
@@ -4352,49 +4352,49 @@ msgid ""
 "contributing to this plugin?"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:501
+#: ../geanyvc/src/geanyvc.c:507
 #, c-format
 msgid "geanyvc: s_spawn_sync error: %s"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:587
+#: ../geanyvc/src/geanyvc.c:593
 #, c-format
 msgid "File %s: action %s executed via %s."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:646 ../geanyvc/src/geanyvc.c:657
+#: ../geanyvc/src/geanyvc.c:633 ../geanyvc/src/geanyvc.c:643
 #, c-format
-msgid "geanyvc: vcdiff_file_activated: Unable to rename '%s' to '%s'"
+msgid "geanyvc: diff_external: Unable to rename '%s' to '%s'"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:683 ../geanyvc/src/geanyvc.c:733
+#: ../geanyvc/src/geanyvc.c:698 ../geanyvc/src/geanyvc.c:784
 msgid "No changes were made."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:760
+#: ../geanyvc/src/geanyvc.c:811
 msgid "No history available"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:953 ../geanyvc/src/geanyvc.c:961
+#: ../geanyvc/src/geanyvc.c:1004 ../geanyvc/src/geanyvc.c:1012
 #, c-format
 msgid "Do you really want to revert: %s?"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:969
+#: ../geanyvc/src/geanyvc.c:1020
 #, c-format
 msgid "Do you really want to add: %s?"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:976
+#: ../geanyvc/src/geanyvc.c:1027
 #, c-format
 msgid "Do you really want to remove: %s?"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:999
+#: ../geanyvc/src/geanyvc.c:1050
 msgid "Do you really want to update?"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1126
+#: ../geanyvc/src/geanyvc.c:1177
 msgid ""
 "The resulting differences cannot be displayed because the changes are too "
 "big to display here and would slow down the UI significantly.\n"
@@ -4403,327 +4403,327 @@ msgid ""
 "Geany directly by using the GeanyVC menu (Base Directory -> Diff)."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1280
+#: ../geanyvc/src/geanyvc.c:1331
 msgid "Commit Y/N"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1290
+#: ../geanyvc/src/geanyvc.c:1341
 msgid "Status"
 msgstr "Күйі"
 
-#: ../geanyvc/src/geanyvc.c:1297
+#: ../geanyvc/src/geanyvc.c:1348
 msgid "Path"
 msgstr "Жолы"
 
-#: ../geanyvc/src/geanyvc.c:1414
+#: ../geanyvc/src/geanyvc.c:1465
 msgid "Choose a previous commit message"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1476
+#: ../geanyvc/src/geanyvc.c:1527
 #, c-format
 msgid "Line: %d Column: %d"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1523
+#: ../geanyvc/src/geanyvc.c:1574
 msgid "Commit"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1564
+#: ../geanyvc/src/geanyvc.c:1615
 msgid "_De-/select all files"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1608
+#: ../geanyvc/src/geanyvc.c:1659
 msgid "<b>Commit message:</b>"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1632
+#: ../geanyvc/src/geanyvc.c:1683
 msgid "C_ommit"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1740
+#: ../geanyvc/src/geanyvc.c:1791
 msgid "Nothing to commit."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1788
+#: ../geanyvc/src/geanyvc.c:1839
 #, c-format
 msgid ""
 "Error initializing GeanyVC spell checking: %s. Check your configuration."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1823
+#: ../geanyvc/src/geanyvc.c:1874
 #, c-format
 msgid "Commit failed (status: %d, error: %s)."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1824
+#: ../geanyvc/src/geanyvc.c:1875
 msgid "Commit failed; see status in the Message window."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1829
+#: ../geanyvc/src/geanyvc.c:1880
 msgid "Changes committed."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2151
+#: ../geanyvc/src/geanyvc.c:2202
 msgid "Set Changed-flag for document tabs created by the plugin"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2154
+#: ../geanyvc/src/geanyvc.c:2205
 msgid ""
 "If this option is activated, every new by the VC-plugin created document tab "
 "will be marked as changed. Even this option is useful in some cases, it "
 "could cause a big number of annoying \"Do you want to save\"-dialogs."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2162
+#: ../geanyvc/src/geanyvc.c:2213
 msgid "Confirm adding new files to a VCS"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2165
+#: ../geanyvc/src/geanyvc.c:2216
 msgid "Shows a confirmation dialog on adding a new (created) file to VCS."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2171
+#: ../geanyvc/src/geanyvc.c:2222
 msgid "Maximize commit dialog"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2172
+#: ../geanyvc/src/geanyvc.c:2223
 msgid "Show commit dialog maximize."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2178
+#: ../geanyvc/src/geanyvc.c:2229
 msgid "Use external diff viewer"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2180
+#: ../geanyvc/src/geanyvc.c:2231
 msgid "Use external diff viewer for file diff."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2186
+#: ../geanyvc/src/geanyvc.c:2237
 msgid "Show VC entries at editor menu"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2188
+#: ../geanyvc/src/geanyvc.c:2239
 msgid "Show entries for VC functions inside editor menu"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2193
+#: ../geanyvc/src/geanyvc.c:2244
 msgid "Attach menu to menubar"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2195
+#: ../geanyvc/src/geanyvc.c:2246
 msgid ""
 "Whether menu for this plugin are getting placed either inside tools menu or "
 "directly inside Geany's menubar. Will take in account after next start of "
 "GeanyVC"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2203
+#: ../geanyvc/src/geanyvc.c:2254
 msgid "Enable CVS"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2208
+#: ../geanyvc/src/geanyvc.c:2259
 msgid "Enable GIT"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2213
+#: ../geanyvc/src/geanyvc.c:2264
 msgid "Enable Fossil"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2218
+#: ../geanyvc/src/geanyvc.c:2269
 msgid "Enable SVN"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2223
+#: ../geanyvc/src/geanyvc.c:2274
 msgid "Enable SVK"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2228
+#: ../geanyvc/src/geanyvc.c:2279
 msgid "Enable Bazaar"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2233
+#: ../geanyvc/src/geanyvc.c:2284
 msgid "Enable Mercurial"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2239
+#: ../geanyvc/src/geanyvc.c:2290
 msgid "Spellcheck language"
 msgstr ""
 
 #. Diff of current file
 #. Diff of the current dir
 #. Complete diff of base directory
-#: ../geanyvc/src/geanyvc.c:2368 ../geanyvc/src/geanyvc.c:2463
-#: ../geanyvc/src/geanyvc.c:2503
+#: ../geanyvc/src/geanyvc.c:2419 ../geanyvc/src/geanyvc.c:2514
+#: ../geanyvc/src/geanyvc.c:2554
 msgid "_Diff"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2371
+#: ../geanyvc/src/geanyvc.c:2422
 msgid "Make a diff from the current active file"
 msgstr ""
 
 #. Revert current file
 #. Revert current dir
 #. Revert everything
-#: ../geanyvc/src/geanyvc.c:2376 ../geanyvc/src/geanyvc.c:2472
-#: ../geanyvc/src/geanyvc.c:2511
+#: ../geanyvc/src/geanyvc.c:2427 ../geanyvc/src/geanyvc.c:2523
+#: ../geanyvc/src/geanyvc.c:2562
 msgid "_Revert"
 msgstr "Қай_тару"
 
-#: ../geanyvc/src/geanyvc.c:2379
+#: ../geanyvc/src/geanyvc.c:2430
 msgid "Restore pristine working copy file (undo local edits)."
 msgstr ""
 
 #. Blame for current file
-#: ../geanyvc/src/geanyvc.c:2388
+#: ../geanyvc/src/geanyvc.c:2439
 msgid "_Blame"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2391
+#: ../geanyvc/src/geanyvc.c:2442
 msgid "Shows the changes made at one file per revision and author."
 msgstr ""
 
 #. History/log of current file
 #. History/log of the current dir
 #. Complete History/Log of base directory
-#: ../geanyvc/src/geanyvc.c:2398 ../geanyvc/src/geanyvc.c:2482
-#: ../geanyvc/src/geanyvc.c:2523
+#: ../geanyvc/src/geanyvc.c:2449 ../geanyvc/src/geanyvc.c:2533
+#: ../geanyvc/src/geanyvc.c:2574
 msgid "_History (log)"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2401
+#: ../geanyvc/src/geanyvc.c:2452
 msgid "Shows the log of the current file"
 msgstr ""
 
 #. base version of the current file
-#: ../geanyvc/src/geanyvc.c:2406
+#: ../geanyvc/src/geanyvc.c:2457
 msgid "_Original"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2409
+#: ../geanyvc/src/geanyvc.c:2460
 msgid "Shows the original of the current file"
 msgstr ""
 
 #. add current file
-#: ../geanyvc/src/geanyvc.c:2417
+#: ../geanyvc/src/geanyvc.c:2468
 msgid "_Add to Version Control"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2419
+#: ../geanyvc/src/geanyvc.c:2470
 msgid "Add file to repository."
 msgstr ""
 
 #. remove current file
-#: ../geanyvc/src/geanyvc.c:2425
+#: ../geanyvc/src/geanyvc.c:2476
 msgid "_Remove from Version Control"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2427
+#: ../geanyvc/src/geanyvc.c:2478
 msgid "Remove file from repository."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2460
+#: ../geanyvc/src/geanyvc.c:2511
 msgid "_Directory"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2466
+#: ../geanyvc/src/geanyvc.c:2517
 msgid "Make a diff from the directory of the current active file"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2475
+#: ../geanyvc/src/geanyvc.c:2526
 msgid "Restore original files in the current folder (undo local edits)."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2485
+#: ../geanyvc/src/geanyvc.c:2536
 msgid "Shows the log of the current directory"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2499
+#: ../geanyvc/src/geanyvc.c:2550
 msgid "_Base Directory"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2505
+#: ../geanyvc/src/geanyvc.c:2556
 msgid "Make a diff from the top VC directory"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2513
+#: ../geanyvc/src/geanyvc.c:2564
 msgid "Revert any local edits."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2526
+#: ../geanyvc/src/geanyvc.c:2577
 msgid "Shows the log of the top VC directory"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2543
+#: ../geanyvc/src/geanyvc.c:2594
 msgid "_VC file Actions"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2552
+#: ../geanyvc/src/geanyvc.c:2603
 msgid "VC _Commit..."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2596
+#: ../geanyvc/src/geanyvc.c:2647
 msgid "Show diff of file"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2598
+#: ../geanyvc/src/geanyvc.c:2649
 msgid "Show diff of directory"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2600
+#: ../geanyvc/src/geanyvc.c:2651
 msgid "Show diff of basedir"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2603
+#: ../geanyvc/src/geanyvc.c:2654
 msgid "Commit changes"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2605
+#: ../geanyvc/src/geanyvc.c:2656
 msgid "Show status"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2607
+#: ../geanyvc/src/geanyvc.c:2658
 msgid "Revert single file"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2609
+#: ../geanyvc/src/geanyvc.c:2660
 msgid "Revert directory"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2611
+#: ../geanyvc/src/geanyvc.c:2662
 msgid "Revert base directory"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2613
+#: ../geanyvc/src/geanyvc.c:2664
 msgid "Update file"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2643
+#: ../geanyvc/src/geanyvc.c:2694
 msgid "_VC"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2650
+#: ../geanyvc/src/geanyvc.c:2701
 msgid "_Version Control"
 msgstr ""
 
 #. Status of basedir
-#: ../geanyvc/src/geanyvc.c:2672
+#: ../geanyvc/src/geanyvc.c:2723
 msgid "_Status"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2674
+#: ../geanyvc/src/geanyvc.c:2725
 msgid "Show status."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2681
+#: ../geanyvc/src/geanyvc.c:2732
 msgid "Update from remote repository."
 msgstr ""
 
 #. Commit all changes
-#: ../geanyvc/src/geanyvc.c:2686
+#: ../geanyvc/src/geanyvc.c:2737
 msgid "_Commit..."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2688
+#: ../geanyvc/src/geanyvc.c:2739
 msgid "Commit changes."
 msgstr ""
 
@@ -4834,33 +4834,6 @@ msgstr ""
 #: ../geniuspaste/src/geniuspaste.c:959
 msgid "_Paste it!"
 msgstr ""
-
-#: ../git-changebar/data/prefs.ui.h:1
-msgid "_Monitor repository for changes"
-msgstr ""
-
-#: ../git-changebar/data/prefs.ui.h:2
-msgid ""
-"Whether to automatically update the diff in order to maintain it up to date "
-"when the underlying Git repository changes.  This should generally be "
-"enabled for optimal user experience."
-msgstr ""
-
-#: ../git-changebar/data/prefs.ui.h:3
-msgid "_Added lines:"
-msgstr ""
-
-#: ../git-changebar/data/prefs.ui.h:4
-msgid "_Changed lines:"
-msgstr ""
-
-#: ../git-changebar/data/prefs.ui.h:5
-msgid "_Removed lines:"
-msgstr ""
-
-#: ../git-changebar/data/prefs.ui.h:6
-msgid "Colors"
-msgstr "Түстер"
 
 #: ../git-changebar/src/gcb-plugin.c:62
 msgid "Git Change Bar"
@@ -5041,8 +5014,8 @@ msgstr ""
 #: ../lipsum/src/lipsum.c:184 ../sendmail/src/sendmail.c:396
 #, c-format
 msgid ""
-"Your configuration directory has been successfully moved from \"%s\" to \"%s"
-"\"."
+"Your configuration directory has been successfully moved from \"%s\" to "
+"\"%s\"."
 msgstr ""
 
 #: ../lipsum/src/lipsum.c:199
@@ -5206,7 +5179,7 @@ msgstr ""
 msgid "Unable to read value for '%s' key: %s"
 msgstr ""
 
-#: ../multiterm/src/tab-label.vala:62 ../treebrowser/src/treebrowser.c:2132
+#: ../multiterm/src/tab-label.vala:62 ../treebrowser/src/treebrowser.c:2137
 msgid "Terminal"
 msgstr "Терминал"
 
@@ -5244,112 +5217,6 @@ msgstr ""
 msgid "Show Overview"
 msgstr ""
 
-#: ../overview/data/prefs.ui.h:1
-msgid ""
-"The amount to zoom the overview sidebar. This should probably negative if "
-"you want the sidebar zoomed out."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:2
-msgid "Zoom Level:"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:3
-msgid "The width of the overview sidebar."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:4
-msgid "Width:"
-msgstr "Ені:"
-
-#: ../overview/data/prefs.ui.h:5
-msgid ""
-"The number of lines to scroll at a time when scrolling the overview sidebar."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:6
-msgid "Scroll Lines:"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:7
-msgid "Position on left"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:8
-msgid ""
-"Position the overview bar on the left rather than the right (requires Geany "
-"1.25 or greater)."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:9
-msgid "Hide tooltip"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:10
-msgid ""
-"Hide the tooltip that is displayed when mousing over the overview that shows "
-"line, column and position information."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:11
-msgid "Hide editor scrollbar"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:12
-msgid ""
-"Whether to hide Geany's regular editor scrollbar while the overview bar is "
-"visible."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:13
-msgid "Disable overlay"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:14
-msgid ""
-"Turn off drawing overlay, which shows the region of the main editor view "
-"that is currently in view, ontop of the overview bar."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:15 ../scope/data/scope.glade.h:130
-#: ../scope/data/scope_gtk3.glade.h:130
-msgid "Options"
-msgstr "Опциялар"
-
-#: ../overview/data/prefs.ui.h:16
-msgid ""
-"The color and opacity of the overlay drawn ontop of the overlay sidebar."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:17
-msgid "Color:"
-msgstr "Түс:"
-
-#: ../overview/data/prefs.ui.h:18
-msgid ""
-"The color and opacity of the border drawn around the revealed area in the "
-"overview sidebar. Set to the same as Overlay Color to disable."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:19
-msgid "Outline Color:"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:20
-msgid "Draw over visible area"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:21
-msgid ""
-"When checked it will draw the overlay ontop of the area that is visible in "
-"the main editor view, when unchecked, it will do the opposite and draw the "
-"overlay everywhere but the visible area, \"revealing\" the visible part."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:22
-msgid "Overlay"
-msgstr ""
-
 #: ../pairtaghighlighter/src/pair_tag_highlighter.c:43
 msgid "Pair Tag Highlighter"
 msgstr ""
@@ -5373,144 +5240,6 @@ msgstr ""
 #: ../pairtaghighlighter/src/pair_tag_highlighter.c:504
 msgid "Select To Matching Tag"
 msgstr ""
-
-#: ../pohelper/data/menus.ui.h:1
-msgid "_Translation Helper"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:2
-msgid "_Previous String"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:3 ../pohelper/src/gph-plugin.c:1590
-msgid "Go to previous string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:4
-msgid "_Next String"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:5 ../pohelper/src/gph-plugin.c:1593
-msgid "Go to next string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:6
-msgid "Pre_vious Untranslated"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:7 ../pohelper/src/gph-plugin.c:1596
-msgid "Go to previous untranslated string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:8
-msgid "Next _Untranslated"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:9 ../pohelper/src/gph-plugin.c:1599
-msgid "Go to next untranslated string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:10
-msgid "Previous Fu_zzy"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:11 ../pohelper/src/gph-plugin.c:1602
-msgid "Go to previous fuzzily translated string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:12
-msgid "Next _Fuzzy"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:13 ../pohelper/src/gph-plugin.c:1605
-msgid "Go to next fuzzily translated string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:14
-msgid "Previous Untranslated or Fuzz_y"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:15 ../pohelper/src/gph-plugin.c:1608
-msgid "Go to previous untranslated or fuzzy string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:16
-msgid "Next Untranslated _or Fuzzy"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:17 ../pohelper/src/gph-plugin.c:1612
-msgid "Go to next untranslated or fuzzy string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:18 ../pohelper/src/gph-plugin.c:1623
-msgid "Toggle current translation fuzziness"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:19
-msgid "_Toggle Fuzziness"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:20
-msgid "Paste _Message as Translation"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:21
-msgid "Paste the original untranslated string to the translation"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:22 ../pohelper/src/gph-plugin.c:1620
-msgid "Reflow the current translation string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:23
-msgid "_Reflow Translation"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:24 ../pohelper/src/gph-plugin.c:1626
-msgid "Show statistics of the current document"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:25
-msgid "_Show stats"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:26
-msgid ""
-"Whether to update the translation headers (author, revision date, ...) upon "
-"file save"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:27
-msgid "Update _Headers Upon Save"
-msgstr ""
-
-#: ../pohelper/data/stats.ui.h:1
-msgid "Translation statistics"
-msgstr ""
-
-#: ../pohelper/data/stats.ui.h:2
-msgid "Choose a color for translated strings"
-msgstr ""
-
-#: ../pohelper/data/stats.ui.h:3
-msgid "Choose a color for fuzzily translated strings"
-msgstr ""
-
-#: ../pohelper/data/stats.ui.h:4
-msgid "Choose a color for untranslated strings"
-msgstr ""
-
-#: ../pohelper/data/stats.ui.h:5
-msgid "Translated:"
-msgstr "Аударылған:"
-
-#: ../pohelper/data/stats.ui.h:6
-msgid "Fuzzy:"
-msgstr "Дәлсіз:"
-
-#: ../pohelper/data/stats.ui.h:7
-msgid "Untranslated:"
-msgstr "Аударылмаған:"
 
 #: ../pohelper/src/gph-plugin.c:40
 msgid "Translation Helper"
@@ -5540,8 +5269,52 @@ msgstr "<b>Аударылмаған:</b> %.3g%%"
 msgid "%u (%.3g%%)"
 msgstr "%u (%.3g%%)"
 
+#: ../pohelper/src/gph-plugin.c:1590
+msgid "Go to previous string"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1593
+msgid "Go to next string"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1596
+msgid "Go to previous untranslated string"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1599
+msgid "Go to next untranslated string"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1602
+msgid "Go to previous fuzzily translated string"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1605
+msgid "Go to next fuzzily translated string"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1608
+msgid "Go to previous untranslated or fuzzy string"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1612
+msgid "Go to next untranslated or fuzzy string"
+msgstr ""
+
 #: ../pohelper/src/gph-plugin.c:1616
 msgid "Paste original untranslated string to translation"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1620
+msgid "Reflow the current translation string"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1623
+msgid "Toggle current translation fuzziness"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1626
+msgid "Show statistics of the current document"
 msgstr ""
 
 #: ../pohelper/src/gph-plugin.c:1833
@@ -5802,7 +5575,7 @@ msgid "Add"
 msgstr "Қосу"
 
 #: ../projectorganizer/src/prjorg-sidebar.c:390
-#: ../treebrowser/src/treebrowser.c:2356
+#: ../treebrowser/src/treebrowser.c:2361
 #, fuzzy
 msgid "New File"
 msgstr "Жаңа файлды жасау"
@@ -6425,6 +6198,10 @@ msgstr ""
 msgid "<b>Others</b>"
 msgstr ""
 
+#: ../scope/data/scope.glade.h:130 ../scope/data/scope_gtk3.glade.h:130
+msgid "Options"
+msgstr "Опциялар"
+
 #: ../scope/data/scope.glade.h:131 ../scope/data/scope_gtk3.glade.h:131
 msgid "_Import"
 msgstr "И_мпорттау"
@@ -6979,11 +6756,11 @@ msgid "Checks the spelling of the current document."
 msgstr "Ағымдағы құжаттың емлесін тексереді."
 
 #: ../spellcheck/src/scplugin.c:225
-msgid "Run Spell Check"
+msgid "Run spell check once"
 msgstr ""
 
-#: ../spellcheck/src/scplugin.c:228
-msgid "Toggle Check While Typing"
+#: ../spellcheck/src/scplugin.c:228 ../spellcheck/src/scplugin.c:333
+msgid "Toggle spell check"
 msgstr ""
 
 #. initialise the dialog
@@ -7009,10 +6786,6 @@ msgstr ""
 
 #: ../spellcheck/src/scplugin.c:325
 msgid "<b>Interface</b>"
-msgstr ""
-
-#: ../spellcheck/src/scplugin.c:333
-msgid "Check spelling while typing"
 msgstr ""
 
 #: ../spellcheck/src/scplugin.c:336
@@ -7045,52 +6818,52 @@ msgstr ""
 msgid "<b>Behavior</b>"
 msgstr ""
 
-#: ../spellcheck/src/gui.c:76
+#: ../spellcheck/src/gui.c:88
 msgid "Spell checking while typing is now enabled"
 msgstr ""
 
-#: ../spellcheck/src/gui.c:78
+#: ../spellcheck/src/gui.c:90
 msgid "Spell checking while typing is now disabled"
 msgstr ""
 
-#: ../spellcheck/src/gui.c:326
+#: ../spellcheck/src/gui.c:323
 msgid "More..."
 msgstr "Қосымша..."
 
-#: ../spellcheck/src/gui.c:347
+#: ../spellcheck/src/gui.c:344
 msgid "(No Suggestions)"
 msgstr ""
 
-#: ../spellcheck/src/gui.c:360
+#: ../spellcheck/src/gui.c:357
 #, c-format
 msgid "Add \"%s\" to Dictionary"
 msgstr ""
 
-#: ../spellcheck/src/gui.c:368
+#: ../spellcheck/src/gui.c:365
 msgid "Ignore All"
 msgstr "Барлығын елемеу"
 
-#: ../spellcheck/src/gui.c:441
+#: ../spellcheck/src/gui.c:438
 msgid ""
 "Search term is too long to provide\n"
 "spelling suggestions in the editor menu."
 msgstr ""
 
-#: ../spellcheck/src/gui.c:447
+#: ../spellcheck/src/gui.c:444
 msgid "Perform Spell Check"
 msgstr ""
 
-#: ../spellcheck/src/gui.c:609
+#: ../spellcheck/src/gui.c:606
 #, c-format
 msgid "Default (%s)"
 msgstr ""
 
-#: ../spellcheck/src/gui.c:620
+#: ../spellcheck/src/gui.c:617
 #, c-format
-msgid "Toggle spell check while typing (current language: %s)"
+msgid "Toggle spell check (current language: %s)"
 msgstr ""
 
-#: ../spellcheck/src/gui.c:698
+#: ../spellcheck/src/gui.c:695
 msgid "Spelling Suggestions"
 msgstr ""
 
@@ -7183,162 +6956,162 @@ msgstr "(Бос)"
 msgid "Could not execute configured external command '%s' (%s)."
 msgstr "Бапталған '%s' сыртқы командасын орындау мүмкін емес (%s)."
 
-#: ../treebrowser/src/treebrowser.c:1089
+#: ../treebrowser/src/treebrowser.c:1093
 msgid "NewDirectory"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1091
+#: ../treebrowser/src/treebrowser.c:1095
 msgid "NewFile"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1096
+#: ../treebrowser/src/treebrowser.c:1100
 #, c-format
 msgid ""
 "Target file '%s' exists.\n"
 "Do you really want to replace it with an empty file?"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1142
+#: ../treebrowser/src/treebrowser.c:1146
 #, c-format
 msgid "Do you really want to delete '%s' ?"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1255 ../treebrowser/src/treebrowser.c:1257
+#: ../treebrowser/src/treebrowser.c:1259 ../treebrowser/src/treebrowser.c:1261
 #, fuzzy
 msgid "Go _Up"
 msgstr "Ж_оғары апару"
 
-#: ../treebrowser/src/treebrowser.c:1263 ../treebrowser/src/treebrowser.c:1265
+#: ../treebrowser/src/treebrowser.c:1267 ../treebrowser/src/treebrowser.c:1269
 #, fuzzy
 msgid "Set _Path From Document"
 msgstr "Орналасу жолын құжаттан орнату"
 
-#: ../treebrowser/src/treebrowser.c:1271 ../treebrowser/src/treebrowser.c:1273
+#: ../treebrowser/src/treebrowser.c:1275 ../treebrowser/src/treebrowser.c:1277
 #, fuzzy
 msgid "_Open Externally"
 msgstr "Терминал"
 
-#: ../treebrowser/src/treebrowser.c:1279
+#: ../treebrowser/src/treebrowser.c:1283
 #, fuzzy
 msgid "Open _Terminal"
 msgstr "Терминал"
 
-#: ../treebrowser/src/treebrowser.c:1284 ../treebrowser/src/treebrowser.c:1286
+#: ../treebrowser/src/treebrowser.c:1288 ../treebrowser/src/treebrowser.c:1290
 msgid "Set as _Root"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1293 ../treebrowser/src/treebrowser.c:1295
+#: ../treebrowser/src/treebrowser.c:1297 ../treebrowser/src/treebrowser.c:1299
 #, fuzzy
 msgid "Refres_h"
 msgstr "Жаңарту"
 
-#: ../treebrowser/src/treebrowser.c:1301 ../treebrowser/src/treebrowser.c:1303
+#: ../treebrowser/src/treebrowser.c:1305 ../treebrowser/src/treebrowser.c:1307
 msgid "_Find in Files"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1313 ../treebrowser/src/treebrowser.c:1315
+#: ../treebrowser/src/treebrowser.c:1317 ../treebrowser/src/treebrowser.c:1319
 #, fuzzy
 msgid "N_ew Folder"
 msgstr "Буманы таңдау"
 
-#: ../treebrowser/src/treebrowser.c:1321 ../treebrowser/src/treebrowser.c:1323
+#: ../treebrowser/src/treebrowser.c:1325 ../treebrowser/src/treebrowser.c:1327
 #, fuzzy
 msgid "_New File"
 msgstr "_Файл"
 
-#: ../treebrowser/src/treebrowser.c:1329 ../treebrowser/src/treebrowser.c:1331
+#: ../treebrowser/src/treebrowser.c:1333 ../treebrowser/src/treebrowser.c:1335
 #, fuzzy
 msgid "Rena_me"
 msgstr "Атын өзгерту"
 
-#: ../treebrowser/src/treebrowser.c:1350 ../treebrowser/src/treebrowser.c:1352
+#: ../treebrowser/src/treebrowser.c:1354 ../treebrowser/src/treebrowser.c:1356
 #, c-format
 msgid "Close: %s"
 msgstr "Жабу: %s"
 
-#: ../treebrowser/src/treebrowser.c:1359 ../treebrowser/src/treebrowser.c:1361
+#: ../treebrowser/src/treebrowser.c:1363 ../treebrowser/src/treebrowser.c:1365
 #, fuzzy, c-format
 msgid "Clo_se Child Documents "
 msgstr "Б_асқа құжаттарды жабу"
 
-#: ../treebrowser/src/treebrowser.c:1368 ../treebrowser/src/treebrowser.c:1370
+#: ../treebrowser/src/treebrowser.c:1372 ../treebrowser/src/treebrowser.c:1374
 msgid "_Copy Full Path to Clipboard"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1381 ../treebrowser/src/treebrowser.c:1383
+#: ../treebrowser/src/treebrowser.c:1385 ../treebrowser/src/treebrowser.c:1387
 #, fuzzy
 msgid "E_xpand All"
 msgstr "Жазық қылу"
 
-#: ../treebrowser/src/treebrowser.c:1389 ../treebrowser/src/treebrowser.c:1391
+#: ../treebrowser/src/treebrowser.c:1393 ../treebrowser/src/treebrowser.c:1395
 #, fuzzy
 msgid "Coll_apse All"
 msgstr "Бар_лығын жабу"
 
-#: ../treebrowser/src/treebrowser.c:1399
+#: ../treebrowser/src/treebrowser.c:1403
 #, fuzzy
 msgid "Show Boo_kmarks"
 msgstr "Бетбелгілер"
 
-#: ../treebrowser/src/treebrowser.c:1404
+#: ../treebrowser/src/treebrowser.c:1408
 #, fuzzy
 msgid "Sho_w Hidden Files"
 msgstr "Жасырын файлдарды көрсету"
 
-#: ../treebrowser/src/treebrowser.c:1409
+#: ../treebrowser/src/treebrowser.c:1413
 #, fuzzy
 msgid "Show Tool_bars"
 msgstr "Беттерді көрсету"
 
-#: ../treebrowser/src/treebrowser.c:1747
+#: ../treebrowser/src/treebrowser.c:1751
 #, c-format
 msgid "Target file '%s' exists, do you really want to replace it?"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1883
+#: ../treebrowser/src/treebrowser.c:1887
 msgid "Go up"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1893 ../treebrowser/src/treebrowser.c:2360
+#: ../treebrowser/src/treebrowser.c:1897 ../treebrowser/src/treebrowser.c:2365
 msgid "Refresh"
 msgstr "Жаңарту"
 
-#: ../treebrowser/src/treebrowser.c:1903
+#: ../treebrowser/src/treebrowser.c:1907
 msgid "Home"
 msgstr "Үй"
 
-#: ../treebrowser/src/treebrowser.c:1913
+#: ../treebrowser/src/treebrowser.c:1917
 msgid "Set path from document"
 msgstr "Орналасу жолын құжаттан орнату"
 
-#: ../treebrowser/src/treebrowser.c:1923
+#: ../treebrowser/src/treebrowser.c:1927
 msgid "Track path"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1933
+#: ../treebrowser/src/treebrowser.c:1937
 msgid "Hide bars"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1943
+#: ../treebrowser/src/treebrowser.c:1947
 msgid ""
 "Filter (*.c;*.h;*.cpp), and if you want temporary filter using the '!' "
 "reverse try for example this '!;*.c;*.h;*.cpp'"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1948
+#: ../treebrowser/src/treebrowser.c:1952
 msgid "Addressbar for example '/projects/my-project'"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1973
+#: ../treebrowser/src/treebrowser.c:1977
 msgid "Tree Browser"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2114
+#: ../treebrowser/src/treebrowser.c:2118
 msgid "External open command"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2124
-#, c-format
+#: ../treebrowser/src/treebrowser.c:2129
+#, no-c-format
 msgid ""
 "The command to execute when using \"Open with\". You can use %f and %d "
 "wildcards.\n"
@@ -7352,118 +7125,118 @@ msgstr ""
 "%d таңдалған файлдың толық орналасу жолымен, сол файлдың атауына дейін, "
 "алмастырылады"
 
-#: ../treebrowser/src/treebrowser.c:2143
+#: ../treebrowser/src/treebrowser.c:2148
 msgid "The terminal to use with the command \"Open Terminal\""
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2149
+#: ../treebrowser/src/treebrowser.c:2154
 msgid "Toolbar"
 msgstr "Саймандар панелі"
 
-#: ../treebrowser/src/treebrowser.c:2151
+#: ../treebrowser/src/treebrowser.c:2156
 msgid "Hidden"
 msgstr "Жасырын"
 
-#: ../treebrowser/src/treebrowser.c:2152
+#: ../treebrowser/src/treebrowser.c:2157
 msgid "Top"
 msgstr "Жоғарыдан"
 
-#: ../treebrowser/src/treebrowser.c:2153
+#: ../treebrowser/src/treebrowser.c:2158
 msgid "Bottom"
 msgstr "Төменнен"
 
-#: ../treebrowser/src/treebrowser.c:2158
+#: ../treebrowser/src/treebrowser.c:2163
 msgid "If position is changed, the option require plugin restart."
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2162
+#: ../treebrowser/src/treebrowser.c:2167
 msgid "Show icons"
 msgstr "Таңбашаларды көрсету"
 
-#: ../treebrowser/src/treebrowser.c:2164
+#: ../treebrowser/src/treebrowser.c:2169
 msgid "None"
 msgstr "Ешнәрсе"
 
-#: ../treebrowser/src/treebrowser.c:2165
+#: ../treebrowser/src/treebrowser.c:2170
 msgid "Base"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2166
+#: ../treebrowser/src/treebrowser.c:2171
 msgid "Content-type"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2172
+#: ../treebrowser/src/treebrowser.c:2177
 msgid "Show hidden files"
 msgstr "Жасырын файлдарды көрсету"
 
-#: ../treebrowser/src/treebrowser.c:2181
+#: ../treebrowser/src/treebrowser.c:2186
 msgid "On Windows, this just hide files that are prefixed with '.' (dot)"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2183
+#: ../treebrowser/src/treebrowser.c:2188
 msgid "Hide object files"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2192
+#: ../treebrowser/src/treebrowser.c:2197
 msgid ""
 "Don't show generated object files in the file browser, this includes *.o, *."
 "obj. *.so, *.dll, *.a, *.lib"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2194
+#: ../treebrowser/src/treebrowser.c:2199
 msgid "Reverse filter"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2203
+#: ../treebrowser/src/treebrowser.c:2208
 msgid "Follow current document"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2212
+#: ../treebrowser/src/treebrowser.c:2217
 msgid "Single click, open document and focus it"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2221
+#: ../treebrowser/src/treebrowser.c:2226
 msgid "Double click open directory"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2230
+#: ../treebrowser/src/treebrowser.c:2235
 msgid "On delete file, close it if is opened"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2239
+#: ../treebrowser/src/treebrowser.c:2244
 msgid "Focus editor on file open"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2248
+#: ../treebrowser/src/treebrowser.c:2253
 msgid "Show tree lines"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2257
+#: ../treebrowser/src/treebrowser.c:2262
 msgid "Show bookmarks"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2266
+#: ../treebrowser/src/treebrowser.c:2271
 msgid "Open new files"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2350
+#: ../treebrowser/src/treebrowser.c:2355
 msgid "Focus File List"
 msgstr "Файлдар тізіміне фокусты орнату"
 
-#: ../treebrowser/src/treebrowser.c:2352
+#: ../treebrowser/src/treebrowser.c:2357
 msgid "Focus Path Entry"
 msgstr "Жол өрісіне фокусты орнату"
 
-#: ../treebrowser/src/treebrowser.c:2354
+#: ../treebrowser/src/treebrowser.c:2359
 msgid "Rename Object"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2358
+#: ../treebrowser/src/treebrowser.c:2363
 #, fuzzy
 msgid "New Folder"
 msgstr "Буманы таңдау"
 
-#: ../treebrowser/src/treebrowser.c:2362
+#: ../treebrowser/src/treebrowser.c:2367
 msgid "Track Current"
 msgstr ""
 
@@ -8138,12 +7911,6 @@ msgstr ""
 msgid "No workbench opened."
 msgstr ""
 
-#: ../workbench/src/sidebar.c:875
-#, fuzzy, c-format
-msgid "%s: %u Project"
-msgid_plural "%s: %u Projects"
-msgstr[0] "Жоба"
-
 #: ../workbench/src/sidebar.c:886
 msgid ""
 "Add a project using the context menu\n"
@@ -8248,3 +8015,26 @@ msgstr ""
 #: ../xmlsnippets/src/plugin.c:45
 msgid "Autocompletes XML/HTML tags using snippets."
 msgstr ""
+
+#~ msgid "Colors"
+#~ msgstr "Түстер"
+
+#~ msgid "Width:"
+#~ msgstr "Ені:"
+
+#~ msgid "Color:"
+#~ msgstr "Түс:"
+
+#~ msgid "Translated:"
+#~ msgstr "Аударылған:"
+
+#~ msgid "Fuzzy:"
+#~ msgstr "Дәлсіз:"
+
+#~ msgid "Untranslated:"
+#~ msgstr "Аударылмаған:"
+
+#, fuzzy, c-format
+#~ msgid "%s: %u Project"
+#~ msgid_plural "%s: %u Projects"
+#~ msgstr[0] "Жоба"

--- a/po/nl.po
+++ b/po/nl.po
@@ -6,8 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Geany-Plugins 1.30\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-29 19:41+0200\n"
+"Report-Msgid-Bugs-To: https://github.com/geany/geany/issues\n"
+"POT-Creation-Date: 2022-06-28 07:39+0200\n"
 "PO-Revision-Date: 2020-10-22 21:22+0200\n"
 "Last-Translator: Peter Scholtens <peter.scholtens@freedom.nl>\n"
 "Language-Team: Dutch\n"
@@ -22,27 +22,27 @@ msgstr ""
 msgid "(Empty Line)"
 msgstr "(Lege regel)"
 
-#: ../addons/src/ao_bookmarklist.c:315
+#: ../addons/src/ao_bookmarklist.c:331
 msgid "_Remove Bookmark"
 msgstr "Verwijder bladwijzer"
 
 #. Translators: Number is meant at this point.
-#: ../addons/src/ao_bookmarklist.c:342
+#: ../addons/src/ao_bookmarklist.c:358
 msgid "No."
 msgstr "Nee."
 
-#: ../addons/src/ao_bookmarklist.c:350 ../devhelp/src/dhp-object.c:494
+#: ../addons/src/ao_bookmarklist.c:366 ../devhelp/src/dhp-object.c:494
 #: ../devhelp/devhelp/dh-window.c:1142
 msgid "Contents"
 msgstr "Inhoud"
 
-#: ../addons/src/ao_bookmarklist.c:383 ../treebrowser/src/treebrowser.c:666
+#: ../addons/src/ao_bookmarklist.c:399 ../treebrowser/src/treebrowser.c:666
 #: ../webhelper/src/gwh-plugin.c:328
 msgid "Bookmarks"
 msgstr "Bladwijzers"
 
 #. complete update
-#: ../addons/src/ao_tasks.c:373 ../geanyvc/src/geanyvc.c:2679
+#: ../addons/src/ao_tasks.c:373 ../geanyvc/src/geanyvc.c:2730
 msgid "_Update"
 msgstr ""
 
@@ -164,10 +164,10 @@ msgstr "Kopiëert pad van huidige document naar klembord"
 #: ../addons/src/addons.c:364 ../autoclose/src/autoclose.c:920
 #: ../codenav/src/codenavigation.c:281 ../latex/src/latex.c:208
 #: ../latex/src/latex.c:293 ../geanyprj/src/geanyprj.c:176
-#: ../geanyvc/src/geanyvc.c:2079 ../geniuspaste/src/geniuspaste.c:336
+#: ../geanyvc/src/geanyvc.c:2130 ../geniuspaste/src/geniuspaste.c:336
 #: ../lineoperations/src/lo_prefs.c:58 ../sendmail/src/sendmail.c:128
 #: ../sendmail/src/sendmail.c:293 ../spellcheck/src/scplugin.c:124
-#: ../treebrowser/src/treebrowser.c:2102
+#: ../treebrowser/src/treebrowser.c:2106
 #: ../updatechecker/src/updatechecker.c:262
 msgid "Plugin configuration directory could not be created."
 msgstr "Plug-in configuratiemap kon niet worden aangemaakt."
@@ -715,7 +715,7 @@ msgstr "~\"Laad doelbestand.\\n\""
 msgid "Error loading file"
 msgstr "Fout gedurende inladen bestand"
 
-#. setting asyncronous mode
+#. setting asynchronous mode
 #. setting null-stop array printing
 #. enable pretty printing
 #: ../debugger/src/dbm_gdb.c:789 ../debugger/src/dbm_gdb.c:792
@@ -1108,7 +1108,7 @@ msgid "A developers' help browser for GNOME"
 msgstr ""
 
 #. Create the current file Submenu
-#: ../devhelp/devhelp/dh-window.c:759 ../geanyvc/src/geanyvc.c:2660
+#: ../devhelp/devhelp/dh-window.c:759 ../geanyvc/src/geanyvc.c:2711
 msgid "_File"
 msgstr "Bestand"
 
@@ -1142,11 +1142,11 @@ msgstr ""
 msgid "_Print…"
 msgstr ""
 
-#: ../devhelp/devhelp/dh-window.c:782 ../devhelp/devhelp/eggfindbar.c:342
+#: ../devhelp/devhelp/dh-window.c:782
 msgid "Find Next"
 msgstr "Zoek volgende"
 
-#: ../devhelp/devhelp/dh-window.c:784 ../devhelp/devhelp/eggfindbar.c:329
+#: ../devhelp/devhelp/dh-window.c:784
 msgid "Find Previous"
 msgstr "Zoek vorige"
 
@@ -1338,7 +1338,7 @@ msgid ""
 "contributing to this plugin?"
 msgstr ""
 
-#: ../geanydoc/src/geanydoc.c:159 ../geanyvc/src/geanyvc.c:442
+#: ../geanydoc/src/geanydoc.c:159 ../geanyvc/src/geanyvc.c:448
 msgid "Could not parse the output of command"
 msgstr "Kon uitvoer van commando niet parsen."
 
@@ -2984,14 +2984,14 @@ msgid ""
 "not enough arguments for command \"%s\".\n"
 msgstr ""
 
-#: ../geanylua/glspi_sci.c:637 ../geanylua/glspi_app.c:406
+#: ../geanylua/glspi_sci.c:729 ../geanylua/glspi_app.c:406
 #, c-format
 msgid ""
 "Error in module \"%s\" at function %s():\n"
 "unknown command \"%s\" given for argument #1.\n"
 msgstr ""
 
-#: ../geanylua/glspi_sci.c:781
+#: ../geanylua/glspi_sci.c:924
 #, c-format
 msgid ""
 "Error in module \"%s\" at function %s():\n"
@@ -2999,7 +2999,7 @@ msgid ""
 " unknown flag \"%s\" for element #%d\n"
 msgstr ""
 
-#: ../geanylua/glspi_sci.c:785
+#: ../geanylua/glspi_sci.c:928
 msgid "<too large to display>"
 msgstr ""
 
@@ -3728,7 +3728,7 @@ msgid "New _Below"
 msgstr ""
 
 #: ../geanymacro/src/geanymacro.c:1824 ../geanymacro/src/geanymacro.c:2120
-#: ../treebrowser/src/treebrowser.c:1338 ../treebrowser/src/treebrowser.c:1340
+#: ../treebrowser/src/treebrowser.c:1342 ../treebrowser/src/treebrowser.c:1344
 #, fuzzy
 msgid "_Delete"
 msgstr "Verwijder"
@@ -4100,8 +4100,8 @@ msgstr ""
 msgid "a key with fingerprint"
 msgstr "een sleutel met vingerafdruk"
 
-#: ../geanypg/src/verify_aux.c:66 ../spellcheck/src/gui.c:610
-#: ../spellcheck/src/gui.c:621
+#: ../geanypg/src/verify_aux.c:66 ../spellcheck/src/gui.c:607
+#: ../spellcheck/src/gui.c:618
 msgid "unknown"
 msgstr "onbekend"
 
@@ -4407,50 +4407,50 @@ msgid ""
 "contributing to this plugin?"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:501
+#: ../geanyvc/src/geanyvc.c:507
 #, c-format
 msgid "geanyvc: s_spawn_sync error: %s"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:587
+#: ../geanyvc/src/geanyvc.c:593
 #, c-format
 msgid "File %s: action %s executed via %s."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:646 ../geanyvc/src/geanyvc.c:657
-#, c-format
-msgid "geanyvc: vcdiff_file_activated: Unable to rename '%s' to '%s'"
+#: ../geanyvc/src/geanyvc.c:633 ../geanyvc/src/geanyvc.c:643
+#, fuzzy, c-format
+msgid "geanyvc: diff_external: Unable to rename '%s' to '%s'"
 msgstr "geanyvc: vcdiff_file_activated: Kon \"%s\" niet hernoemen tot \"%s\""
 
-#: ../geanyvc/src/geanyvc.c:683 ../geanyvc/src/geanyvc.c:733
+#: ../geanyvc/src/geanyvc.c:698 ../geanyvc/src/geanyvc.c:784
 msgid "No changes were made."
 msgstr "Er zijn geen wijzigingen gemaakt."
 
-#: ../geanyvc/src/geanyvc.c:760
+#: ../geanyvc/src/geanyvc.c:811
 #, fuzzy
 msgid "No history available"
 msgstr "Geen geschiedenis beschikbaar."
 
-#: ../geanyvc/src/geanyvc.c:953 ../geanyvc/src/geanyvc.c:961
+#: ../geanyvc/src/geanyvc.c:1004 ../geanyvc/src/geanyvc.c:1012
 #, c-format
 msgid "Do you really want to revert: %s?"
 msgstr "Wil je echt de wijzigingen in \"%s\" terugdraaien?"
 
-#: ../geanyvc/src/geanyvc.c:969
+#: ../geanyvc/src/geanyvc.c:1020
 #, c-format
 msgid "Do you really want to add: %s?"
 msgstr "Wil je echt \"%s\" toevoegen?"
 
-#: ../geanyvc/src/geanyvc.c:976
+#: ../geanyvc/src/geanyvc.c:1027
 #, c-format
 msgid "Do you really want to remove: %s?"
 msgstr "Wil je echt \"%s\" verwijderen"
 
-#: ../geanyvc/src/geanyvc.c:999
+#: ../geanyvc/src/geanyvc.c:1050
 msgid "Do you really want to update?"
 msgstr "Wil je echt updaten?"
 
-#: ../geanyvc/src/geanyvc.c:1126
+#: ../geanyvc/src/geanyvc.c:1177
 msgid ""
 "The resulting differences cannot be displayed because the changes are too "
 "big to display here and would slow down the UI significantly.\n"
@@ -4459,74 +4459,74 @@ msgid ""
 "Geany directly by using the GeanyVC menu (Base Directory -> Diff)."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1280
+#: ../geanyvc/src/geanyvc.c:1331
 msgid "Commit Y/N"
 msgstr "Doorvoeren J/N"
 
-#: ../geanyvc/src/geanyvc.c:1290
+#: ../geanyvc/src/geanyvc.c:1341
 msgid "Status"
 msgstr "Toestand"
 
-#: ../geanyvc/src/geanyvc.c:1297
+#: ../geanyvc/src/geanyvc.c:1348
 msgid "Path"
 msgstr "Pad"
 
-#: ../geanyvc/src/geanyvc.c:1414
+#: ../geanyvc/src/geanyvc.c:1465
 msgid "Choose a previous commit message"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1476
+#: ../geanyvc/src/geanyvc.c:1527
 #, c-format
 msgid "Line: %d Column: %d"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1523
+#: ../geanyvc/src/geanyvc.c:1574
 msgid "Commit"
 msgstr "Doorvoeren"
 
-#: ../geanyvc/src/geanyvc.c:1564
+#: ../geanyvc/src/geanyvc.c:1615
 msgid "_De-/select all files"
 msgstr "(De-)selecteer alle bestanden"
 
-#: ../geanyvc/src/geanyvc.c:1608
+#: ../geanyvc/src/geanyvc.c:1659
 msgid "<b>Commit message:</b>"
 msgstr "<b>Doorvoer commentaar:</b>"
 
-#: ../geanyvc/src/geanyvc.c:1632
+#: ../geanyvc/src/geanyvc.c:1683
 msgid "C_ommit"
 msgstr "Doorvoeren"
 
-#: ../geanyvc/src/geanyvc.c:1740
+#: ../geanyvc/src/geanyvc.c:1791
 msgid "Nothing to commit."
 msgstr "Niets door te voeren."
 
-#: ../geanyvc/src/geanyvc.c:1788
+#: ../geanyvc/src/geanyvc.c:1839
 #, fuzzy, c-format
 msgid ""
 "Error initializing GeanyVC spell checking: %s. Check your configuration."
 msgstr "Fout tijdens spellingscontrole-initialisatie: \"%s\""
 
-#: ../geanyvc/src/geanyvc.c:1823
+#: ../geanyvc/src/geanyvc.c:1874
 #, c-format
 msgid "Commit failed (status: %d, error: %s)."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1824
+#: ../geanyvc/src/geanyvc.c:1875
 #, fuzzy
 msgid "Commit failed; see status in the Message window."
 msgstr "Laat beschikbare taken in het berichtenvenster zien"
 
-#: ../geanyvc/src/geanyvc.c:1829
+#: ../geanyvc/src/geanyvc.c:1880
 #, fuzzy
 msgid "Changes committed."
 msgstr "Niets door te voeren."
 
-#: ../geanyvc/src/geanyvc.c:2151
+#: ../geanyvc/src/geanyvc.c:2202
 msgid "Set Changed-flag for document tabs created by the plugin"
 msgstr ""
 "Zet vlag 'gewijzigd' bij tabbladen van de door plugin gecreërde documenten."
 
-#: ../geanyvc/src/geanyvc.c:2154
+#: ../geanyvc/src/geanyvc.c:2205
 msgid ""
 "If this option is activated, every new by the VC-plugin created document tab "
 "will be marked as changed. Even this option is useful in some cases, it "
@@ -4537,259 +4537,259 @@ msgstr ""
 "gevallen, zal het mogelijkerwijs ook een groot aantal hinderlijke 'Wil je "
 "dit bewaren' dialogen veroorzaken."
 
-#: ../geanyvc/src/geanyvc.c:2162
+#: ../geanyvc/src/geanyvc.c:2213
 msgid "Confirm adding new files to a VCS"
 msgstr "Bevestig het toevoegen van nieuwe bestanden aan VBS."
 
-#: ../geanyvc/src/geanyvc.c:2165
+#: ../geanyvc/src/geanyvc.c:2216
 msgid "Shows a confirmation dialog on adding a new (created) file to VCS."
 msgstr ""
 "Laat een bevestigingsdialoog zien bij het toevoegen van een nieuw (gecreërd) "
 "bestand aan het VBS."
 
-#: ../geanyvc/src/geanyvc.c:2171
+#: ../geanyvc/src/geanyvc.c:2222
 msgid "Maximize commit dialog"
 msgstr "Maximaliseer doorvoer dialoog."
 
-#: ../geanyvc/src/geanyvc.c:2172
+#: ../geanyvc/src/geanyvc.c:2223
 msgid "Show commit dialog maximize."
 msgstr "Laat doorvoer dialoog maximalisatie zien."
 
-#: ../geanyvc/src/geanyvc.c:2178
+#: ../geanyvc/src/geanyvc.c:2229
 msgid "Use external diff viewer"
 msgstr "Gebruik externe diff viewer"
 
-#: ../geanyvc/src/geanyvc.c:2180
+#: ../geanyvc/src/geanyvc.c:2231
 msgid "Use external diff viewer for file diff."
 msgstr "Gebruik externe diff viewer voor bestanden."
 
-#: ../geanyvc/src/geanyvc.c:2186
+#: ../geanyvc/src/geanyvc.c:2237
 msgid "Show VC entries at editor menu"
 msgstr "Laat VB entries zien bij editor menu"
 
-#: ../geanyvc/src/geanyvc.c:2188
+#: ../geanyvc/src/geanyvc.c:2239
 msgid "Show entries for VC functions inside editor menu"
 msgstr "Laat entries voor VB functies in editor menu"
 
-#: ../geanyvc/src/geanyvc.c:2193
+#: ../geanyvc/src/geanyvc.c:2244
 msgid "Attach menu to menubar"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2195
+#: ../geanyvc/src/geanyvc.c:2246
 msgid ""
 "Whether menu for this plugin are getting placed either inside tools menu or "
 "directly inside Geany's menubar. Will take in account after next start of "
 "GeanyVC"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2203
+#: ../geanyvc/src/geanyvc.c:2254
 msgid "Enable CVS"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2208
+#: ../geanyvc/src/geanyvc.c:2259
 msgid "Enable GIT"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2213
+#: ../geanyvc/src/geanyvc.c:2264
 msgid "Enable Fossil"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2218
+#: ../geanyvc/src/geanyvc.c:2269
 msgid "Enable SVN"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2223
+#: ../geanyvc/src/geanyvc.c:2274
 msgid "Enable SVK"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2228
+#: ../geanyvc/src/geanyvc.c:2279
 msgid "Enable Bazaar"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2233
+#: ../geanyvc/src/geanyvc.c:2284
 msgid "Enable Mercurial"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2239
+#: ../geanyvc/src/geanyvc.c:2290
 msgid "Spellcheck language"
 msgstr "Spellingscontroletaal"
 
 #. Diff of current file
 #. Diff of the current dir
 #. Complete diff of base directory
-#: ../geanyvc/src/geanyvc.c:2368 ../geanyvc/src/geanyvc.c:2463
-#: ../geanyvc/src/geanyvc.c:2503
+#: ../geanyvc/src/geanyvc.c:2419 ../geanyvc/src/geanyvc.c:2514
+#: ../geanyvc/src/geanyvc.c:2554
 msgid "_Diff"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2371
+#: ../geanyvc/src/geanyvc.c:2422
 msgid "Make a diff from the current active file"
 msgstr "Maak een 'diff' van het huidige actieve bestand"
 
 #. Revert current file
 #. Revert current dir
 #. Revert everything
-#: ../geanyvc/src/geanyvc.c:2376 ../geanyvc/src/geanyvc.c:2472
-#: ../geanyvc/src/geanyvc.c:2511
+#: ../geanyvc/src/geanyvc.c:2427 ../geanyvc/src/geanyvc.c:2523
+#: ../geanyvc/src/geanyvc.c:2562
 msgid "_Revert"
 msgstr "Draai terug"
 
-#: ../geanyvc/src/geanyvc.c:2379
+#: ../geanyvc/src/geanyvc.c:2430
 msgid "Restore pristine working copy file (undo local edits)."
 msgstr "Herstel oorspronkelijke werkversie (maak lokale wijzigingen ongedaan)."
 
 #. Blame for current file
-#: ../geanyvc/src/geanyvc.c:2388
+#: ../geanyvc/src/geanyvc.c:2439
 msgid "_Blame"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2391
+#: ../geanyvc/src/geanyvc.c:2442
 msgid "Shows the changes made at one file per revision and author."
 msgstr "Laat de wijzigingen van een bestand per revisie en auteur zien."
 
 #. History/log of current file
 #. History/log of the current dir
 #. Complete History/Log of base directory
-#: ../geanyvc/src/geanyvc.c:2398 ../geanyvc/src/geanyvc.c:2482
-#: ../geanyvc/src/geanyvc.c:2523
+#: ../geanyvc/src/geanyvc.c:2449 ../geanyvc/src/geanyvc.c:2533
+#: ../geanyvc/src/geanyvc.c:2574
 msgid "_History (log)"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2401
+#: ../geanyvc/src/geanyvc.c:2452
 msgid "Shows the log of the current file"
 msgstr "Laat de log van het huidige bestand zien"
 
 #. base version of the current file
-#: ../geanyvc/src/geanyvc.c:2406
+#: ../geanyvc/src/geanyvc.c:2457
 msgid "_Original"
 msgstr "Origineel"
 
-#: ../geanyvc/src/geanyvc.c:2409
+#: ../geanyvc/src/geanyvc.c:2460
 #, fuzzy
 msgid "Shows the original of the current file"
 msgstr "Laat het origineel van het huidige bestand zien"
 
 #. add current file
-#: ../geanyvc/src/geanyvc.c:2417
+#: ../geanyvc/src/geanyvc.c:2468
 msgid "_Add to Version Control"
 msgstr "Voeg aan Versie Beheer toe"
 
-#: ../geanyvc/src/geanyvc.c:2419
+#: ../geanyvc/src/geanyvc.c:2470
 msgid "Add file to repository."
 msgstr "Voeg bestand aan opslagplaats toe."
 
 #. remove current file
-#: ../geanyvc/src/geanyvc.c:2425
+#: ../geanyvc/src/geanyvc.c:2476
 msgid "_Remove from Version Control"
 msgstr "Verwijder van Versie Beheer"
 
-#: ../geanyvc/src/geanyvc.c:2427
+#: ../geanyvc/src/geanyvc.c:2478
 msgid "Remove file from repository."
 msgstr "Verwijder bestand van opslagplaats."
 
-#: ../geanyvc/src/geanyvc.c:2460
+#: ../geanyvc/src/geanyvc.c:2511
 msgid "_Directory"
 msgstr "Map"
 
-#: ../geanyvc/src/geanyvc.c:2466
+#: ../geanyvc/src/geanyvc.c:2517
 msgid "Make a diff from the directory of the current active file"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2475
+#: ../geanyvc/src/geanyvc.c:2526
 msgid "Restore original files in the current folder (undo local edits)."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2485
+#: ../geanyvc/src/geanyvc.c:2536
 msgid "Shows the log of the current directory"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2499
+#: ../geanyvc/src/geanyvc.c:2550
 msgid "_Base Directory"
 msgstr "Basismap"
 
-#: ../geanyvc/src/geanyvc.c:2505
+#: ../geanyvc/src/geanyvc.c:2556
 msgid "Make a diff from the top VC directory"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2513
+#: ../geanyvc/src/geanyvc.c:2564
 msgid "Revert any local edits."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2526
+#: ../geanyvc/src/geanyvc.c:2577
 msgid "Shows the log of the top VC directory"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2543
+#: ../geanyvc/src/geanyvc.c:2594
 msgid "_VC file Actions"
 msgstr "VB bestandhandelingen"
 
-#: ../geanyvc/src/geanyvc.c:2552
+#: ../geanyvc/src/geanyvc.c:2603
 msgid "VC _Commit..."
 msgstr "VB doorvoeren..."
 
-#: ../geanyvc/src/geanyvc.c:2596
+#: ../geanyvc/src/geanyvc.c:2647
 msgid "Show diff of file"
 msgstr "Laat verschil tussen bestanden zien"
 
-#: ../geanyvc/src/geanyvc.c:2598
+#: ../geanyvc/src/geanyvc.c:2649
 msgid "Show diff of directory"
 msgstr "Laat verschil tussen mappen zien"
 
-#: ../geanyvc/src/geanyvc.c:2600
+#: ../geanyvc/src/geanyvc.c:2651
 msgid "Show diff of basedir"
 msgstr "Laat verschil van basismap zien"
 
-#: ../geanyvc/src/geanyvc.c:2603
+#: ../geanyvc/src/geanyvc.c:2654
 msgid "Commit changes"
 msgstr "Voer wijzigingen door"
 
-#: ../geanyvc/src/geanyvc.c:2605
+#: ../geanyvc/src/geanyvc.c:2656
 msgid "Show status"
 msgstr "Laat toestand zien"
 
-#: ../geanyvc/src/geanyvc.c:2607
+#: ../geanyvc/src/geanyvc.c:2658
 msgid "Revert single file"
 msgstr "Draai wijzigingen van bestand terug"
 
-#: ../geanyvc/src/geanyvc.c:2609
+#: ../geanyvc/src/geanyvc.c:2660
 msgid "Revert directory"
 msgstr "Draai wijzigingen map terug"
 
-#: ../geanyvc/src/geanyvc.c:2611
+#: ../geanyvc/src/geanyvc.c:2662
 msgid "Revert base directory"
 msgstr "Draai wijzigingen basismap terug"
 
-#: ../geanyvc/src/geanyvc.c:2613
+#: ../geanyvc/src/geanyvc.c:2664
 msgid "Update file"
 msgstr "Update bestand"
 
-#: ../geanyvc/src/geanyvc.c:2643
+#: ../geanyvc/src/geanyvc.c:2694
 msgid "_VC"
 msgstr "VB"
 
-#: ../geanyvc/src/geanyvc.c:2650
+#: ../geanyvc/src/geanyvc.c:2701
 msgid "_Version Control"
 msgstr "Versie Beheer"
 
 #. Status of basedir
-#: ../geanyvc/src/geanyvc.c:2672
+#: ../geanyvc/src/geanyvc.c:2723
 msgid "_Status"
 msgstr "Toestand"
 
-#: ../geanyvc/src/geanyvc.c:2674
+#: ../geanyvc/src/geanyvc.c:2725
 msgid "Show status."
 msgstr "Laat toestand zien."
 
-#: ../geanyvc/src/geanyvc.c:2681
+#: ../geanyvc/src/geanyvc.c:2732
 msgid "Update from remote repository."
 msgstr "Update van opslagplaats op afstand"
 
 #. Commit all changes
-#: ../geanyvc/src/geanyvc.c:2686
+#: ../geanyvc/src/geanyvc.c:2737
 msgid "_Commit..."
 msgstr "Doorvoeren..."
 
-#: ../geanyvc/src/geanyvc.c:2688
+#: ../geanyvc/src/geanyvc.c:2739
 msgid "Commit changes."
 msgstr "Voer wijzigingen door."
 
@@ -4903,34 +4903,6 @@ msgstr ""
 
 #: ../geniuspaste/src/geniuspaste.c:959
 msgid "_Paste it!"
-msgstr ""
-
-#: ../git-changebar/data/prefs.ui.h:1
-msgid "_Monitor repository for changes"
-msgstr ""
-
-#: ../git-changebar/data/prefs.ui.h:2
-msgid ""
-"Whether to automatically update the diff in order to maintain it up to date "
-"when the underlying Git repository changes.  This should generally be "
-"enabled for optimal user experience."
-msgstr ""
-
-#: ../git-changebar/data/prefs.ui.h:3
-msgid "_Added lines:"
-msgstr ""
-
-#: ../git-changebar/data/prefs.ui.h:4
-msgid "_Changed lines:"
-msgstr ""
-
-#: ../git-changebar/data/prefs.ui.h:5
-#, fuzzy
-msgid "_Removed lines:"
-msgstr "Verwijder bestand"
-
-#: ../git-changebar/data/prefs.ui.h:6
-msgid "Colors"
 msgstr ""
 
 #: ../git-changebar/src/gcb-plugin.c:62
@@ -5123,8 +5095,8 @@ msgstr ""
 #: ../lipsum/src/lipsum.c:184 ../sendmail/src/sendmail.c:396
 #, c-format
 msgid ""
-"Your configuration directory has been successfully moved from \"%s\" to \"%s"
-"\"."
+"Your configuration directory has been successfully moved from \"%s\" to "
+"\"%s\"."
 msgstr ""
 
 #: ../lipsum/src/lipsum.c:199
@@ -5300,7 +5272,7 @@ msgstr "Kon default configuratie niet wegschrijven: %s"
 msgid "Unable to read value for '%s' key: %s"
 msgstr "Kon configuratie map niet creëren op '%s'"
 
-#: ../multiterm/src/tab-label.vala:62 ../treebrowser/src/treebrowser.c:2132
+#: ../multiterm/src/tab-label.vala:62 ../treebrowser/src/treebrowser.c:2137
 #, fuzzy
 msgid "Terminal"
 msgstr "Open terminalvenster"
@@ -5341,115 +5313,6 @@ msgstr ""
 msgid "Show Overview"
 msgstr "Laat regels van boom zien"
 
-#: ../overview/data/prefs.ui.h:1
-msgid ""
-"The amount to zoom the overview sidebar. This should probably negative if "
-"you want the sidebar zoomed out."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:2
-msgid "Zoom Level:"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:3
-msgid "The width of the overview sidebar."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:4
-msgid "Width:"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:5
-msgid ""
-"The number of lines to scroll at a time when scrolling the overview sidebar."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:6
-msgid "Scroll Lines:"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:7
-#, fuzzy
-msgid "Position on left"
-msgstr "Zet op een regel"
-
-#: ../overview/data/prefs.ui.h:8
-msgid ""
-"Position the overview bar on the left rather than the right (requires Geany "
-"1.25 or greater)."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:9
-#, fuzzy
-msgid "Hide tooltip"
-msgstr "Laat balk met hulpmiddelen zien"
-
-#: ../overview/data/prefs.ui.h:10
-msgid ""
-"Hide the tooltip that is displayed when mousing over the overview that shows "
-"line, column and position information."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:11
-msgid "Hide editor scrollbar"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:12
-msgid ""
-"Whether to hide Geany's regular editor scrollbar while the overview bar is "
-"visible."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:13
-msgid "Disable overlay"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:14
-msgid ""
-"Turn off drawing overlay, which shows the region of the main editor view "
-"that is currently in view, ontop of the overview bar."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:15 ../scope/data/scope.glade.h:130
-#: ../scope/data/scope_gtk3.glade.h:130
-#, fuzzy
-msgid "Options"
-msgstr "Zoektermen:"
-
-#: ../overview/data/prefs.ui.h:16
-msgid ""
-"The color and opacity of the overlay drawn ontop of the overlay sidebar."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:17
-msgid "Color:"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:18
-msgid ""
-"The color and opacity of the border drawn around the revealed area in the "
-"overview sidebar. Set to the same as Overlay Color to disable."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:19
-msgid "Outline Color:"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:20
-msgid "Draw over visible area"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:21
-msgid ""
-"When checked it will draw the overlay ontop of the area that is visible in "
-"the main editor view, when unchecked, it will do the opposite and draw the "
-"overlay everywhere but the visible area, \"revealing\" the visible part."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:22
-msgid "Overlay"
-msgstr ""
-
 #: ../pairtaghighlighter/src/pair_tag_highlighter.c:43
 msgid "Pair Tag Highlighter"
 msgstr "Labelpaar markeerder"
@@ -5474,146 +5337,6 @@ msgstr ""
 #, fuzzy
 msgid "Select To Matching Tag"
 msgstr "Selecteer een ondertekenaar"
-
-#: ../pohelper/data/menus.ui.h:1
-msgid "_Translation Helper"
-msgstr "Vertalingshulp"
-
-#: ../pohelper/data/menus.ui.h:2
-msgid "_Previous String"
-msgstr "Vorige string"
-
-#: ../pohelper/data/menus.ui.h:3 ../pohelper/src/gph-plugin.c:1590
-msgid "Go to previous string"
-msgstr "Ga naar vorige string"
-
-#: ../pohelper/data/menus.ui.h:4
-msgid "_Next String"
-msgstr "Volgende string"
-
-#: ../pohelper/data/menus.ui.h:5 ../pohelper/src/gph-plugin.c:1593
-msgid "Go to next string"
-msgstr "Ga naar volgende string"
-
-#: ../pohelper/data/menus.ui.h:6
-msgid "Pre_vious Untranslated"
-msgstr "Vorige onvertaalde string"
-
-#: ../pohelper/data/menus.ui.h:7 ../pohelper/src/gph-plugin.c:1596
-msgid "Go to previous untranslated string"
-msgstr "Ga naar vorige onvertaalde string"
-
-#: ../pohelper/data/menus.ui.h:8
-msgid "Next _Untranslated"
-msgstr "Volgende onvertaalde string"
-
-#: ../pohelper/data/menus.ui.h:9 ../pohelper/src/gph-plugin.c:1599
-msgid "Go to next untranslated string"
-msgstr "Ga naar volgende onvertaalde string"
-
-#: ../pohelper/data/menus.ui.h:10
-msgid "Previous Fu_zzy"
-msgstr "Vorige onduidelijkheid"
-
-#: ../pohelper/data/menus.ui.h:11 ../pohelper/src/gph-plugin.c:1602
-msgid "Go to previous fuzzily translated string"
-msgstr "Ga naar de vorige onduidelijk vertaalde string"
-
-#: ../pohelper/data/menus.ui.h:12
-msgid "Next _Fuzzy"
-msgstr "Volgende onduidelijkheid"
-
-#: ../pohelper/data/menus.ui.h:13 ../pohelper/src/gph-plugin.c:1605
-msgid "Go to next fuzzily translated string"
-msgstr "Ga naar volgende onduidelijk vertaalde string"
-
-#: ../pohelper/data/menus.ui.h:14
-msgid "Previous Untranslated or Fuzz_y"
-msgstr "Vorige onvertaalde of onduidelijke string"
-
-#: ../pohelper/data/menus.ui.h:15 ../pohelper/src/gph-plugin.c:1608
-msgid "Go to previous untranslated or fuzzy string"
-msgstr "Ga naar vorige onvertaalde of onduidelijke string"
-
-#: ../pohelper/data/menus.ui.h:16
-msgid "Next Untranslated _or Fuzzy"
-msgstr "Volgende onvertaalde of onduidelijke string"
-
-#: ../pohelper/data/menus.ui.h:17 ../pohelper/src/gph-plugin.c:1612
-msgid "Go to next untranslated or fuzzy string"
-msgstr "Ga naar volgende onvertaalde of onduidelijke string"
-
-#: ../pohelper/data/menus.ui.h:18 ../pohelper/src/gph-plugin.c:1623
-msgid "Toggle current translation fuzziness"
-msgstr "Markeer huidige vertaling als (on)duidelijk"
-
-#: ../pohelper/data/menus.ui.h:19
-msgid "_Toggle Fuzziness"
-msgstr "Zet (on)duidelijkheid"
-
-#: ../pohelper/data/menus.ui.h:20
-msgid "Paste _Message as Translation"
-msgstr "Plak bericht als vertaling"
-
-#: ../pohelper/data/menus.ui.h:21
-msgid "Paste the original untranslated string to the translation"
-msgstr "Plak de orginele onvertaalde string naar de vertaling"
-
-#: ../pohelper/data/menus.ui.h:22 ../pohelper/src/gph-plugin.c:1620
-msgid "Reflow the current translation string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:23
-msgid "_Reflow Translation"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:24 ../pohelper/src/gph-plugin.c:1626
-msgid "Show statistics of the current document"
-msgstr "Laat de statistieken van het hudige document zien"
-
-#: ../pohelper/data/menus.ui.h:25
-msgid "_Show stats"
-msgstr "Laat statistiek zien"
-
-#: ../pohelper/data/menus.ui.h:26
-msgid ""
-"Whether to update the translation headers (author, revision date, ...) upon "
-"file save"
-msgstr ""
-"Of de vertalingsinformatie (auteur, revisiedatum, ...) aangepast moet worden "
-"bij het wegschrijven"
-
-#: ../pohelper/data/menus.ui.h:27
-msgid "Update _Headers Upon Save"
-msgstr "Pas vertalingsinfo aan bij wegschrijven"
-
-#: ../pohelper/data/stats.ui.h:1
-msgid "Translation statistics"
-msgstr "Vertalingsstatistieken"
-
-#: ../pohelper/data/stats.ui.h:2
-msgid "Choose a color for translated strings"
-msgstr "Kies een kleur voor de vertaalde string"
-
-#: ../pohelper/data/stats.ui.h:3
-msgid "Choose a color for fuzzily translated strings"
-msgstr "Kies een kleur voor de onduidelijk vertaalde string"
-
-#: ../pohelper/data/stats.ui.h:4
-msgid "Choose a color for untranslated strings"
-msgstr "Kies een kleur voor de onvertaalde string"
-
-#: ../pohelper/data/stats.ui.h:5
-msgid "Translated:"
-msgstr "Vertaald:"
-
-#: ../pohelper/data/stats.ui.h:6
-msgid "Fuzzy:"
-msgstr "Onduidelijk:"
-
-#: ../pohelper/data/stats.ui.h:7
-msgid "Untranslated:"
-msgstr "Onvertaalde:"
 
 #: ../pohelper/src/gph-plugin.c:40
 msgid "Translation Helper"
@@ -5643,9 +5366,53 @@ msgstr "<b>Onvertaald:</b> %.3g%%"
 msgid "%u (%.3g%%)"
 msgstr "%u (%.3g%%)"
 
+#: ../pohelper/src/gph-plugin.c:1590
+msgid "Go to previous string"
+msgstr "Ga naar vorige string"
+
+#: ../pohelper/src/gph-plugin.c:1593
+msgid "Go to next string"
+msgstr "Ga naar volgende string"
+
+#: ../pohelper/src/gph-plugin.c:1596
+msgid "Go to previous untranslated string"
+msgstr "Ga naar vorige onvertaalde string"
+
+#: ../pohelper/src/gph-plugin.c:1599
+msgid "Go to next untranslated string"
+msgstr "Ga naar volgende onvertaalde string"
+
+#: ../pohelper/src/gph-plugin.c:1602
+msgid "Go to previous fuzzily translated string"
+msgstr "Ga naar de vorige onduidelijk vertaalde string"
+
+#: ../pohelper/src/gph-plugin.c:1605
+msgid "Go to next fuzzily translated string"
+msgstr "Ga naar volgende onduidelijk vertaalde string"
+
+#: ../pohelper/src/gph-plugin.c:1608
+msgid "Go to previous untranslated or fuzzy string"
+msgstr "Ga naar vorige onvertaalde of onduidelijke string"
+
+#: ../pohelper/src/gph-plugin.c:1612
+msgid "Go to next untranslated or fuzzy string"
+msgstr "Ga naar volgende onvertaalde of onduidelijke string"
+
 #: ../pohelper/src/gph-plugin.c:1616
 msgid "Paste original untranslated string to translation"
 msgstr "Plak originele onvertaalde string naar vertalingsveld"
+
+#: ../pohelper/src/gph-plugin.c:1620
+msgid "Reflow the current translation string"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1623
+msgid "Toggle current translation fuzziness"
+msgstr "Markeer huidige vertaling als (on)duidelijk"
+
+#: ../pohelper/src/gph-plugin.c:1626
+msgid "Show statistics of the current document"
+msgstr "Laat de statistieken van het hudige document zien"
 
 #: ../pohelper/src/gph-plugin.c:1833
 #, c-format
@@ -5918,7 +5685,7 @@ msgid "Add"
 msgstr "Toevoegingen"
 
 #: ../projectorganizer/src/prjorg-sidebar.c:390
-#: ../treebrowser/src/treebrowser.c:2356
+#: ../treebrowser/src/treebrowser.c:2361
 #, fuzzy
 msgid "New File"
 msgstr "NieuwBestand"
@@ -6577,6 +6344,11 @@ msgstr "Laat balk met hulpmiddelen zien"
 msgid "<b>Others</b>"
 msgstr ""
 
+#: ../scope/data/scope.glade.h:130 ../scope/data/scope_gtk3.glade.h:130
+#, fuzzy
+msgid "Options"
+msgstr "Zoektermen:"
+
 #: ../scope/data/scope.glade.h:131 ../scope/data/scope_gtk3.glade.h:131
 #, fuzzy
 msgid "_Import"
@@ -7159,12 +6931,14 @@ msgid "Checks the spelling of the current document."
 msgstr "Controleert de spelling in het huidige bestand"
 
 #: ../spellcheck/src/scplugin.c:225
-msgid "Run Spell Check"
+#, fuzzy
+msgid "Run spell check once"
 msgstr "Draai spellingscontrole"
 
-#: ../spellcheck/src/scplugin.c:228
-msgid "Toggle Check While Typing"
-msgstr ""
+#: ../spellcheck/src/scplugin.c:228 ../spellcheck/src/scplugin.c:333
+#, fuzzy
+msgid "Toggle spell check"
+msgstr "Spellingscontrole"
 
 #. initialise the dialog
 #: ../spellcheck/src/scplugin.c:239
@@ -7191,10 +6965,6 @@ msgstr "Geef verkeerd gespelde woorden en suggesties in berichtenvenster weer"
 #: ../spellcheck/src/scplugin.c:325
 msgid "<b>Interface</b>"
 msgstr ""
-
-#: ../spellcheck/src/scplugin.c:333
-msgid "Check spelling while typing"
-msgstr "Controleer spelling gedurende het typen"
 
 #: ../spellcheck/src/scplugin.c:336
 #, fuzzy
@@ -7227,52 +6997,52 @@ msgstr ""
 msgid "<b>Behavior</b>"
 msgstr ""
 
-#: ../spellcheck/src/gui.c:76
+#: ../spellcheck/src/gui.c:88
 msgid "Spell checking while typing is now enabled"
 msgstr "Spellingscontrole gedurende het typen is aangeschakeld"
 
-#: ../spellcheck/src/gui.c:78
+#: ../spellcheck/src/gui.c:90
 msgid "Spell checking while typing is now disabled"
 msgstr "Spellingscontrole gedurende het typen is uitgeschakeld"
 
-#: ../spellcheck/src/gui.c:326
+#: ../spellcheck/src/gui.c:323
 msgid "More..."
 msgstr "Meer..."
 
-#: ../spellcheck/src/gui.c:347
+#: ../spellcheck/src/gui.c:344
 msgid "(No Suggestions)"
 msgstr "(Geen suggesties)"
 
-#: ../spellcheck/src/gui.c:360
+#: ../spellcheck/src/gui.c:357
 #, c-format
 msgid "Add \"%s\" to Dictionary"
 msgstr "Voeg \"%s\" aan woordenboek toe"
 
-#: ../spellcheck/src/gui.c:368
+#: ../spellcheck/src/gui.c:365
 msgid "Ignore All"
 msgstr "Negeer alles"
 
-#: ../spellcheck/src/gui.c:441
+#: ../spellcheck/src/gui.c:438
 msgid ""
 "Search term is too long to provide\n"
 "spelling suggestions in the editor menu."
 msgstr "Zoekterm is te lang om suggesties te genereren in editor menu"
 
-#: ../spellcheck/src/gui.c:447
+#: ../spellcheck/src/gui.c:444
 msgid "Perform Spell Check"
 msgstr "Voer spellingscontrole uit"
 
-#: ../spellcheck/src/gui.c:609
+#: ../spellcheck/src/gui.c:606
 #, c-format
 msgid "Default (%s)"
 msgstr ""
 
-#: ../spellcheck/src/gui.c:620
-#, c-format
-msgid "Toggle spell check while typing (current language: %s)"
-msgstr ""
+#: ../spellcheck/src/gui.c:617
+#, fuzzy, c-format
+msgid "Toggle spell check (current language: %s)"
+msgstr "Spellingscontroletaal"
 
-#: ../spellcheck/src/gui.c:698
+#: ../spellcheck/src/gui.c:695
 msgid "Spelling Suggestions"
 msgstr "Spellingssuggesties"
 
@@ -7367,15 +7137,15 @@ msgstr "(Leeg)"
 msgid "Could not execute configured external command '%s' (%s)."
 msgstr "Kon extern geconfigureerde commando '%s' (%s) niet uitvoeren."
 
-#: ../treebrowser/src/treebrowser.c:1089
+#: ../treebrowser/src/treebrowser.c:1093
 msgid "NewDirectory"
 msgstr "NieuweMap"
 
-#: ../treebrowser/src/treebrowser.c:1091
+#: ../treebrowser/src/treebrowser.c:1095
 msgid "NewFile"
 msgstr "NieuwBestand"
 
-#: ../treebrowser/src/treebrowser.c:1096
+#: ../treebrowser/src/treebrowser.c:1100
 #, fuzzy, c-format
 msgid ""
 "Target file '%s' exists.\n"
@@ -7384,129 +7154,129 @@ msgstr ""
 "Doelbestand '%s' bestaat reeds,\n"
 "wil je het echt vervangen door een leeg bestand?"
 
-#: ../treebrowser/src/treebrowser.c:1142
+#: ../treebrowser/src/treebrowser.c:1146
 #, c-format
 msgid "Do you really want to delete '%s' ?"
 msgstr "Wil je echt '%s' verwijderen?"
 
-#: ../treebrowser/src/treebrowser.c:1255 ../treebrowser/src/treebrowser.c:1257
+#: ../treebrowser/src/treebrowser.c:1259 ../treebrowser/src/treebrowser.c:1261
 msgid "Go _Up"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1263 ../treebrowser/src/treebrowser.c:1265
+#: ../treebrowser/src/treebrowser.c:1267 ../treebrowser/src/treebrowser.c:1269
 #, fuzzy
 msgid "Set _Path From Document"
 msgstr "Zet pad van document"
 
-#: ../treebrowser/src/treebrowser.c:1271 ../treebrowser/src/treebrowser.c:1273
+#: ../treebrowser/src/treebrowser.c:1275 ../treebrowser/src/treebrowser.c:1277
 #, fuzzy
 msgid "_Open Externally"
 msgstr "Open extern"
 
-#: ../treebrowser/src/treebrowser.c:1279
+#: ../treebrowser/src/treebrowser.c:1283
 #, fuzzy
 msgid "Open _Terminal"
 msgstr "Open terminalvenster"
 
-#: ../treebrowser/src/treebrowser.c:1284 ../treebrowser/src/treebrowser.c:1286
+#: ../treebrowser/src/treebrowser.c:1288 ../treebrowser/src/treebrowser.c:1290
 #, fuzzy
 msgid "Set as _Root"
 msgstr "Stel in als begin"
 
-#: ../treebrowser/src/treebrowser.c:1293 ../treebrowser/src/treebrowser.c:1295
+#: ../treebrowser/src/treebrowser.c:1297 ../treebrowser/src/treebrowser.c:1299
 #, fuzzy
 msgid "Refres_h"
 msgstr "Ververs"
 
-#: ../treebrowser/src/treebrowser.c:1301 ../treebrowser/src/treebrowser.c:1303
+#: ../treebrowser/src/treebrowser.c:1305 ../treebrowser/src/treebrowser.c:1307
 msgid "_Find in Files"
 msgstr "Zoek in bestanden"
 
-#: ../treebrowser/src/treebrowser.c:1313 ../treebrowser/src/treebrowser.c:1315
+#: ../treebrowser/src/treebrowser.c:1317 ../treebrowser/src/treebrowser.c:1319
 #, fuzzy
 msgid "N_ew Folder"
 msgstr "Selecteer een ondertekenaar"
 
-#: ../treebrowser/src/treebrowser.c:1321 ../treebrowser/src/treebrowser.c:1323
+#: ../treebrowser/src/treebrowser.c:1325 ../treebrowser/src/treebrowser.c:1327
 #, fuzzy
 msgid "_New File"
 msgstr "NieuwBestand"
 
-#: ../treebrowser/src/treebrowser.c:1329 ../treebrowser/src/treebrowser.c:1331
+#: ../treebrowser/src/treebrowser.c:1333 ../treebrowser/src/treebrowser.c:1335
 #, fuzzy
 msgid "Rena_me"
 msgstr "Hernoem"
 
-#: ../treebrowser/src/treebrowser.c:1350 ../treebrowser/src/treebrowser.c:1352
+#: ../treebrowser/src/treebrowser.c:1354 ../treebrowser/src/treebrowser.c:1356
 #, c-format
 msgid "Close: %s"
 msgstr "Sluit: %s"
 
-#: ../treebrowser/src/treebrowser.c:1359 ../treebrowser/src/treebrowser.c:1361
+#: ../treebrowser/src/treebrowser.c:1363 ../treebrowser/src/treebrowser.c:1365
 #, fuzzy, c-format
 msgid "Clo_se Child Documents "
 msgstr "Sluit "
 
-#: ../treebrowser/src/treebrowser.c:1368 ../treebrowser/src/treebrowser.c:1370
+#: ../treebrowser/src/treebrowser.c:1372 ../treebrowser/src/treebrowser.c:1374
 #, fuzzy
 msgid "_Copy Full Path to Clipboard"
 msgstr "Kopiëer volledig padnaam naar klembord"
 
-#: ../treebrowser/src/treebrowser.c:1381 ../treebrowser/src/treebrowser.c:1383
+#: ../treebrowser/src/treebrowser.c:1385 ../treebrowser/src/treebrowser.c:1387
 #, fuzzy
 msgid "E_xpand All"
 msgstr "Alles uitvouwen"
 
-#: ../treebrowser/src/treebrowser.c:1389 ../treebrowser/src/treebrowser.c:1391
+#: ../treebrowser/src/treebrowser.c:1393 ../treebrowser/src/treebrowser.c:1395
 #, fuzzy
 msgid "Coll_apse All"
 msgstr "Alles samenvouwen"
 
-#: ../treebrowser/src/treebrowser.c:1399
+#: ../treebrowser/src/treebrowser.c:1403
 #, fuzzy
 msgid "Show Boo_kmarks"
 msgstr "Laat bladwijzers zien"
 
-#: ../treebrowser/src/treebrowser.c:1404
+#: ../treebrowser/src/treebrowser.c:1408
 #, fuzzy
 msgid "Sho_w Hidden Files"
 msgstr "Laat verborgen bestanden zien"
 
-#: ../treebrowser/src/treebrowser.c:1409
+#: ../treebrowser/src/treebrowser.c:1413
 #, fuzzy
 msgid "Show Tool_bars"
 msgstr "Laat balk met hulpmiddelen zien"
 
-#: ../treebrowser/src/treebrowser.c:1747
+#: ../treebrowser/src/treebrowser.c:1751
 #, c-format
 msgid "Target file '%s' exists, do you really want to replace it?"
 msgstr "Doelbestand '%s' bestaat, wil je het echt vervangen?"
 
-#: ../treebrowser/src/treebrowser.c:1883
+#: ../treebrowser/src/treebrowser.c:1887
 msgid "Go up"
 msgstr "Ga naar boven"
 
-#: ../treebrowser/src/treebrowser.c:1893 ../treebrowser/src/treebrowser.c:2360
+#: ../treebrowser/src/treebrowser.c:1897 ../treebrowser/src/treebrowser.c:2365
 msgid "Refresh"
 msgstr "Ververs"
 
-#: ../treebrowser/src/treebrowser.c:1903
+#: ../treebrowser/src/treebrowser.c:1907
 msgid "Home"
 msgstr "Thuis"
 
-#: ../treebrowser/src/treebrowser.c:1913
+#: ../treebrowser/src/treebrowser.c:1917
 msgid "Set path from document"
 msgstr "Zet pad van document"
 
-#: ../treebrowser/src/treebrowser.c:1923
+#: ../treebrowser/src/treebrowser.c:1927
 msgid "Track path"
 msgstr "Volg pad"
 
-#: ../treebrowser/src/treebrowser.c:1933
+#: ../treebrowser/src/treebrowser.c:1937
 msgid "Hide bars"
 msgstr "Verberg balken"
 
-#: ../treebrowser/src/treebrowser.c:1943
+#: ../treebrowser/src/treebrowser.c:1947
 msgid ""
 "Filter (*.c;*.h;*.cpp), and if you want temporary filter using the '!' "
 "reverse try for example this '!;*.c;*.h;*.cpp'"
@@ -7514,20 +7284,20 @@ msgstr ""
 "Filter (*.c;*.h;*.cpp), en als je tijdelijk andersom wilt filteren gebruik "
 "'!' zoals bijvoorbeeld '!;*.c;*.h;*.cpp'"
 
-#: ../treebrowser/src/treebrowser.c:1948
+#: ../treebrowser/src/treebrowser.c:1952
 msgid "Addressbar for example '/projects/my-project'"
 msgstr "Adresregel, bijvoorbeeld '/projecten/mijn-project'"
 
-#: ../treebrowser/src/treebrowser.c:1973
+#: ../treebrowser/src/treebrowser.c:1977
 msgid "Tree Browser"
 msgstr "Bestandsboom"
 
-#: ../treebrowser/src/treebrowser.c:2114
+#: ../treebrowser/src/treebrowser.c:2118
 msgid "External open command"
 msgstr "Extern commando op te openen"
 
-#: ../treebrowser/src/treebrowser.c:2124
-#, c-format
+#: ../treebrowser/src/treebrowser.c:2129
+#, no-c-format
 msgid ""
 "The command to execute when using \"Open with\". You can use %f and %d "
 "wildcards.\n"
@@ -7540,59 +7310,59 @@ msgstr ""
 "%f zal vervangen worden door de bestandsnaam inclusief volledig pad\n"
 "%d zal vervangen worden door slechts de padnaam van de geselecteerde bestand."
 
-#: ../treebrowser/src/treebrowser.c:2143
+#: ../treebrowser/src/treebrowser.c:2148
 msgid "The terminal to use with the command \"Open Terminal\""
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2149
+#: ../treebrowser/src/treebrowser.c:2154
 msgid "Toolbar"
 msgstr "Hulpmiddelenbalk"
 
-#: ../treebrowser/src/treebrowser.c:2151
+#: ../treebrowser/src/treebrowser.c:2156
 msgid "Hidden"
 msgstr "Verborgen"
 
-#: ../treebrowser/src/treebrowser.c:2152
+#: ../treebrowser/src/treebrowser.c:2157
 msgid "Top"
 msgstr "Bovenaan"
 
-#: ../treebrowser/src/treebrowser.c:2153
+#: ../treebrowser/src/treebrowser.c:2158
 msgid "Bottom"
 msgstr "Onderaan"
 
-#: ../treebrowser/src/treebrowser.c:2158
+#: ../treebrowser/src/treebrowser.c:2163
 msgid "If position is changed, the option require plugin restart."
 msgstr "De plug-in moet herstart worden als de positie gewijzigd is."
 
-#: ../treebrowser/src/treebrowser.c:2162
+#: ../treebrowser/src/treebrowser.c:2167
 msgid "Show icons"
 msgstr "Laat pictogrammen zien"
 
-#: ../treebrowser/src/treebrowser.c:2164
+#: ../treebrowser/src/treebrowser.c:2169
 msgid "None"
 msgstr "Geen"
 
-#: ../treebrowser/src/treebrowser.c:2165
+#: ../treebrowser/src/treebrowser.c:2170
 msgid "Base"
 msgstr "Basis"
 
-#: ../treebrowser/src/treebrowser.c:2166
+#: ../treebrowser/src/treebrowser.c:2171
 msgid "Content-type"
 msgstr "Inhouds-type"
 
-#: ../treebrowser/src/treebrowser.c:2172
+#: ../treebrowser/src/treebrowser.c:2177
 msgid "Show hidden files"
 msgstr "Laat verborgen bestanden zien"
 
-#: ../treebrowser/src/treebrowser.c:2181
+#: ../treebrowser/src/treebrowser.c:2186
 msgid "On Windows, this just hide files that are prefixed with '.' (dot)"
 msgstr "Dit verbergt bestanden, in Windows, die beginnen met een '.' (punt)"
 
-#: ../treebrowser/src/treebrowser.c:2183
+#: ../treebrowser/src/treebrowser.c:2188
 msgid "Hide object files"
 msgstr "Verberg object bestanden"
 
-#: ../treebrowser/src/treebrowser.c:2192
+#: ../treebrowser/src/treebrowser.c:2197
 msgid ""
 "Don't show generated object files in the file browser, this includes *.o, *."
 "obj. *.so, *.dll, *.a, *.lib"
@@ -7600,61 +7370,61 @@ msgstr ""
 "Laat geen gegenereerde object bestanden zien in de bestandsbrowser, "
 "waaronder *.o, *.obj. *.so, *.dll, *.a, *.lib"
 
-#: ../treebrowser/src/treebrowser.c:2194
+#: ../treebrowser/src/treebrowser.c:2199
 msgid "Reverse filter"
 msgstr "Keer filter om"
 
-#: ../treebrowser/src/treebrowser.c:2203
+#: ../treebrowser/src/treebrowser.c:2208
 msgid "Follow current document"
 msgstr "Volg huidige directory"
 
-#: ../treebrowser/src/treebrowser.c:2212
+#: ../treebrowser/src/treebrowser.c:2217
 msgid "Single click, open document and focus it"
 msgstr "Enkele klik, open document en zet op de voorgrond"
 
-#: ../treebrowser/src/treebrowser.c:2221
+#: ../treebrowser/src/treebrowser.c:2226
 msgid "Double click open directory"
 msgstr "Dubbelklik, open map"
 
-#: ../treebrowser/src/treebrowser.c:2230
+#: ../treebrowser/src/treebrowser.c:2235
 msgid "On delete file, close it if is opened"
 msgstr "Sluit bestand af wanneer het wordt verwijderd en nog geopend is."
 
-#: ../treebrowser/src/treebrowser.c:2239
+#: ../treebrowser/src/treebrowser.c:2244
 msgid "Focus editor on file open"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2248
+#: ../treebrowser/src/treebrowser.c:2253
 msgid "Show tree lines"
 msgstr "Laat regels van boom zien"
 
-#: ../treebrowser/src/treebrowser.c:2257
+#: ../treebrowser/src/treebrowser.c:2262
 msgid "Show bookmarks"
 msgstr "Laat bladwijzers zien"
 
-#: ../treebrowser/src/treebrowser.c:2266
+#: ../treebrowser/src/treebrowser.c:2271
 #, fuzzy
 msgid "Open new files"
 msgstr "Creër nieuw bestand"
 
-#: ../treebrowser/src/treebrowser.c:2350
+#: ../treebrowser/src/treebrowser.c:2355
 msgid "Focus File List"
 msgstr "Zet bestandslijst op voorgrond"
 
-#: ../treebrowser/src/treebrowser.c:2352
+#: ../treebrowser/src/treebrowser.c:2357
 msgid "Focus Path Entry"
 msgstr "Zet pad entry op voorgrond"
 
-#: ../treebrowser/src/treebrowser.c:2354
+#: ../treebrowser/src/treebrowser.c:2359
 msgid "Rename Object"
 msgstr "Hernoem object"
 
-#: ../treebrowser/src/treebrowser.c:2358
+#: ../treebrowser/src/treebrowser.c:2363
 #, fuzzy
 msgid "New Folder"
 msgstr "Selecteer een ondertekenaar"
 
-#: ../treebrowser/src/treebrowser.c:2362
+#: ../treebrowser/src/treebrowser.c:2367
 #, fuzzy
 msgid "Track Current"
 msgstr "Volg pad"
@@ -8349,13 +8119,6 @@ msgstr "NieuweMap"
 msgid "No workbench opened."
 msgstr ""
 
-#: ../workbench/src/sidebar.c:875
-#, fuzzy, c-format
-msgid "%s: %u Project"
-msgid_plural "%s: %u Projects"
-msgstr[0] "Nieuw project"
-msgstr[1] "Nieuw project"
-
 #: ../workbench/src/sidebar.c:886
 msgid ""
 "Add a project using the context menu\n"
@@ -8460,6 +8223,97 @@ msgstr "XML Snippers"
 #: ../xmlsnippets/src/plugin.c:45
 msgid "Autocompletes XML/HTML tags using snippets."
 msgstr "Completeerd automatisch XML/HTML labels."
+
+#, fuzzy
+#~ msgid "_Removed lines:"
+#~ msgstr "Verwijder bestand"
+
+#, fuzzy
+#~ msgid "Position on left"
+#~ msgstr "Zet op een regel"
+
+#, fuzzy
+#~ msgid "Hide tooltip"
+#~ msgstr "Laat balk met hulpmiddelen zien"
+
+#~ msgid "_Translation Helper"
+#~ msgstr "Vertalingshulp"
+
+#~ msgid "_Previous String"
+#~ msgstr "Vorige string"
+
+#~ msgid "_Next String"
+#~ msgstr "Volgende string"
+
+#~ msgid "Pre_vious Untranslated"
+#~ msgstr "Vorige onvertaalde string"
+
+#~ msgid "Next _Untranslated"
+#~ msgstr "Volgende onvertaalde string"
+
+#~ msgid "Previous Fu_zzy"
+#~ msgstr "Vorige onduidelijkheid"
+
+#~ msgid "Next _Fuzzy"
+#~ msgstr "Volgende onduidelijkheid"
+
+#~ msgid "Previous Untranslated or Fuzz_y"
+#~ msgstr "Vorige onvertaalde of onduidelijke string"
+
+#~ msgid "Next Untranslated _or Fuzzy"
+#~ msgstr "Volgende onvertaalde of onduidelijke string"
+
+#~ msgid "_Toggle Fuzziness"
+#~ msgstr "Zet (on)duidelijkheid"
+
+#~ msgid "Paste _Message as Translation"
+#~ msgstr "Plak bericht als vertaling"
+
+#~ msgid "Paste the original untranslated string to the translation"
+#~ msgstr "Plak de orginele onvertaalde string naar de vertaling"
+
+#~ msgid "_Show stats"
+#~ msgstr "Laat statistiek zien"
+
+#~ msgid ""
+#~ "Whether to update the translation headers (author, revision date, ...) "
+#~ "upon file save"
+#~ msgstr ""
+#~ "Of de vertalingsinformatie (auteur, revisiedatum, ...) aangepast moet "
+#~ "worden bij het wegschrijven"
+
+#~ msgid "Update _Headers Upon Save"
+#~ msgstr "Pas vertalingsinfo aan bij wegschrijven"
+
+#~ msgid "Translation statistics"
+#~ msgstr "Vertalingsstatistieken"
+
+#~ msgid "Choose a color for translated strings"
+#~ msgstr "Kies een kleur voor de vertaalde string"
+
+#~ msgid "Choose a color for fuzzily translated strings"
+#~ msgstr "Kies een kleur voor de onduidelijk vertaalde string"
+
+#~ msgid "Choose a color for untranslated strings"
+#~ msgstr "Kies een kleur voor de onvertaalde string"
+
+#~ msgid "Translated:"
+#~ msgstr "Vertaald:"
+
+#~ msgid "Fuzzy:"
+#~ msgstr "Onduidelijk:"
+
+#~ msgid "Untranslated:"
+#~ msgstr "Onvertaalde:"
+
+#~ msgid "Check spelling while typing"
+#~ msgstr "Controleer spelling gedurende het typen"
+
+#, fuzzy, c-format
+#~ msgid "%s: %u Project"
+#~ msgid_plural "%s: %u Projects"
+#~ msgstr[0] "Nieuw project"
+#~ msgstr[1] "Nieuw project"
 
 #, fuzzy
 #~ msgid "E_xpand all"

--- a/po/pt.po
+++ b/po/pt.po
@@ -8,8 +8,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Geany-Plugins 1.38\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-30 03:19+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/geany/geany/issues\n"
+"POT-Creation-Date: 2022-06-28 07:39+0200\n"
 "PO-Revision-Date: 2021-11-01 20:50+0000\n"
 "Last-Translator: Hugo Carvalho <hugokarvalho@hotmail.com>\n"
 "Language-Team: Português <translation-team-pt@lists.sourceforge.net>\n"
@@ -24,27 +24,27 @@ msgstr ""
 msgid "(Empty Line)"
 msgstr "(linha vazia)"
 
-#: ../addons/src/ao_bookmarklist.c:315
+#: ../addons/src/ao_bookmarklist.c:331
 msgid "_Remove Bookmark"
 msgstr "_Remover marcador"
 
 #. Translators: Number is meant at this point.
-#: ../addons/src/ao_bookmarklist.c:342
+#: ../addons/src/ao_bookmarklist.c:358
 msgid "No."
 msgstr "Nº."
 
-#: ../addons/src/ao_bookmarklist.c:350 ../devhelp/src/dhp-object.c:494
+#: ../addons/src/ao_bookmarklist.c:366 ../devhelp/src/dhp-object.c:494
 #: ../devhelp/devhelp/dh-window.c:1142
 msgid "Contents"
 msgstr "Conteúdo"
 
-#: ../addons/src/ao_bookmarklist.c:383 ../treebrowser/src/treebrowser.c:666
+#: ../addons/src/ao_bookmarklist.c:399 ../treebrowser/src/treebrowser.c:666
 #: ../webhelper/src/gwh-plugin.c:328
 msgid "Bookmarks"
 msgstr "Marcadores"
 
 #. complete update
-#: ../addons/src/ao_tasks.c:373 ../geanyvc/src/geanyvc.c:2679
+#: ../addons/src/ao_tasks.c:373 ../geanyvc/src/geanyvc.c:2730
 msgid "_Update"
 msgstr "Act_ualizar"
 
@@ -166,10 +166,10 @@ msgstr "Copiar a localização do actual documento para a área de transferênci
 #: ../addons/src/addons.c:364 ../autoclose/src/autoclose.c:920
 #: ../codenav/src/codenavigation.c:281 ../latex/src/latex.c:208
 #: ../latex/src/latex.c:293 ../geanyprj/src/geanyprj.c:176
-#: ../geanyvc/src/geanyvc.c:2079 ../geniuspaste/src/geniuspaste.c:336
+#: ../geanyvc/src/geanyvc.c:2130 ../geniuspaste/src/geniuspaste.c:336
 #: ../lineoperations/src/lo_prefs.c:58 ../sendmail/src/sendmail.c:128
 #: ../sendmail/src/sendmail.c:293 ../spellcheck/src/scplugin.c:124
-#: ../treebrowser/src/treebrowser.c:2102
+#: ../treebrowser/src/treebrowser.c:2106
 #: ../updatechecker/src/updatechecker.c:262
 msgid "Plugin configuration directory could not be created."
 msgstr "Não foi possível criar a pasta de configuração da extensão."
@@ -751,7 +751,7 @@ msgstr "~\"A carregar ficheiro destino.\\n\""
 msgid "Error loading file"
 msgstr "Erro ao carregar ficheiro"
 
-#. setting asyncronous mode
+#. setting asynchronous mode
 #. setting null-stop array printing
 #. enable pretty printing
 #: ../debugger/src/dbm_gdb.c:789 ../debugger/src/dbm_gdb.c:792
@@ -1155,7 +1155,7 @@ msgid "A developers' help browser for GNOME"
 msgstr "Um navegador de ajuda ao programador para GNOME"
 
 #. Create the current file Submenu
-#: ../devhelp/devhelp/dh-window.c:759 ../geanyvc/src/geanyvc.c:2660
+#: ../devhelp/devhelp/dh-window.c:759 ../geanyvc/src/geanyvc.c:2711
 msgid "_File"
 msgstr "_Ficheiro"
 
@@ -1189,11 +1189,11 @@ msgstr "Novo _separador"
 msgid "_Print…"
 msgstr "Im_primir…"
 
-#: ../devhelp/devhelp/dh-window.c:782 ../devhelp/devhelp/eggfindbar.c:342
+#: ../devhelp/devhelp/dh-window.c:782
 msgid "Find Next"
 msgstr "Localizar seguinte"
 
-#: ../devhelp/devhelp/dh-window.c:784 ../devhelp/devhelp/eggfindbar.c:329
+#: ../devhelp/devhelp/dh-window.c:784
 msgid "Find Previous"
 msgstr "Localizar anterior"
 
@@ -1380,7 +1380,7 @@ msgstr ""
 "Chamar o visualizador de documentação no símbolo actual. \n"
 "Esta extensão actualmente não é mantida. Quer ajudar a manter a extensão?"
 
-#: ../geanydoc/src/geanydoc.c:159 ../geanyvc/src/geanyvc.c:442
+#: ../geanydoc/src/geanydoc.c:159 ../geanyvc/src/geanyvc.c:448
 msgid "Could not parse the output of command"
 msgstr "Impossível processar a saída do comando"
 
@@ -1660,8 +1660,8 @@ msgstr "Impossível gravar a configuração: %s"
 #, c-format
 msgid "Failed to find configuration file for file type \"%s\": %s"
 msgstr ""
-"Falha ao encontrar o ficheiro de configuração para o tipo de ficheiro \"%s"
-"\": %s"
+"Falha ao encontrar o ficheiro de configuração para o tipo de ficheiro "
+"\"%s\": %s"
 
 #: ../geanygendoc/src/ggd-plugin.c:329
 msgid ""
@@ -3105,7 +3105,7 @@ msgstr ""
 "Erro no módulo \"%s\" na função %s():\n"
 "Faltam argumentos para o comando \"%s\".\n"
 
-#: ../geanylua/glspi_sci.c:637 ../geanylua/glspi_app.c:406
+#: ../geanylua/glspi_sci.c:729 ../geanylua/glspi_app.c:406
 #, c-format
 msgid ""
 "Error in module \"%s\" at function %s():\n"
@@ -3114,7 +3114,7 @@ msgstr ""
 "Erro no módulo \"%s\" na função %s():\n"
 "Comando desconhecido \"%s\" dado como argumento #1.\n"
 
-#: ../geanylua/glspi_sci.c:781
+#: ../geanylua/glspi_sci.c:924
 #, c-format
 msgid ""
 "Error in module \"%s\" at function %s():\n"
@@ -3125,7 +3125,7 @@ msgstr ""
 " Tabela inválida no argumento #%d:\n"
 " flag desconhecida \"%s\" para o elemento #%d\n"
 
-#: ../geanylua/glspi_sci.c:785
+#: ../geanylua/glspi_sci.c:928
 msgid "<too large to display>"
 msgstr "<demasiado longo para mostrar>"
 
@@ -3913,7 +3913,7 @@ msgid "New _Below"
 msgstr "Novo a_baixo"
 
 #: ../geanymacro/src/geanymacro.c:1824 ../geanymacro/src/geanymacro.c:2120
-#: ../treebrowser/src/treebrowser.c:1338 ../treebrowser/src/treebrowser.c:1340
+#: ../treebrowser/src/treebrowser.c:1342 ../treebrowser/src/treebrowser.c:1344
 msgid "_Delete"
 msgstr "_Eliminar"
 
@@ -4192,8 +4192,8 @@ msgstr ""
 "número de marcador ele é removido, senão move o marcador para aí se estiver "
 "definido noutra linha ou cria um novo se ainda não existir. Só será mostrado "
 "o marcador numerado mais recentemente definido, mas pode ter mais de um "
-"marcador por linha. Para mover um marcador anteriormente definido, prima Ctrl"
-"+nº de 0 a 9."
+"marcador por linha. Para mover um marcador anteriormente definido, prima "
+"Ctrl+nº de 0 a 9."
 
 #: ../geanynumberedbookmarks/src/geanynumberedbookmarks.c:1408
 msgid "Unable to apply markers as all being used."
@@ -4328,8 +4328,8 @@ msgstr ""
 msgid "a key with fingerprint"
 msgstr "uma chave com impressão digital"
 
-#: ../geanypg/src/verify_aux.c:66 ../spellcheck/src/gui.c:610
-#: ../spellcheck/src/gui.c:621
+#: ../geanypg/src/verify_aux.c:66 ../spellcheck/src/gui.c:607
+#: ../spellcheck/src/gui.c:618
 msgid "unknown"
 msgstr "desconhecido"
 
@@ -4642,49 +4642,49 @@ msgstr ""
 "Interface para diferentes sistemas de controlo de versões. \n"
 "Esta extensão actualmente não é mantida. Quer ajudar a manter a extensão?"
 
-#: ../geanyvc/src/geanyvc.c:501
+#: ../geanyvc/src/geanyvc.c:507
 #, c-format
 msgid "geanyvc: s_spawn_sync error: %s"
 msgstr "geanyvc:  erro s_spawn_sync: %s"
 
-#: ../geanyvc/src/geanyvc.c:587
+#: ../geanyvc/src/geanyvc.c:593
 #, c-format
 msgid "File %s: action %s executed via %s."
 msgstr "Ficheiro %s: acção %s executada via %s."
 
-#: ../geanyvc/src/geanyvc.c:646 ../geanyvc/src/geanyvc.c:657
-#, c-format
-msgid "geanyvc: vcdiff_file_activated: Unable to rename '%s' to '%s'"
+#: ../geanyvc/src/geanyvc.c:633 ../geanyvc/src/geanyvc.c:643
+#, fuzzy, c-format
+msgid "geanyvc: diff_external: Unable to rename '%s' to '%s'"
 msgstr "geanyvc: vcdiff_file_activated: impossível renomear \"%s\" para \"%s\""
 
-#: ../geanyvc/src/geanyvc.c:683 ../geanyvc/src/geanyvc.c:733
+#: ../geanyvc/src/geanyvc.c:698 ../geanyvc/src/geanyvc.c:784
 msgid "No changes were made."
 msgstr "Não foram efetuadas quaisquer alterações."
 
-#: ../geanyvc/src/geanyvc.c:760
+#: ../geanyvc/src/geanyvc.c:811
 msgid "No history available"
 msgstr "Nenhum histórico disponível"
 
-#: ../geanyvc/src/geanyvc.c:953 ../geanyvc/src/geanyvc.c:961
+#: ../geanyvc/src/geanyvc.c:1004 ../geanyvc/src/geanyvc.c:1012
 #, c-format
 msgid "Do you really want to revert: %s?"
 msgstr "Tem a certeza que quer reverter: %s?"
 
-#: ../geanyvc/src/geanyvc.c:969
+#: ../geanyvc/src/geanyvc.c:1020
 #, c-format
 msgid "Do you really want to add: %s?"
 msgstr "Tem a certeza que quer adicionar: %s?"
 
-#: ../geanyvc/src/geanyvc.c:976
+#: ../geanyvc/src/geanyvc.c:1027
 #, c-format
 msgid "Do you really want to remove: %s?"
 msgstr "Tem a certeza que quer remover: %s?"
 
-#: ../geanyvc/src/geanyvc.c:999
+#: ../geanyvc/src/geanyvc.c:1050
 msgid "Do you really want to update?"
 msgstr "Tem a certeza que quer actualizar?"
 
-#: ../geanyvc/src/geanyvc.c:1126
+#: ../geanyvc/src/geanyvc.c:1177
 msgid ""
 "The resulting differences cannot be displayed because the changes are too "
 "big to display here and would slow down the UI significantly.\n"
@@ -4698,48 +4698,48 @@ msgstr ""
 "Para ver as diferenças, cancele o diálogo e abra as diferenças directamente "
 "no Geany usando o menu GeanyVC (pasta base -> Diff)."
 
-#: ../geanyvc/src/geanyvc.c:1280
+#: ../geanyvc/src/geanyvc.c:1331
 msgid "Commit Y/N"
 msgstr "Submeter S/N"
 
-#: ../geanyvc/src/geanyvc.c:1290
+#: ../geanyvc/src/geanyvc.c:1341
 msgid "Status"
 msgstr "Estado"
 
-#: ../geanyvc/src/geanyvc.c:1297
+#: ../geanyvc/src/geanyvc.c:1348
 msgid "Path"
 msgstr "Caminho"
 
-#: ../geanyvc/src/geanyvc.c:1414
+#: ../geanyvc/src/geanyvc.c:1465
 msgid "Choose a previous commit message"
 msgstr "Escolha uma mensagem de commit anterior"
 
-#: ../geanyvc/src/geanyvc.c:1476
+#: ../geanyvc/src/geanyvc.c:1527
 #, c-format
 msgid "Line: %d Column: %d"
 msgstr "Linha: %d coluna: %d"
 
-#: ../geanyvc/src/geanyvc.c:1523
+#: ../geanyvc/src/geanyvc.c:1574
 msgid "Commit"
 msgstr "Submeter"
 
-#: ../geanyvc/src/geanyvc.c:1564
+#: ../geanyvc/src/geanyvc.c:1615
 msgid "_De-/select all files"
 msgstr "Remover selecção/Seleccionar to_dos os ficheiros"
 
-#: ../geanyvc/src/geanyvc.c:1608
+#: ../geanyvc/src/geanyvc.c:1659
 msgid "<b>Commit message:</b>"
 msgstr "<b>Mensagem de submissão:</b>"
 
-#: ../geanyvc/src/geanyvc.c:1632
+#: ../geanyvc/src/geanyvc.c:1683
 msgid "C_ommit"
 msgstr "_Submeter"
 
-#: ../geanyvc/src/geanyvc.c:1740
+#: ../geanyvc/src/geanyvc.c:1791
 msgid "Nothing to commit."
 msgstr "Nada para submeter."
 
-#: ../geanyvc/src/geanyvc.c:1788
+#: ../geanyvc/src/geanyvc.c:1839
 #, c-format
 msgid ""
 "Error initializing GeanyVC spell checking: %s. Check your configuration."
@@ -4747,26 +4747,26 @@ msgstr ""
 "Falha ao inicializar a correcção ortográfica GeanyVC: %s. Verifique a sua "
 "configuração."
 
-#: ../geanyvc/src/geanyvc.c:1823
+#: ../geanyvc/src/geanyvc.c:1874
 #, c-format
 msgid "Commit failed (status: %d, error: %s)."
 msgstr "Falha ao submeter (estado: %d, erro: %s)."
 
-#: ../geanyvc/src/geanyvc.c:1824
+#: ../geanyvc/src/geanyvc.c:1875
 msgid "Commit failed; see status in the Message window."
 msgstr "Falha ao submeter; veja o estado na janela de mensagens."
 
-#: ../geanyvc/src/geanyvc.c:1829
+#: ../geanyvc/src/geanyvc.c:1880
 msgid "Changes committed."
 msgstr "Alterações submetidas."
 
-#: ../geanyvc/src/geanyvc.c:2151
+#: ../geanyvc/src/geanyvc.c:2202
 msgid "Set Changed-flag for document tabs created by the plugin"
 msgstr ""
 "Definir estado Modificado nos separadores dos documentos criados pela "
 "extensão"
 
-#: ../geanyvc/src/geanyvc.c:2154
+#: ../geanyvc/src/geanyvc.c:2205
 msgid ""
 "If this option is activated, every new by the VC-plugin created document tab "
 "will be marked as changed. Even this option is useful in some cases, it "
@@ -4777,46 +4777,46 @@ msgstr ""
 "gerar um elevado número de irritantes diálogos \"Tem a certeza que quer "
 "gravar?\"."
 
-#: ../geanyvc/src/geanyvc.c:2162
+#: ../geanyvc/src/geanyvc.c:2213
 msgid "Confirm adding new files to a VCS"
 msgstr "Confirmar adicionar novos ficheiros a um SCV"
 
-#: ../geanyvc/src/geanyvc.c:2165
+#: ../geanyvc/src/geanyvc.c:2216
 msgid "Shows a confirmation dialog on adding a new (created) file to VCS."
 msgstr ""
 "Mostra um diálogo de confirmação ao adicionar um novo (criado) ficheiro ao "
 "SCV."
 
-#: ../geanyvc/src/geanyvc.c:2171
+#: ../geanyvc/src/geanyvc.c:2222
 msgid "Maximize commit dialog"
 msgstr "Maximizar janela de submissão"
 
-#: ../geanyvc/src/geanyvc.c:2172
+#: ../geanyvc/src/geanyvc.c:2223
 msgid "Show commit dialog maximize."
 msgstr "Mostra a janela de submissão maximizada."
 
-#: ../geanyvc/src/geanyvc.c:2178
+#: ../geanyvc/src/geanyvc.c:2229
 msgid "Use external diff viewer"
 msgstr "Usar aplicação de diferenças externa"
 
-#: ../geanyvc/src/geanyvc.c:2180
+#: ../geanyvc/src/geanyvc.c:2231
 msgid "Use external diff viewer for file diff."
 msgstr ""
 "Usar uma aplicação de diferenças externa para ver diferenças entre ficheiros."
 
-#: ../geanyvc/src/geanyvc.c:2186
+#: ../geanyvc/src/geanyvc.c:2237
 msgid "Show VC entries at editor menu"
 msgstr "Mostrar entrada do CV no menu do editor"
 
-#: ../geanyvc/src/geanyvc.c:2188
+#: ../geanyvc/src/geanyvc.c:2239
 msgid "Show entries for VC functions inside editor menu"
 msgstr "Mostra entradas das funções do VC dentro do menu do editor"
 
-#: ../geanyvc/src/geanyvc.c:2193
+#: ../geanyvc/src/geanyvc.c:2244
 msgid "Attach menu to menubar"
 msgstr "Anexar menu à barra de menus"
 
-#: ../geanyvc/src/geanyvc.c:2195
+#: ../geanyvc/src/geanyvc.c:2246
 msgid ""
 "Whether menu for this plugin are getting placed either inside tools menu or "
 "directly inside Geany's menubar. Will take in account after next start of "
@@ -4826,215 +4826,215 @@ msgstr ""
 "na barra de menus do Geany. Será tido em conta no arranque seguinte do "
 "GeanyVC"
 
-#: ../geanyvc/src/geanyvc.c:2203
+#: ../geanyvc/src/geanyvc.c:2254
 msgid "Enable CVS"
 msgstr "Activar SCV"
 
-#: ../geanyvc/src/geanyvc.c:2208
+#: ../geanyvc/src/geanyvc.c:2259
 msgid "Enable GIT"
 msgstr "Activar GIT"
 
-#: ../geanyvc/src/geanyvc.c:2213
+#: ../geanyvc/src/geanyvc.c:2264
 msgid "Enable Fossil"
 msgstr "Activar Fossil"
 
-#: ../geanyvc/src/geanyvc.c:2218
+#: ../geanyvc/src/geanyvc.c:2269
 msgid "Enable SVN"
 msgstr "Activar SVN"
 
-#: ../geanyvc/src/geanyvc.c:2223
+#: ../geanyvc/src/geanyvc.c:2274
 msgid "Enable SVK"
 msgstr "Activar SVK"
 
-#: ../geanyvc/src/geanyvc.c:2228
+#: ../geanyvc/src/geanyvc.c:2279
 msgid "Enable Bazaar"
 msgstr "Activar Bazaar"
 
-#: ../geanyvc/src/geanyvc.c:2233
+#: ../geanyvc/src/geanyvc.c:2284
 msgid "Enable Mercurial"
 msgstr "Activar Mercurial"
 
-#: ../geanyvc/src/geanyvc.c:2239
+#: ../geanyvc/src/geanyvc.c:2290
 msgid "Spellcheck language"
 msgstr "Idioma para correcção ortográfica"
 
 #. Diff of current file
 #. Diff of the current dir
 #. Complete diff of base directory
-#: ../geanyvc/src/geanyvc.c:2368 ../geanyvc/src/geanyvc.c:2463
-#: ../geanyvc/src/geanyvc.c:2503
+#: ../geanyvc/src/geanyvc.c:2419 ../geanyvc/src/geanyvc.c:2514
+#: ../geanyvc/src/geanyvc.c:2554
 msgid "_Diff"
 msgstr "_Diferenças"
 
-#: ../geanyvc/src/geanyvc.c:2371
+#: ../geanyvc/src/geanyvc.c:2422
 msgid "Make a diff from the current active file"
 msgstr "Inicia uma comparação de diferenças no ficheiro activo"
 
 #. Revert current file
 #. Revert current dir
 #. Revert everything
-#: ../geanyvc/src/geanyvc.c:2376 ../geanyvc/src/geanyvc.c:2472
-#: ../geanyvc/src/geanyvc.c:2511
+#: ../geanyvc/src/geanyvc.c:2427 ../geanyvc/src/geanyvc.c:2523
+#: ../geanyvc/src/geanyvc.c:2562
 msgid "_Revert"
 msgstr "_Reverter"
 
-#: ../geanyvc/src/geanyvc.c:2379
+#: ../geanyvc/src/geanyvc.c:2430
 msgid "Restore pristine working copy file (undo local edits)."
 msgstr ""
 "Restaurar a antiga cópia original do ficheiro (descarta alterações locais)."
 
 #. Blame for current file
-#: ../geanyvc/src/geanyvc.c:2388
+#: ../geanyvc/src/geanyvc.c:2439
 msgid "_Blame"
 msgstr "_Culpar"
 
-#: ../geanyvc/src/geanyvc.c:2391
+#: ../geanyvc/src/geanyvc.c:2442
 msgid "Shows the changes made at one file per revision and author."
 msgstr "Mostra as alterações realizadas a um ficheiro por revisão e autor."
 
 #. History/log of current file
 #. History/log of the current dir
 #. Complete History/Log of base directory
-#: ../geanyvc/src/geanyvc.c:2398 ../geanyvc/src/geanyvc.c:2482
-#: ../geanyvc/src/geanyvc.c:2523
+#: ../geanyvc/src/geanyvc.c:2449 ../geanyvc/src/geanyvc.c:2533
+#: ../geanyvc/src/geanyvc.c:2574
 msgid "_History (log)"
 msgstr "_Histórico (diário)"
 
-#: ../geanyvc/src/geanyvc.c:2401
+#: ../geanyvc/src/geanyvc.c:2452
 msgid "Shows the log of the current file"
 msgstr "Mostra o histórico do ficheiro activo"
 
 #. base version of the current file
-#: ../geanyvc/src/geanyvc.c:2406
+#: ../geanyvc/src/geanyvc.c:2457
 msgid "_Original"
 msgstr "_Original"
 
-#: ../geanyvc/src/geanyvc.c:2409
+#: ../geanyvc/src/geanyvc.c:2460
 msgid "Shows the original of the current file"
 msgstr "Mostra o original do ficheiro activo"
 
 #. add current file
-#: ../geanyvc/src/geanyvc.c:2417
+#: ../geanyvc/src/geanyvc.c:2468
 msgid "_Add to Version Control"
 msgstr "_Adicionar ao controlo de versão"
 
-#: ../geanyvc/src/geanyvc.c:2419
+#: ../geanyvc/src/geanyvc.c:2470
 msgid "Add file to repository."
 msgstr "Adiciona o ficheiro ao repositório."
 
 #. remove current file
-#: ../geanyvc/src/geanyvc.c:2425
+#: ../geanyvc/src/geanyvc.c:2476
 msgid "_Remove from Version Control"
 msgstr "_Remover do controlo de versão"
 
-#: ../geanyvc/src/geanyvc.c:2427
+#: ../geanyvc/src/geanyvc.c:2478
 msgid "Remove file from repository."
 msgstr "Remove o ficheiro do repositório."
 
-#: ../geanyvc/src/geanyvc.c:2460
+#: ../geanyvc/src/geanyvc.c:2511
 msgid "_Directory"
 msgstr "_Pasta"
 
-#: ../geanyvc/src/geanyvc.c:2466
+#: ../geanyvc/src/geanyvc.c:2517
 msgid "Make a diff from the directory of the current active file"
 msgstr "Inicia uma comparação de diferenças na pasta do ficheiro activo"
 
-#: ../geanyvc/src/geanyvc.c:2475
+#: ../geanyvc/src/geanyvc.c:2526
 msgid "Restore original files in the current folder (undo local edits)."
 msgstr ""
 "Restaura os ficheiros originais na pasta actual (descarta alterações locais)."
 
-#: ../geanyvc/src/geanyvc.c:2485
+#: ../geanyvc/src/geanyvc.c:2536
 msgid "Shows the log of the current directory"
 msgstr "Mostra o diário da pasta actual"
 
-#: ../geanyvc/src/geanyvc.c:2499
+#: ../geanyvc/src/geanyvc.c:2550
 msgid "_Base Directory"
 msgstr "Pasta _base"
 
-#: ../geanyvc/src/geanyvc.c:2505
+#: ../geanyvc/src/geanyvc.c:2556
 msgid "Make a diff from the top VC directory"
 msgstr "Inicia uma comparação de diferenças a partir da primeira pasta do CV"
 
-#: ../geanyvc/src/geanyvc.c:2513
+#: ../geanyvc/src/geanyvc.c:2564
 msgid "Revert any local edits."
 msgstr "Reverte quaisquer alterações locais."
 
-#: ../geanyvc/src/geanyvc.c:2526
+#: ../geanyvc/src/geanyvc.c:2577
 msgid "Shows the log of the top VC directory"
 msgstr "Mostra o diário da primeira pasta do CV"
 
-#: ../geanyvc/src/geanyvc.c:2543
+#: ../geanyvc/src/geanyvc.c:2594
 msgid "_VC file Actions"
 msgstr "Acções C_V sobre ficheiros"
 
-#: ../geanyvc/src/geanyvc.c:2552
+#: ../geanyvc/src/geanyvc.c:2603
 msgid "VC _Commit..."
 msgstr "_Submeter CV..."
 
-#: ../geanyvc/src/geanyvc.c:2596
+#: ../geanyvc/src/geanyvc.c:2647
 msgid "Show diff of file"
 msgstr "Mostrar diferenças do ficheiro"
 
-#: ../geanyvc/src/geanyvc.c:2598
+#: ../geanyvc/src/geanyvc.c:2649
 msgid "Show diff of directory"
 msgstr "Mostrar diferenças da pasta"
 
-#: ../geanyvc/src/geanyvc.c:2600
+#: ../geanyvc/src/geanyvc.c:2651
 msgid "Show diff of basedir"
 msgstr "Mostrar diferenças da pasta base"
 
-#: ../geanyvc/src/geanyvc.c:2603
+#: ../geanyvc/src/geanyvc.c:2654
 msgid "Commit changes"
 msgstr "Submeter alterações"
 
-#: ../geanyvc/src/geanyvc.c:2605
+#: ../geanyvc/src/geanyvc.c:2656
 msgid "Show status"
 msgstr "Mostrar estado"
 
-#: ../geanyvc/src/geanyvc.c:2607
+#: ../geanyvc/src/geanyvc.c:2658
 msgid "Revert single file"
 msgstr "Reverter ficheiro único"
 
-#: ../geanyvc/src/geanyvc.c:2609
+#: ../geanyvc/src/geanyvc.c:2660
 msgid "Revert directory"
 msgstr "Reverter pasta"
 
-#: ../geanyvc/src/geanyvc.c:2611
+#: ../geanyvc/src/geanyvc.c:2662
 msgid "Revert base directory"
 msgstr "Reverter pasta base"
 
-#: ../geanyvc/src/geanyvc.c:2613
+#: ../geanyvc/src/geanyvc.c:2664
 msgid "Update file"
 msgstr "Actualizar ficheiro"
 
-#: ../geanyvc/src/geanyvc.c:2643
+#: ../geanyvc/src/geanyvc.c:2694
 msgid "_VC"
 msgstr "C_V"
 
-#: ../geanyvc/src/geanyvc.c:2650
+#: ../geanyvc/src/geanyvc.c:2701
 msgid "_Version Control"
 msgstr "Controlo de _versão"
 
 #. Status of basedir
-#: ../geanyvc/src/geanyvc.c:2672
+#: ../geanyvc/src/geanyvc.c:2723
 msgid "_Status"
 msgstr "E_stado"
 
-#: ../geanyvc/src/geanyvc.c:2674
+#: ../geanyvc/src/geanyvc.c:2725
 msgid "Show status."
 msgstr "Mostrar estado."
 
-#: ../geanyvc/src/geanyvc.c:2681
+#: ../geanyvc/src/geanyvc.c:2732
 msgid "Update from remote repository."
 msgstr "Actualizar a partir de repositório remoto."
 
 #. Commit all changes
-#: ../geanyvc/src/geanyvc.c:2686
+#: ../geanyvc/src/geanyvc.c:2737
 msgid "_Commit..."
 msgstr "_Submeter..."
 
-#: ../geanyvc/src/geanyvc.c:2688
+#: ../geanyvc/src/geanyvc.c:2739
 msgid "Commit changes."
 msgstr "Submeter alterações."
 
@@ -5159,36 +5159,6 @@ msgstr "Mostrar a sua colagem num novo separador do navegador"
 #: ../geniuspaste/src/geniuspaste.c:959
 msgid "_Paste it!"
 msgstr "C_olar!"
-
-#: ../git-changebar/data/prefs.ui.h:1
-msgid "_Monitor repository for changes"
-msgstr "_Monitorizar alterações no repositório"
-
-#: ../git-changebar/data/prefs.ui.h:2
-msgid ""
-"Whether to automatically update the diff in order to maintain it up to date "
-"when the underlying Git repository changes.  This should generally be "
-"enabled for optimal user experience."
-msgstr ""
-"Se actualiza as diferenças automaticamente ao haver alterações subjacentes "
-"no repositório Git. Por norma isto deve estar activado para uma experiência "
-"de utilização optimizada."
-
-#: ../git-changebar/data/prefs.ui.h:3
-msgid "_Added lines:"
-msgstr "Linhas _adicionadas:"
-
-#: ../git-changebar/data/prefs.ui.h:4
-msgid "_Changed lines:"
-msgstr "Linhas al_teradas:"
-
-#: ../git-changebar/data/prefs.ui.h:5
-msgid "_Removed lines:"
-msgstr "Linhas _removidas:"
-
-#: ../git-changebar/data/prefs.ui.h:6
-msgid "Colors"
-msgstr "Cores"
 
 #: ../git-changebar/src/gcb-plugin.c:62
 msgid "Git Change Bar"
@@ -5378,8 +5348,8 @@ msgstr ""
 #: ../lipsum/src/lipsum.c:184 ../sendmail/src/sendmail.c:396
 #, c-format
 msgid ""
-"Your configuration directory has been successfully moved from \"%s\" to \"%s"
-"\"."
+"Your configuration directory has been successfully moved from \"%s\" to "
+"\"%s\"."
 msgstr ""
 "A sua pasta de configuração foi movida com sucesso de \"%s\" para \"%s\"."
 
@@ -5389,8 +5359,8 @@ msgid ""
 "Your old configuration directory \"%s\" could not be moved to \"%s\" (%s). "
 "Please manually move the directory to the new location."
 msgstr ""
-"A sua pasta de configuração antiga \"%s\" não pôde ser movida para \"%s"
-"\" (%s). Por favor, mova-a manualmente para a nova localização."
+"A sua pasta de configuração antiga \"%s\" não pôde ser movida para "
+"\"%s\" (%s). Por favor, mova-a manualmente para a nova localização."
 
 #: ../lipsum/src/lipsum.c:223 ../lipsum/src/lipsum.c:225
 msgid "_Lipsum..."
@@ -5545,7 +5515,7 @@ msgstr "Impossível escrever configuração predefinida: %s"
 msgid "Unable to read value for '%s' key: %s"
 msgstr "Impossível ler valor para \"%s\": %s"
 
-#: ../multiterm/src/tab-label.vala:62 ../treebrowser/src/treebrowser.c:2132
+#: ../multiterm/src/tab-label.vala:62 ../treebrowser/src/treebrowser.c:2137
 msgid "Terminal"
 msgstr "Terminal"
 
@@ -5583,131 +5553,6 @@ msgstr "Linha <b>%d</b>, coluna <b>%d</b>, posição <b>%d</b>"
 msgid "Show Overview"
 msgstr "Mostrar vista geral"
 
-#: ../overview/data/prefs.ui.h:1
-msgid ""
-"The amount to zoom the overview sidebar. This should probably negative if "
-"you want the sidebar zoomed out."
-msgstr ""
-"Quanto ampliar a barra lateral da vista geral. Provavelmente deve ser "
-"negativo se quiser a barra lateral reduzida."
-
-#: ../overview/data/prefs.ui.h:2
-msgid "Zoom Level:"
-msgstr "Factor de ampliação:"
-
-#: ../overview/data/prefs.ui.h:3
-msgid "The width of the overview sidebar."
-msgstr "A largura da barra lateral da vista geral."
-
-#: ../overview/data/prefs.ui.h:4
-msgid "Width:"
-msgstr "Largura:"
-
-#: ../overview/data/prefs.ui.h:5
-msgid ""
-"The number of lines to scroll at a time when scrolling the overview sidebar."
-msgstr ""
-"O número de linhas a rolar de uma só vez ao rolar a barra lateral da vista "
-"geral."
-
-#: ../overview/data/prefs.ui.h:6
-msgid "Scroll Lines:"
-msgstr "Rolar linhas:"
-
-#: ../overview/data/prefs.ui.h:7
-msgid "Position on left"
-msgstr "Posição à esquerda"
-
-#: ../overview/data/prefs.ui.h:8
-msgid ""
-"Position the overview bar on the left rather than the right (requires Geany "
-"1.25 or greater)."
-msgstr ""
-"Posicionar a barra de vista geral à esquerda em vez de à direita ( requer o "
-"Geany 1.25 ou superior)."
-
-#: ../overview/data/prefs.ui.h:9
-msgid "Hide tooltip"
-msgstr "Ocultar sugestão"
-
-#: ../overview/data/prefs.ui.h:10
-msgid ""
-"Hide the tooltip that is displayed when mousing over the overview that shows "
-"line, column and position information."
-msgstr ""
-"Ocultar a sugestão mostrada quando o rato paira sobre a vista geral, que "
-"informa sobre linha, coluna e posição."
-
-#: ../overview/data/prefs.ui.h:11
-msgid "Hide editor scrollbar"
-msgstr "Ocultar barra de rolamento do editor"
-
-#: ../overview/data/prefs.ui.h:12
-msgid ""
-"Whether to hide Geany's regular editor scrollbar while the overview bar is "
-"visible."
-msgstr ""
-"Se deve ocultar a barra de rolamento do editor normal do Geany enquanto a "
-"barra de vista geral está visível."
-
-#: ../overview/data/prefs.ui.h:13
-msgid "Disable overlay"
-msgstr "Desactivar cobertura"
-
-#: ../overview/data/prefs.ui.h:14
-msgid ""
-"Turn off drawing overlay, which shows the region of the main editor view "
-"that is currently in view, ontop of the overview bar."
-msgstr ""
-"Desligar o desenho da cobertura, o que mostra a região da vista do editor "
-"principal actual, no topo da barra de vista geral."
-
-#: ../overview/data/prefs.ui.h:15 ../scope/data/scope.glade.h:130
-#: ../scope/data/scope_gtk3.glade.h:130
-msgid "Options"
-msgstr "Opções"
-
-#: ../overview/data/prefs.ui.h:16
-msgid ""
-"The color and opacity of the overlay drawn ontop of the overlay sidebar."
-msgstr ""
-"A cor e opacidade da cobertura desenhada no topo da barra lateral da "
-"cobertura."
-
-#: ../overview/data/prefs.ui.h:17
-msgid "Color:"
-msgstr "Cor:"
-
-#: ../overview/data/prefs.ui.h:18
-msgid ""
-"The color and opacity of the border drawn around the revealed area in the "
-"overview sidebar. Set to the same as Overlay Color to disable."
-msgstr ""
-"A cor e opacidade do contorno desenhado à volta da área revelada na barra de "
-"visão geral. Defina como igual à cor de sobreposição para desactivar."
-
-#: ../overview/data/prefs.ui.h:19
-msgid "Outline Color:"
-msgstr "Cor de realce:"
-
-#: ../overview/data/prefs.ui.h:20
-msgid "Draw over visible area"
-msgstr "Desenhar sobre a parte visível"
-
-#: ../overview/data/prefs.ui.h:21
-msgid ""
-"When checked it will draw the overlay ontop of the area that is visible in "
-"the main editor view, when unchecked, it will do the opposite and draw the "
-"overlay everywhere but the visible area, \"revealing\" the visible part."
-msgstr ""
-"Quando marcada, desenha a cobertura por cima da área visível na vista "
-"principal do editor. Sem marcação faz o oposto, desenha a cobertura em todo "
-"o lado menos na área visível, \"revelando\" a parte visível."
-
-#: ../overview/data/prefs.ui.h:22
-msgid "Overlay"
-msgstr "Cobertura"
-
 #: ../pairtaghighlighter/src/pair_tag_highlighter.c:43
 msgid "Pair Tag Highlighter"
 msgstr "Realce de par de etiquetas"
@@ -5731,146 +5576,6 @@ msgstr "Ir até à etiqueta correspondente"
 #: ../pairtaghighlighter/src/pair_tag_highlighter.c:504
 msgid "Select To Matching Tag"
 msgstr "Seleccionar até à etiqueta correspondente"
-
-#: ../pohelper/data/menus.ui.h:1
-msgid "_Translation Helper"
-msgstr "Auxiliar de _tradução"
-
-#: ../pohelper/data/menus.ui.h:2
-msgid "_Previous String"
-msgstr "Cadeia _anterior"
-
-#: ../pohelper/data/menus.ui.h:3 ../pohelper/src/gph-plugin.c:1590
-msgid "Go to previous string"
-msgstr "Ir para a cadeia anterior"
-
-#: ../pohelper/data/menus.ui.h:4
-msgid "_Next String"
-msgstr "Cadeia segui_nte"
-
-#: ../pohelper/data/menus.ui.h:5 ../pohelper/src/gph-plugin.c:1593
-msgid "Go to next string"
-msgstr "Ir para a cadeia seguinte"
-
-#: ../pohelper/data/menus.ui.h:6
-msgid "Pre_vious Untranslated"
-msgstr "Não _traduzida anterior"
-
-#: ../pohelper/data/menus.ui.h:7 ../pohelper/src/gph-plugin.c:1596
-msgid "Go to previous untranslated string"
-msgstr "Ir para a cadeia não traduzida anterior"
-
-#: ../pohelper/data/menus.ui.h:8
-msgid "Next _Untranslated"
-msgstr "Não traduzida _seguinte"
-
-#: ../pohelper/data/menus.ui.h:9 ../pohelper/src/gph-plugin.c:1599
-msgid "Go to next untranslated string"
-msgstr "Ir para a cadeia não traduzida seguinte"
-
-#: ../pohelper/data/menus.ui.h:10
-msgid "Previous Fu_zzy"
-msgstr "_Confusa anterior"
-
-#: ../pohelper/data/menus.ui.h:11 ../pohelper/src/gph-plugin.c:1602
-msgid "Go to previous fuzzily translated string"
-msgstr "Ir para a cadeia com tradução confusa anterior"
-
-#: ../pohelper/data/menus.ui.h:12
-msgid "Next _Fuzzy"
-msgstr "Con_fusa seguinte"
-
-#: ../pohelper/data/menus.ui.h:13 ../pohelper/src/gph-plugin.c:1605
-msgid "Go to next fuzzily translated string"
-msgstr "Ir para a cadeia com tradução confusa seguinte"
-
-#: ../pohelper/data/menus.ui.h:14
-msgid "Previous Untranslated or Fuzz_y"
-msgstr "Não traduz_ida ou confusa anterior"
-
-#: ../pohelper/data/menus.ui.h:15 ../pohelper/src/gph-plugin.c:1608
-msgid "Go to previous untranslated or fuzzy string"
-msgstr "Ir para a cadeia não traduzida ou confusa anterior"
-
-#: ../pohelper/data/menus.ui.h:16
-msgid "Next Untranslated _or Fuzzy"
-msgstr "Não trad_uzida ou confusa seguinte"
-
-#: ../pohelper/data/menus.ui.h:17 ../pohelper/src/gph-plugin.c:1612
-msgid "Go to next untranslated or fuzzy string"
-msgstr "Ir para a cadeia não traduzida ou confusa seguinte"
-
-#: ../pohelper/data/menus.ui.h:18 ../pohelper/src/gph-plugin.c:1623
-msgid "Toggle current translation fuzziness"
-msgstr "Alternar a confusão da tradução actual"
-
-#: ../pohelper/data/menus.ui.h:19
-msgid "_Toggle Fuzziness"
-msgstr "A_lternar confusão"
-
-#: ../pohelper/data/menus.ui.h:20
-msgid "Paste _Message as Translation"
-msgstr "Colar _mensagem como tradução"
-
-#: ../pohelper/data/menus.ui.h:21
-msgid "Paste the original untranslated string to the translation"
-msgstr "Colar a mensagem original não traduzida como tradução"
-
-#: ../pohelper/data/menus.ui.h:22 ../pohelper/src/gph-plugin.c:1620
-msgid "Reflow the current translation string"
-msgstr "Testar a cadeia de tradução actual"
-
-#: ../pohelper/data/menus.ui.h:23
-msgid "_Reflow Translation"
-msgstr "Testar t_radução"
-
-#: ../pohelper/data/menus.ui.h:24 ../pohelper/src/gph-plugin.c:1626
-msgid "Show statistics of the current document"
-msgstr "Mostra estatísticas do documento actual"
-
-#: ../pohelper/data/menus.ui.h:25
-msgid "_Show stats"
-msgstr "_Mostrar estatísticas"
-
-#: ../pohelper/data/menus.ui.h:26
-msgid ""
-"Whether to update the translation headers (author, revision date, ...) upon "
-"file save"
-msgstr ""
-"Se actualiza os cabeçalhos da tradução (autor, data de revisão, ...) ao "
-"gravar o ficheiro"
-
-#: ../pohelper/data/menus.ui.h:27
-msgid "Update _Headers Upon Save"
-msgstr "Actualizar cabeçal_hos ao gravar"
-
-#: ../pohelper/data/stats.ui.h:1
-msgid "Translation statistics"
-msgstr "Estatísticas da tradução"
-
-#: ../pohelper/data/stats.ui.h:2
-msgid "Choose a color for translated strings"
-msgstr "Escolha uma cor para cadeias traduzidas"
-
-#: ../pohelper/data/stats.ui.h:3
-msgid "Choose a color for fuzzily translated strings"
-msgstr "Escolha uma cor para traduções confusas"
-
-#: ../pohelper/data/stats.ui.h:4
-msgid "Choose a color for untranslated strings"
-msgstr "Escolha uma cor para cadeias não traduzidas"
-
-#: ../pohelper/data/stats.ui.h:5
-msgid "Translated:"
-msgstr "Traduzidas:"
-
-#: ../pohelper/data/stats.ui.h:6
-msgid "Fuzzy:"
-msgstr "Confusas:"
-
-#: ../pohelper/data/stats.ui.h:7
-msgid "Untranslated:"
-msgstr "Não traduzidas:"
 
 #: ../pohelper/src/gph-plugin.c:40
 msgid "Translation Helper"
@@ -5900,9 +5605,53 @@ msgstr "<b>Não traduzido:</b> %.3g%%"
 msgid "%u (%.3g%%)"
 msgstr "%u (%.3g%%)"
 
+#: ../pohelper/src/gph-plugin.c:1590
+msgid "Go to previous string"
+msgstr "Ir para a cadeia anterior"
+
+#: ../pohelper/src/gph-plugin.c:1593
+msgid "Go to next string"
+msgstr "Ir para a cadeia seguinte"
+
+#: ../pohelper/src/gph-plugin.c:1596
+msgid "Go to previous untranslated string"
+msgstr "Ir para a cadeia não traduzida anterior"
+
+#: ../pohelper/src/gph-plugin.c:1599
+msgid "Go to next untranslated string"
+msgstr "Ir para a cadeia não traduzida seguinte"
+
+#: ../pohelper/src/gph-plugin.c:1602
+msgid "Go to previous fuzzily translated string"
+msgstr "Ir para a cadeia com tradução confusa anterior"
+
+#: ../pohelper/src/gph-plugin.c:1605
+msgid "Go to next fuzzily translated string"
+msgstr "Ir para a cadeia com tradução confusa seguinte"
+
+#: ../pohelper/src/gph-plugin.c:1608
+msgid "Go to previous untranslated or fuzzy string"
+msgstr "Ir para a cadeia não traduzida ou confusa anterior"
+
+#: ../pohelper/src/gph-plugin.c:1612
+msgid "Go to next untranslated or fuzzy string"
+msgstr "Ir para a cadeia não traduzida ou confusa seguinte"
+
 #: ../pohelper/src/gph-plugin.c:1616
 msgid "Paste original untranslated string to translation"
 msgstr "Colar cadeia original não traduzida na tradução"
+
+#: ../pohelper/src/gph-plugin.c:1620
+msgid "Reflow the current translation string"
+msgstr "Testar a cadeia de tradução actual"
+
+#: ../pohelper/src/gph-plugin.c:1623
+msgid "Toggle current translation fuzziness"
+msgstr "Alternar a confusão da tradução actual"
+
+#: ../pohelper/src/gph-plugin.c:1626
+msgid "Show statistics of the current document"
+msgstr "Mostra estatísticas do documento actual"
 
 #: ../pohelper/src/gph-plugin.c:1833
 #, c-format
@@ -6191,7 +5940,7 @@ msgid "Add"
 msgstr "Adicionar"
 
 #: ../projectorganizer/src/prjorg-sidebar.c:390
-#: ../treebrowser/src/treebrowser.c:2356
+#: ../treebrowser/src/treebrowser.c:2361
 msgid "New File"
 msgstr "Novo ficheiro"
 
@@ -6802,6 +6551,10 @@ msgstr "Mostrar suges_tões"
 msgid "<b>Others</b>"
 msgstr "<b>Outros</b>"
 
+#: ../scope/data/scope.glade.h:130 ../scope/data/scope_gtk3.glade.h:130
+msgid "Options"
+msgstr "Opções"
+
 #: ../scope/data/scope.glade.h:131 ../scope/data/scope_gtk3.glade.h:131
 msgid "_Import"
 msgstr "_Importar"
@@ -7336,8 +7089,8 @@ msgid ""
 "Your old configuration directory \"%s\" could not be moved to \"%s\" (%s). "
 "Please move manually the directory to the new location."
 msgstr ""
-"A sua pasta de configuração antiga \"%s\" não pôde ser movida para \"%s"
-"\" (%s). Por favor, mova-a manualmente para a nova localização."
+"A sua pasta de configuração antiga \"%s\" não pôde ser movida para "
+"\"%s\" (%s). Por favor, mova-a manualmente para a nova localização."
 
 #. Build up menu entry
 #: ../sendmail/src/sendmail.c:442
@@ -7392,12 +7145,14 @@ msgid "Checks the spelling of the current document."
 msgstr "Verifica a ortografia do actual documento."
 
 #: ../spellcheck/src/scplugin.c:225
-msgid "Run Spell Check"
+#, fuzzy
+msgid "Run spell check once"
 msgstr "Executar o corrector ortográfico"
 
-#: ../spellcheck/src/scplugin.c:228
-msgid "Toggle Check While Typing"
-msgstr "Alternar correcção ortográfica ao digitar"
+#: ../spellcheck/src/scplugin.c:228 ../spellcheck/src/scplugin.c:333
+#, fuzzy
+msgid "Toggle spell check"
+msgstr "Correcção ortográfica"
 
 #. initialise the dialog
 #: ../spellcheck/src/scplugin.c:239
@@ -7425,10 +7180,6 @@ msgstr "Imprimir palavras incorrectas e sugestões na janela de mensagens"
 #: ../spellcheck/src/scplugin.c:325
 msgid "<b>Interface</b>"
 msgstr "<b>Ambiente</b>"
-
-#: ../spellcheck/src/scplugin.c:333
-msgid "Check spelling while typing"
-msgstr "Verificar ortografia enquanto digita"
 
 #: ../spellcheck/src/scplugin.c:336
 msgid "Check spelling when opening a document"
@@ -7466,32 +7217,32 @@ msgstr ""
 msgid "<b>Behavior</b>"
 msgstr "<b>Comportamento</b>"
 
-#: ../spellcheck/src/gui.c:76
+#: ../spellcheck/src/gui.c:88
 msgid "Spell checking while typing is now enabled"
 msgstr "Correcção ortográfica enquanto digita encontra-se activa agora"
 
-#: ../spellcheck/src/gui.c:78
+#: ../spellcheck/src/gui.c:90
 msgid "Spell checking while typing is now disabled"
 msgstr "Correcção ortográfica enquanto digita encontra-se desactiva agora"
 
-#: ../spellcheck/src/gui.c:326
+#: ../spellcheck/src/gui.c:323
 msgid "More..."
 msgstr "Mais..."
 
-#: ../spellcheck/src/gui.c:347
+#: ../spellcheck/src/gui.c:344
 msgid "(No Suggestions)"
 msgstr "(sem sugestões)"
 
-#: ../spellcheck/src/gui.c:360
+#: ../spellcheck/src/gui.c:357
 #, c-format
 msgid "Add \"%s\" to Dictionary"
 msgstr "Adicionar \"%s\" ao dicionário"
 
-#: ../spellcheck/src/gui.c:368
+#: ../spellcheck/src/gui.c:365
 msgid "Ignore All"
 msgstr "Ignorar tudo"
 
-#: ../spellcheck/src/gui.c:441
+#: ../spellcheck/src/gui.c:438
 msgid ""
 "Search term is too long to provide\n"
 "spelling suggestions in the editor menu."
@@ -7499,21 +7250,21 @@ msgstr ""
 "Termo a procurar demasiado longo para mostrar\n"
 "sugestões de escrita no menu do editor."
 
-#: ../spellcheck/src/gui.c:447
+#: ../spellcheck/src/gui.c:444
 msgid "Perform Spell Check"
 msgstr "Realizar correcção ortográfica"
 
-#: ../spellcheck/src/gui.c:609
+#: ../spellcheck/src/gui.c:606
 #, c-format
 msgid "Default (%s)"
 msgstr "Predefinição (%s)"
 
-#: ../spellcheck/src/gui.c:620
-#, c-format
-msgid "Toggle spell check while typing (current language: %s)"
+#: ../spellcheck/src/gui.c:617
+#, fuzzy, c-format
+msgid "Toggle spell check (current language: %s)"
 msgstr "Alternar correcção ortográfica enquanto digita (idioma actual: %s)"
 
-#: ../spellcheck/src/gui.c:698
+#: ../spellcheck/src/gui.c:695
 msgid "Spelling Suggestions"
 msgstr "Sugestões de ortografia"
 
@@ -7610,15 +7361,15 @@ msgstr "(vazio)"
 msgid "Could not execute configured external command '%s' (%s)."
 msgstr "Impossível executar o comando externo configurado \"%s\" (%s)."
 
-#: ../treebrowser/src/treebrowser.c:1089
+#: ../treebrowser/src/treebrowser.c:1093
 msgid "NewDirectory"
 msgstr "Nova pasta"
 
-#: ../treebrowser/src/treebrowser.c:1091
+#: ../treebrowser/src/treebrowser.c:1095
 msgid "NewFile"
 msgstr "Novo ficheiro"
 
-#: ../treebrowser/src/treebrowser.c:1096
+#: ../treebrowser/src/treebrowser.c:1100
 #, c-format
 msgid ""
 "Target file '%s' exists.\n"
@@ -7627,115 +7378,115 @@ msgstr ""
 "O ficheiro destino \"%s\" já existe.\n"
 "Tem a certeza que o quer substituir por um ficheiro vazio?"
 
-#: ../treebrowser/src/treebrowser.c:1142
+#: ../treebrowser/src/treebrowser.c:1146
 #, c-format
 msgid "Do you really want to delete '%s' ?"
 msgstr "Tem a certeza que quer eliminar \"%s\"?"
 
-#: ../treebrowser/src/treebrowser.c:1255 ../treebrowser/src/treebrowser.c:1257
+#: ../treebrowser/src/treebrowser.c:1259 ../treebrowser/src/treebrowser.c:1261
 msgid "Go _Up"
 msgstr "S_ubir"
 
-#: ../treebrowser/src/treebrowser.c:1263 ../treebrowser/src/treebrowser.c:1265
+#: ../treebrowser/src/treebrowser.c:1267 ../treebrowser/src/treebrowser.c:1269
 msgid "Set _Path From Document"
 msgstr "Definir _caminho do documento"
 
-#: ../treebrowser/src/treebrowser.c:1271 ../treebrowser/src/treebrowser.c:1273
+#: ../treebrowser/src/treebrowser.c:1275 ../treebrowser/src/treebrowser.c:1277
 msgid "_Open Externally"
 msgstr "_Abrir externamente"
 
-#: ../treebrowser/src/treebrowser.c:1279
+#: ../treebrowser/src/treebrowser.c:1283
 msgid "Open _Terminal"
 msgstr "Abrir _terminal"
 
-#: ../treebrowser/src/treebrowser.c:1284 ../treebrowser/src/treebrowser.c:1286
+#: ../treebrowser/src/treebrowser.c:1288 ../treebrowser/src/treebrowser.c:1290
 msgid "Set as _Root"
 msgstr "Definir como _raiz"
 
-#: ../treebrowser/src/treebrowser.c:1293 ../treebrowser/src/treebrowser.c:1295
+#: ../treebrowser/src/treebrowser.c:1297 ../treebrowser/src/treebrowser.c:1299
 msgid "Refres_h"
 msgstr "Actuali_zar"
 
-#: ../treebrowser/src/treebrowser.c:1301 ../treebrowser/src/treebrowser.c:1303
+#: ../treebrowser/src/treebrowser.c:1305 ../treebrowser/src/treebrowser.c:1307
 msgid "_Find in Files"
 msgstr "Localizar em _ficheiros"
 
-#: ../treebrowser/src/treebrowser.c:1313 ../treebrowser/src/treebrowser.c:1315
+#: ../treebrowser/src/treebrowser.c:1317 ../treebrowser/src/treebrowser.c:1319
 msgid "N_ew Folder"
 msgstr "N_ova pasta"
 
-#: ../treebrowser/src/treebrowser.c:1321 ../treebrowser/src/treebrowser.c:1323
+#: ../treebrowser/src/treebrowser.c:1325 ../treebrowser/src/treebrowser.c:1327
 msgid "_New File"
 msgstr "_Novo ficheiro"
 
-#: ../treebrowser/src/treebrowser.c:1329 ../treebrowser/src/treebrowser.c:1331
+#: ../treebrowser/src/treebrowser.c:1333 ../treebrowser/src/treebrowser.c:1335
 msgid "Rena_me"
 msgstr "Reno_mear"
 
-#: ../treebrowser/src/treebrowser.c:1350 ../treebrowser/src/treebrowser.c:1352
+#: ../treebrowser/src/treebrowser.c:1354 ../treebrowser/src/treebrowser.c:1356
 #, c-format
 msgid "Close: %s"
 msgstr "Fechar: %s"
 
-#: ../treebrowser/src/treebrowser.c:1359 ../treebrowser/src/treebrowser.c:1361
+#: ../treebrowser/src/treebrowser.c:1363 ../treebrowser/src/treebrowser.c:1365
 #, c-format
 msgid "Clo_se Child Documents "
 msgstr "Fechar documento_s-filho "
 
-#: ../treebrowser/src/treebrowser.c:1368 ../treebrowser/src/treebrowser.c:1370
+#: ../treebrowser/src/treebrowser.c:1372 ../treebrowser/src/treebrowser.c:1374
 msgid "_Copy Full Path to Clipboard"
 msgstr "_Copiar caminho completo para a área de transferência"
 
-#: ../treebrowser/src/treebrowser.c:1381 ../treebrowser/src/treebrowser.c:1383
+#: ../treebrowser/src/treebrowser.c:1385 ../treebrowser/src/treebrowser.c:1387
 msgid "E_xpand All"
 msgstr "E_xpandir tudo"
 
-#: ../treebrowser/src/treebrowser.c:1389 ../treebrowser/src/treebrowser.c:1391
+#: ../treebrowser/src/treebrowser.c:1393 ../treebrowser/src/treebrowser.c:1395
 msgid "Coll_apse All"
 msgstr "Col_apsar tudo"
 
-#: ../treebrowser/src/treebrowser.c:1399
+#: ../treebrowser/src/treebrowser.c:1403
 msgid "Show Boo_kmarks"
 msgstr "Mostrar mar_cadores"
 
-#: ../treebrowser/src/treebrowser.c:1404
+#: ../treebrowser/src/treebrowser.c:1408
 msgid "Sho_w Hidden Files"
 msgstr "Mostrar ficheiros oc_ultos"
 
-#: ../treebrowser/src/treebrowser.c:1409
+#: ../treebrowser/src/treebrowser.c:1413
 msgid "Show Tool_bars"
 msgstr "Mostrar _barras de ferramentas"
 
-#: ../treebrowser/src/treebrowser.c:1747
+#: ../treebrowser/src/treebrowser.c:1751
 #, c-format
 msgid "Target file '%s' exists, do you really want to replace it?"
 msgstr "O ficheiro destino \"%s\" já existe, quer realmente substituir?"
 
-#: ../treebrowser/src/treebrowser.c:1883
+#: ../treebrowser/src/treebrowser.c:1887
 msgid "Go up"
 msgstr "Ir para cima"
 
-#: ../treebrowser/src/treebrowser.c:1893 ../treebrowser/src/treebrowser.c:2360
+#: ../treebrowser/src/treebrowser.c:1897 ../treebrowser/src/treebrowser.c:2365
 msgid "Refresh"
 msgstr "Actualizar"
 
-#: ../treebrowser/src/treebrowser.c:1903
+#: ../treebrowser/src/treebrowser.c:1907
 msgid "Home"
 msgstr "Pasta pessoal"
 
-#: ../treebrowser/src/treebrowser.c:1913
+#: ../treebrowser/src/treebrowser.c:1917
 msgid "Set path from document"
 msgstr "Definir caminho a partir do documento"
 
-#: ../treebrowser/src/treebrowser.c:1923
+#: ../treebrowser/src/treebrowser.c:1927
 msgid "Track path"
 msgstr "Rastrear caminho"
 
-#: ../treebrowser/src/treebrowser.c:1933
+#: ../treebrowser/src/treebrowser.c:1937
 msgid "Hide bars"
 msgstr "Ocultar barras"
 
-#: ../treebrowser/src/treebrowser.c:1943
+#: ../treebrowser/src/treebrowser.c:1947
 msgid ""
 "Filter (*.c;*.h;*.cpp), and if you want temporary filter using the '!' "
 "reverse try for example this '!;*.c;*.h;*.cpp'"
@@ -7743,20 +7494,20 @@ msgstr ""
 "Filtrar (*.c;*.h;*.cpp) e, se quiser uma filtragem temporária, use \"!\". "
 "Tente por exemplo isto \"!;*.c;*.h;*.cpp\""
 
-#: ../treebrowser/src/treebrowser.c:1948
+#: ../treebrowser/src/treebrowser.c:1952
 msgid "Addressbar for example '/projects/my-project'"
 msgstr "Barra de endereço por exemplo \"/projectos/meu-projecto\""
 
-#: ../treebrowser/src/treebrowser.c:1973
+#: ../treebrowser/src/treebrowser.c:1977
 msgid "Tree Browser"
 msgstr "Navegador em árvore"
 
-#: ../treebrowser/src/treebrowser.c:2114
+#: ../treebrowser/src/treebrowser.c:2118
 msgid "External open command"
 msgstr "Comando externo para abrir"
 
-#: ../treebrowser/src/treebrowser.c:2124
-#, c-format
+#: ../treebrowser/src/treebrowser.c:2129
+#, no-c-format
 msgid ""
 "The command to execute when using \"Open with\". You can use %f and %d "
 "wildcards.\n"
@@ -7770,59 +7521,59 @@ msgstr ""
 "%d será substituído pelo nome do caminho do ficheiro seleccionado, sem o "
 "nome do ficheiro"
 
-#: ../treebrowser/src/treebrowser.c:2143
+#: ../treebrowser/src/treebrowser.c:2148
 msgid "The terminal to use with the command \"Open Terminal\""
 msgstr "O terminal a usar com o comando \"Abrir terminal\""
 
-#: ../treebrowser/src/treebrowser.c:2149
+#: ../treebrowser/src/treebrowser.c:2154
 msgid "Toolbar"
 msgstr "Barra de ferramentas"
 
-#: ../treebrowser/src/treebrowser.c:2151
+#: ../treebrowser/src/treebrowser.c:2156
 msgid "Hidden"
 msgstr "Oculto"
 
-#: ../treebrowser/src/treebrowser.c:2152
+#: ../treebrowser/src/treebrowser.c:2157
 msgid "Top"
 msgstr "Topo"
 
-#: ../treebrowser/src/treebrowser.c:2153
+#: ../treebrowser/src/treebrowser.c:2158
 msgid "Bottom"
 msgstr "Fundo"
 
-#: ../treebrowser/src/treebrowser.c:2158
+#: ../treebrowser/src/treebrowser.c:2163
 msgid "If position is changed, the option require plugin restart."
 msgstr "Se a posição mudar, esta opção requer reinicialização da extensão."
 
-#: ../treebrowser/src/treebrowser.c:2162
+#: ../treebrowser/src/treebrowser.c:2167
 msgid "Show icons"
 msgstr "Mostrar ícones"
 
-#: ../treebrowser/src/treebrowser.c:2164
+#: ../treebrowser/src/treebrowser.c:2169
 msgid "None"
 msgstr "Nenhum"
 
-#: ../treebrowser/src/treebrowser.c:2165
+#: ../treebrowser/src/treebrowser.c:2170
 msgid "Base"
 msgstr "Base"
 
-#: ../treebrowser/src/treebrowser.c:2166
+#: ../treebrowser/src/treebrowser.c:2171
 msgid "Content-type"
 msgstr "Tipo de conteúdo"
 
-#: ../treebrowser/src/treebrowser.c:2172
+#: ../treebrowser/src/treebrowser.c:2177
 msgid "Show hidden files"
 msgstr "Mostrar ficheiros ocultos"
 
-#: ../treebrowser/src/treebrowser.c:2181
+#: ../treebrowser/src/treebrowser.c:2186
 msgid "On Windows, this just hide files that are prefixed with '.' (dot)"
 msgstr "Em Windows, isto apenas oculta ficheiros precedidos de \".\" (ponto)"
 
-#: ../treebrowser/src/treebrowser.c:2183
+#: ../treebrowser/src/treebrowser.c:2188
 msgid "Hide object files"
 msgstr "Ocultar ficheiros objecto"
 
-#: ../treebrowser/src/treebrowser.c:2192
+#: ../treebrowser/src/treebrowser.c:2197
 msgid ""
 "Don't show generated object files in the file browser, this includes *.o, *."
 "obj. *.so, *.dll, *.a, *.lib"
@@ -7830,59 +7581,59 @@ msgstr ""
 "Não mostrar ficheiros objecto gerados no navegador, isto inclui *.o, *.obj, "
 "*.so, *.dll, *.a, *.lib"
 
-#: ../treebrowser/src/treebrowser.c:2194
+#: ../treebrowser/src/treebrowser.c:2199
 msgid "Reverse filter"
 msgstr "Reverte o filtro"
 
-#: ../treebrowser/src/treebrowser.c:2203
+#: ../treebrowser/src/treebrowser.c:2208
 msgid "Follow current document"
 msgstr "Seguir o documento activo"
 
-#: ../treebrowser/src/treebrowser.c:2212
+#: ../treebrowser/src/treebrowser.c:2217
 msgid "Single click, open document and focus it"
 msgstr "Clique único abre documento e foca-o"
 
-#: ../treebrowser/src/treebrowser.c:2221
+#: ../treebrowser/src/treebrowser.c:2226
 msgid "Double click open directory"
 msgstr "Clique duplo abre pasta"
 
-#: ../treebrowser/src/treebrowser.c:2230
+#: ../treebrowser/src/treebrowser.c:2235
 msgid "On delete file, close it if is opened"
 msgstr "Ao eliminar ficheiro, fechá-lo caso esteja aberto"
 
-#: ../treebrowser/src/treebrowser.c:2239
+#: ../treebrowser/src/treebrowser.c:2244
 msgid "Focus editor on file open"
 msgstr "Focar o editor ao abrir ficheiro"
 
-#: ../treebrowser/src/treebrowser.c:2248
+#: ../treebrowser/src/treebrowser.c:2253
 msgid "Show tree lines"
 msgstr "Mostrar as linhas da árvore"
 
-#: ../treebrowser/src/treebrowser.c:2257
+#: ../treebrowser/src/treebrowser.c:2262
 msgid "Show bookmarks"
 msgstr "Mostrar marcadores"
 
-#: ../treebrowser/src/treebrowser.c:2266
+#: ../treebrowser/src/treebrowser.c:2271
 msgid "Open new files"
 msgstr "Abrir novos ficheiros"
 
-#: ../treebrowser/src/treebrowser.c:2350
+#: ../treebrowser/src/treebrowser.c:2355
 msgid "Focus File List"
 msgstr "Focar a lista de ficheiros"
 
-#: ../treebrowser/src/treebrowser.c:2352
+#: ../treebrowser/src/treebrowser.c:2357
 msgid "Focus Path Entry"
 msgstr "Focar a entrada de caminho"
 
-#: ../treebrowser/src/treebrowser.c:2354
+#: ../treebrowser/src/treebrowser.c:2359
 msgid "Rename Object"
 msgstr "Renomear objecto"
 
-#: ../treebrowser/src/treebrowser.c:2358
+#: ../treebrowser/src/treebrowser.c:2363
 msgid "New Folder"
 msgstr "Nova pasta"
 
-#: ../treebrowser/src/treebrowser.c:2362
+#: ../treebrowser/src/treebrowser.c:2367
 msgid "Track Current"
 msgstr "Rastrear actual"
 
@@ -8570,13 +8321,6 @@ msgstr "Sem pastas"
 msgid "No workbench opened."
 msgstr "Sem bancada aberta."
 
-#: ../workbench/src/sidebar.c:875
-#, c-format
-msgid "%s: %u Project"
-msgid_plural "%s: %u Projects"
-msgstr[0] "%s: %u projecto"
-msgstr[1] "%s: %u projectos"
-
 #: ../workbench/src/sidebar.c:886
 msgid ""
 "Add a project using the context menu\n"
@@ -8690,6 +8434,216 @@ msgstr "Excertos de código XML"
 #: ../xmlsnippets/src/plugin.c:45
 msgid "Autocompletes XML/HTML tags using snippets."
 msgstr "Conclusão automática de etiquetas  XML/HTML usando excertos de código."
+
+#~ msgid "_Monitor repository for changes"
+#~ msgstr "_Monitorizar alterações no repositório"
+
+#~ msgid ""
+#~ "Whether to automatically update the diff in order to maintain it up to "
+#~ "date when the underlying Git repository changes.  This should generally "
+#~ "be enabled for optimal user experience."
+#~ msgstr ""
+#~ "Se actualiza as diferenças automaticamente ao haver alterações "
+#~ "subjacentes no repositório Git. Por norma isto deve estar activado para "
+#~ "uma experiência de utilização optimizada."
+
+#~ msgid "_Added lines:"
+#~ msgstr "Linhas _adicionadas:"
+
+#~ msgid "_Changed lines:"
+#~ msgstr "Linhas al_teradas:"
+
+#~ msgid "_Removed lines:"
+#~ msgstr "Linhas _removidas:"
+
+#~ msgid "Colors"
+#~ msgstr "Cores"
+
+#~ msgid ""
+#~ "The amount to zoom the overview sidebar. This should probably negative if "
+#~ "you want the sidebar zoomed out."
+#~ msgstr ""
+#~ "Quanto ampliar a barra lateral da vista geral. Provavelmente deve ser "
+#~ "negativo se quiser a barra lateral reduzida."
+
+#~ msgid "Zoom Level:"
+#~ msgstr "Factor de ampliação:"
+
+#~ msgid "The width of the overview sidebar."
+#~ msgstr "A largura da barra lateral da vista geral."
+
+#~ msgid "Width:"
+#~ msgstr "Largura:"
+
+#~ msgid ""
+#~ "The number of lines to scroll at a time when scrolling the overview "
+#~ "sidebar."
+#~ msgstr ""
+#~ "O número de linhas a rolar de uma só vez ao rolar a barra lateral da "
+#~ "vista geral."
+
+#~ msgid "Scroll Lines:"
+#~ msgstr "Rolar linhas:"
+
+#~ msgid "Position on left"
+#~ msgstr "Posição à esquerda"
+
+#~ msgid ""
+#~ "Position the overview bar on the left rather than the right (requires "
+#~ "Geany 1.25 or greater)."
+#~ msgstr ""
+#~ "Posicionar a barra de vista geral à esquerda em vez de à direita ( requer "
+#~ "o Geany 1.25 ou superior)."
+
+#~ msgid "Hide tooltip"
+#~ msgstr "Ocultar sugestão"
+
+#~ msgid ""
+#~ "Hide the tooltip that is displayed when mousing over the overview that "
+#~ "shows line, column and position information."
+#~ msgstr ""
+#~ "Ocultar a sugestão mostrada quando o rato paira sobre a vista geral, que "
+#~ "informa sobre linha, coluna e posição."
+
+#~ msgid "Hide editor scrollbar"
+#~ msgstr "Ocultar barra de rolamento do editor"
+
+#~ msgid ""
+#~ "Whether to hide Geany's regular editor scrollbar while the overview bar "
+#~ "is visible."
+#~ msgstr ""
+#~ "Se deve ocultar a barra de rolamento do editor normal do Geany enquanto a "
+#~ "barra de vista geral está visível."
+
+#~ msgid "Disable overlay"
+#~ msgstr "Desactivar cobertura"
+
+#~ msgid ""
+#~ "Turn off drawing overlay, which shows the region of the main editor view "
+#~ "that is currently in view, ontop of the overview bar."
+#~ msgstr ""
+#~ "Desligar o desenho da cobertura, o que mostra a região da vista do editor "
+#~ "principal actual, no topo da barra de vista geral."
+
+#~ msgid ""
+#~ "The color and opacity of the overlay drawn ontop of the overlay sidebar."
+#~ msgstr ""
+#~ "A cor e opacidade da cobertura desenhada no topo da barra lateral da "
+#~ "cobertura."
+
+#~ msgid "Color:"
+#~ msgstr "Cor:"
+
+#~ msgid ""
+#~ "The color and opacity of the border drawn around the revealed area in the "
+#~ "overview sidebar. Set to the same as Overlay Color to disable."
+#~ msgstr ""
+#~ "A cor e opacidade do contorno desenhado à volta da área revelada na barra "
+#~ "de visão geral. Defina como igual à cor de sobreposição para desactivar."
+
+#~ msgid "Outline Color:"
+#~ msgstr "Cor de realce:"
+
+#~ msgid "Draw over visible area"
+#~ msgstr "Desenhar sobre a parte visível"
+
+#~ msgid ""
+#~ "When checked it will draw the overlay ontop of the area that is visible "
+#~ "in the main editor view, when unchecked, it will do the opposite and draw "
+#~ "the overlay everywhere but the visible area, \"revealing\" the visible "
+#~ "part."
+#~ msgstr ""
+#~ "Quando marcada, desenha a cobertura por cima da área visível na vista "
+#~ "principal do editor. Sem marcação faz o oposto, desenha a cobertura em "
+#~ "todo o lado menos na área visível, \"revelando\" a parte visível."
+
+#~ msgid "Overlay"
+#~ msgstr "Cobertura"
+
+#~ msgid "_Translation Helper"
+#~ msgstr "Auxiliar de _tradução"
+
+#~ msgid "_Previous String"
+#~ msgstr "Cadeia _anterior"
+
+#~ msgid "_Next String"
+#~ msgstr "Cadeia segui_nte"
+
+#~ msgid "Pre_vious Untranslated"
+#~ msgstr "Não _traduzida anterior"
+
+#~ msgid "Next _Untranslated"
+#~ msgstr "Não traduzida _seguinte"
+
+#~ msgid "Previous Fu_zzy"
+#~ msgstr "_Confusa anterior"
+
+#~ msgid "Next _Fuzzy"
+#~ msgstr "Con_fusa seguinte"
+
+#~ msgid "Previous Untranslated or Fuzz_y"
+#~ msgstr "Não traduz_ida ou confusa anterior"
+
+#~ msgid "Next Untranslated _or Fuzzy"
+#~ msgstr "Não trad_uzida ou confusa seguinte"
+
+#~ msgid "_Toggle Fuzziness"
+#~ msgstr "A_lternar confusão"
+
+#~ msgid "Paste _Message as Translation"
+#~ msgstr "Colar _mensagem como tradução"
+
+#~ msgid "Paste the original untranslated string to the translation"
+#~ msgstr "Colar a mensagem original não traduzida como tradução"
+
+#~ msgid "_Reflow Translation"
+#~ msgstr "Testar t_radução"
+
+#~ msgid "_Show stats"
+#~ msgstr "_Mostrar estatísticas"
+
+#~ msgid ""
+#~ "Whether to update the translation headers (author, revision date, ...) "
+#~ "upon file save"
+#~ msgstr ""
+#~ "Se actualiza os cabeçalhos da tradução (autor, data de revisão, ...) ao "
+#~ "gravar o ficheiro"
+
+#~ msgid "Update _Headers Upon Save"
+#~ msgstr "Actualizar cabeçal_hos ao gravar"
+
+#~ msgid "Translation statistics"
+#~ msgstr "Estatísticas da tradução"
+
+#~ msgid "Choose a color for translated strings"
+#~ msgstr "Escolha uma cor para cadeias traduzidas"
+
+#~ msgid "Choose a color for fuzzily translated strings"
+#~ msgstr "Escolha uma cor para traduções confusas"
+
+#~ msgid "Choose a color for untranslated strings"
+#~ msgstr "Escolha uma cor para cadeias não traduzidas"
+
+#~ msgid "Translated:"
+#~ msgstr "Traduzidas:"
+
+#~ msgid "Fuzzy:"
+#~ msgstr "Confusas:"
+
+#~ msgid "Untranslated:"
+#~ msgstr "Não traduzidas:"
+
+#~ msgid "Toggle Check While Typing"
+#~ msgstr "Alternar correcção ortográfica ao digitar"
+
+#~ msgid "Check spelling while typing"
+#~ msgstr "Verificar ortografia enquanto digita"
+
+#, c-format
+#~ msgid "%s: %u Project"
+#~ msgid_plural "%s: %u Projects"
+#~ msgstr[0] "%s: %u projecto"
+#~ msgstr[1] "%s: %u projectos"
 
 #~ msgid "_Save"
 #~ msgstr "_Gravar"
@@ -9281,8 +9235,8 @@ msgstr "Conclusão automática de etiquetas  XML/HTML usando excertos de código
 #~ "Permite usar 10 favoritos numerados. Normalmente se tiver mais do que um "
 #~ "favorito, terá de percorrê-los a todos até chegar ao que pretende. Com "
 #~ "este plugin pode ir diretamente ao favorito que pretende com uma única "
-#~ "combinação de teclas. Para definir um favorito numerado carregue em Ctrl"
-#~ "+Shift+um número de 0 a 9. Verá uma marca aparecer junto do número da "
+#~ "combinação de teclas. Para definir um favorito numerado carregue em "
+#~ "Ctrl+Shift+um número de 0 a 9. Verá uma marca aparecer junto do número da "
 #~ "linha. Se carregar em Ctrl+Shift+um número quando está numa linha com "
 #~ "favorito numerado previamente atribuído, irá remover esse favorito. Caso "
 #~ "contrário, irá mover o favorito para a linha em questão se este estava já "

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -5,8 +5,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Geany-Plugins 1.30\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-29 19:41+0200\n"
+"Report-Msgid-Bugs-To: https://github.com/geany/geany/issues\n"
+"POT-Creation-Date: 2022-06-28 07:39+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Adrovane Marques Kade <adrovane@gmail.com>\n"
 "Language-Team: Adrovane Marques Kade <adrovane@gmail.com>\n"
@@ -21,27 +21,27 @@ msgstr ""
 msgid "(Empty Line)"
 msgstr "(Linha vazia)"
 
-#: ../addons/src/ao_bookmarklist.c:315
+#: ../addons/src/ao_bookmarklist.c:331
 msgid "_Remove Bookmark"
 msgstr "_Remover Bookmark"
 
 #. Translators: Number is meant at this point.
-#: ../addons/src/ao_bookmarklist.c:342
+#: ../addons/src/ao_bookmarklist.c:358
 msgid "No."
 msgstr "Não."
 
-#: ../addons/src/ao_bookmarklist.c:350 ../devhelp/src/dhp-object.c:494
+#: ../addons/src/ao_bookmarklist.c:366 ../devhelp/src/dhp-object.c:494
 #: ../devhelp/devhelp/dh-window.c:1142
 msgid "Contents"
 msgstr "Conteúdos"
 
-#: ../addons/src/ao_bookmarklist.c:383 ../treebrowser/src/treebrowser.c:666
+#: ../addons/src/ao_bookmarklist.c:399 ../treebrowser/src/treebrowser.c:666
 #: ../webhelper/src/gwh-plugin.c:328
 msgid "Bookmarks"
 msgstr "Marcadores"
 
 #. complete update
-#: ../addons/src/ao_tasks.c:373 ../geanyvc/src/geanyvc.c:2679
+#: ../addons/src/ao_tasks.c:373 ../geanyvc/src/geanyvc.c:2730
 msgid "_Update"
 msgstr "At_ualizar"
 
@@ -166,10 +166,10 @@ msgstr "Verifica a ortografia do documento atual."
 #: ../addons/src/addons.c:364 ../autoclose/src/autoclose.c:920
 #: ../codenav/src/codenavigation.c:281 ../latex/src/latex.c:208
 #: ../latex/src/latex.c:293 ../geanyprj/src/geanyprj.c:176
-#: ../geanyvc/src/geanyvc.c:2079 ../geniuspaste/src/geniuspaste.c:336
+#: ../geanyvc/src/geanyvc.c:2130 ../geniuspaste/src/geniuspaste.c:336
 #: ../lineoperations/src/lo_prefs.c:58 ../sendmail/src/sendmail.c:128
 #: ../sendmail/src/sendmail.c:293 ../spellcheck/src/scplugin.c:124
-#: ../treebrowser/src/treebrowser.c:2102
+#: ../treebrowser/src/treebrowser.c:2106
 #: ../updatechecker/src/updatechecker.c:262
 msgid "Plugin configuration directory could not be created."
 msgstr "O diretório de configuração de plugins não pôde ser criado."
@@ -737,7 +737,7 @@ msgstr ""
 msgid "Error loading file"
 msgstr ""
 
-#. setting asyncronous mode
+#. setting asynchronous mode
 #. setting null-stop array printing
 #. enable pretty printing
 #: ../debugger/src/dbm_gdb.c:789 ../debugger/src/dbm_gdb.c:792
@@ -1152,7 +1152,7 @@ msgid "A developers' help browser for GNOME"
 msgstr ""
 
 #. Create the current file Submenu
-#: ../devhelp/devhelp/dh-window.c:759 ../geanyvc/src/geanyvc.c:2660
+#: ../devhelp/devhelp/dh-window.c:759 ../geanyvc/src/geanyvc.c:2711
 msgid "_File"
 msgstr "_Arquivo"
 
@@ -1187,12 +1187,12 @@ msgstr ""
 msgid "_Print…"
 msgstr ""
 
-#: ../devhelp/devhelp/dh-window.c:782 ../devhelp/devhelp/eggfindbar.c:342
+#: ../devhelp/devhelp/dh-window.c:782
 #, fuzzy
 msgid "Find Next"
 msgstr "Incluir Arquivo"
 
-#: ../devhelp/devhelp/dh-window.c:784 ../devhelp/devhelp/eggfindbar.c:329
+#: ../devhelp/devhelp/dh-window.c:784
 #, fuzzy
 msgid "Find Previous"
 msgstr "Pesquisa em Projeto"
@@ -1394,7 +1394,7 @@ msgid ""
 "contributing to this plugin?"
 msgstr ""
 
-#: ../geanydoc/src/geanydoc.c:159 ../geanyvc/src/geanyvc.c:442
+#: ../geanydoc/src/geanydoc.c:159 ../geanyvc/src/geanyvc.c:448
 msgid "Could not parse the output of command"
 msgstr "Não foi possível reconhecer a saída do comando"
 
@@ -3123,7 +3123,7 @@ msgstr ""
 "Erro no módulo \"%s\" na função %s():\n"
 "argumentos insuficientes para o comando \"%s\".\n"
 
-#: ../geanylua/glspi_sci.c:637 ../geanylua/glspi_app.c:406
+#: ../geanylua/glspi_sci.c:729 ../geanylua/glspi_app.c:406
 #, c-format
 msgid ""
 "Error in module \"%s\" at function %s():\n"
@@ -3132,7 +3132,7 @@ msgstr ""
 "Erro no módulo \"%s\" da função %s():\n"
 "comando desconhecido \"%s\" dado pelo argumento #1.\n"
 
-#: ../geanylua/glspi_sci.c:781
+#: ../geanylua/glspi_sci.c:924
 #, c-format
 msgid ""
 "Error in module \"%s\" at function %s():\n"
@@ -3143,7 +3143,7 @@ msgstr ""
 " tabela inválida no argumento #%d:\n"
 "  flag desconhecida \"%s\" para o elemento #%d\n"
 
-#: ../geanylua/glspi_sci.c:785
+#: ../geanylua/glspi_sci.c:928
 msgid "<too large to display>"
 msgstr "<grande demais para exibir>"
 
@@ -3937,7 +3937,7 @@ msgid "New _Below"
 msgstr ""
 
 #: ../geanymacro/src/geanymacro.c:1824 ../geanymacro/src/geanymacro.c:2120
-#: ../treebrowser/src/treebrowser.c:1338 ../treebrowser/src/treebrowser.c:1340
+#: ../treebrowser/src/treebrowser.c:1342 ../treebrowser/src/treebrowser.c:1344
 #, fuzzy
 msgid "_Delete"
 msgstr "Excluir"
@@ -4317,8 +4317,8 @@ msgstr ""
 msgid "a key with fingerprint"
 msgstr ""
 
-#: ../geanypg/src/verify_aux.c:66 ../spellcheck/src/gui.c:610
-#: ../spellcheck/src/gui.c:621
+#: ../geanypg/src/verify_aux.c:66 ../spellcheck/src/gui.c:607
+#: ../spellcheck/src/gui.c:618
 msgid "unknown"
 msgstr "desconhecido"
 
@@ -4624,50 +4624,50 @@ msgid ""
 "contributing to this plugin?"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:501
+#: ../geanyvc/src/geanyvc.c:507
 #, c-format
 msgid "geanyvc: s_spawn_sync error: %s"
 msgstr "geanyvc: s_spawn_sync error: %s"
 
-#: ../geanyvc/src/geanyvc.c:587
+#: ../geanyvc/src/geanyvc.c:593
 #, c-format
 msgid "File %s: action %s executed via %s."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:646 ../geanyvc/src/geanyvc.c:657
-#, c-format
-msgid "geanyvc: vcdiff_file_activated: Unable to rename '%s' to '%s'"
+#: ../geanyvc/src/geanyvc.c:633 ../geanyvc/src/geanyvc.c:643
+#, fuzzy, c-format
+msgid "geanyvc: diff_external: Unable to rename '%s' to '%s'"
 msgstr "geanyvc: vcdiff_file_activated: Incapaz de renomear '%s' para '%s'"
 
-#: ../geanyvc/src/geanyvc.c:683 ../geanyvc/src/geanyvc.c:733
+#: ../geanyvc/src/geanyvc.c:698 ../geanyvc/src/geanyvc.c:784
 msgid "No changes were made."
 msgstr "Nenhuma alteração foi feita."
 
-#: ../geanyvc/src/geanyvc.c:760
+#: ../geanyvc/src/geanyvc.c:811
 #, fuzzy
 msgid "No history available"
 msgstr "Histórico não disponível"
 
-#: ../geanyvc/src/geanyvc.c:953 ../geanyvc/src/geanyvc.c:961
+#: ../geanyvc/src/geanyvc.c:1004 ../geanyvc/src/geanyvc.c:1012
 #, c-format
 msgid "Do you really want to revert: %s?"
 msgstr "Você deseja mesmo reverter: %s?"
 
-#: ../geanyvc/src/geanyvc.c:969
+#: ../geanyvc/src/geanyvc.c:1020
 #, c-format
 msgid "Do you really want to add: %s?"
 msgstr "Você deseja mesmo incluir: %s?"
 
-#: ../geanyvc/src/geanyvc.c:976
+#: ../geanyvc/src/geanyvc.c:1027
 #, c-format
 msgid "Do you really want to remove: %s?"
 msgstr "Você deseja mesmo remover: %s?"
 
-#: ../geanyvc/src/geanyvc.c:999
+#: ../geanyvc/src/geanyvc.c:1050
 msgid "Do you really want to update?"
 msgstr "Você deseja mesmo atualizar?"
 
-#: ../geanyvc/src/geanyvc.c:1126
+#: ../geanyvc/src/geanyvc.c:1177
 msgid ""
 "The resulting differences cannot be displayed because the changes are too "
 "big to display here and would slow down the UI significantly.\n"
@@ -4676,74 +4676,74 @@ msgid ""
 "Geany directly by using the GeanyVC menu (Base Directory -> Diff)."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1280
+#: ../geanyvc/src/geanyvc.c:1331
 msgid "Commit Y/N"
 msgstr "Submeter S/N"
 
-#: ../geanyvc/src/geanyvc.c:1290
+#: ../geanyvc/src/geanyvc.c:1341
 msgid "Status"
 msgstr "Estado"
 
-#: ../geanyvc/src/geanyvc.c:1297
+#: ../geanyvc/src/geanyvc.c:1348
 msgid "Path"
 msgstr "Caminho"
 
-#: ../geanyvc/src/geanyvc.c:1414
+#: ../geanyvc/src/geanyvc.c:1465
 msgid "Choose a previous commit message"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1476
+#: ../geanyvc/src/geanyvc.c:1527
 #, c-format
 msgid "Line: %d Column: %d"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1523
+#: ../geanyvc/src/geanyvc.c:1574
 msgid "Commit"
 msgstr "Submeter"
 
-#: ../geanyvc/src/geanyvc.c:1564
+#: ../geanyvc/src/geanyvc.c:1615
 msgid "_De-/select all files"
 msgstr "_De-/selecionar todos os arquivos"
 
-#: ../geanyvc/src/geanyvc.c:1608
+#: ../geanyvc/src/geanyvc.c:1659
 msgid "<b>Commit message:</b>"
 msgstr "<b>Mensagem de submeter:</b>"
 
-#: ../geanyvc/src/geanyvc.c:1632
+#: ../geanyvc/src/geanyvc.c:1683
 #, fuzzy
 msgid "C_ommit"
 msgstr "Submeter"
 
-#: ../geanyvc/src/geanyvc.c:1740
+#: ../geanyvc/src/geanyvc.c:1791
 msgid "Nothing to commit."
 msgstr "Nada para submeter."
 
-#: ../geanyvc/src/geanyvc.c:1788
+#: ../geanyvc/src/geanyvc.c:1839
 #, fuzzy, c-format
 msgid ""
 "Error initializing GeanyVC spell checking: %s. Check your configuration."
 msgstr "Erro ao inicializar verificação ortográfica automática: %s"
 
-#: ../geanyvc/src/geanyvc.c:1823
+#: ../geanyvc/src/geanyvc.c:1874
 #, c-format
 msgid "Commit failed (status: %d, error: %s)."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1824
+#: ../geanyvc/src/geanyvc.c:1875
 #, fuzzy
 msgid "Commit failed; see status in the Message window."
 msgstr "Exibir Tarefas disponíveis na Janela de Mensagens"
 
-#: ../geanyvc/src/geanyvc.c:1829
+#: ../geanyvc/src/geanyvc.c:1880
 #, fuzzy
 msgid "Changes committed."
 msgstr "Nada para submeter."
 
-#: ../geanyvc/src/geanyvc.c:2151
+#: ../geanyvc/src/geanyvc.c:2202
 msgid "Set Changed-flag for document tabs created by the plugin"
 msgstr "Definir a flag Alterado para abas de documentos criados pelo plugin"
 
-#: ../geanyvc/src/geanyvc.c:2154
+#: ../geanyvc/src/geanyvc.c:2205
 msgid ""
 "If this option is activated, every new by the VC-plugin created document tab "
 "will be marked as changed. Even this option is useful in some cases, it "
@@ -4753,259 +4753,259 @@ msgstr ""
 "CV será marcada como alterada. Mesmo que essa opção seja útil algumas vezes, "
 "pode causar diálogos de mensagens \"Você quer salvar\" irritantes."
 
-#: ../geanyvc/src/geanyvc.c:2162
+#: ../geanyvc/src/geanyvc.c:2213
 msgid "Confirm adding new files to a VCS"
 msgstr "Confirmar inclusão de novos arquivos em um SCV"
 
-#: ../geanyvc/src/geanyvc.c:2165
+#: ../geanyvc/src/geanyvc.c:2216
 msgid "Shows a confirmation dialog on adding a new (created) file to VCS."
 msgstr ""
 "Exibe um diálogo de confirmação ao incluir um novo (criado) arquivo ao SCV."
 
-#: ../geanyvc/src/geanyvc.c:2171
+#: ../geanyvc/src/geanyvc.c:2222
 msgid "Maximize commit dialog"
 msgstr "Maximizar diálogo de submeter"
 
-#: ../geanyvc/src/geanyvc.c:2172
+#: ../geanyvc/src/geanyvc.c:2223
 msgid "Show commit dialog maximize."
 msgstr "Exibe o diálogo de submeter maximizado. "
 
-#: ../geanyvc/src/geanyvc.c:2178
+#: ../geanyvc/src/geanyvc.c:2229
 msgid "Use external diff viewer"
 msgstr "Usar vizualizador de diff externo"
 
-#: ../geanyvc/src/geanyvc.c:2180
+#: ../geanyvc/src/geanyvc.c:2231
 msgid "Use external diff viewer for file diff."
 msgstr "Usar vizualizador externo de diff para diff de arquivos."
 
-#: ../geanyvc/src/geanyvc.c:2186
+#: ../geanyvc/src/geanyvc.c:2237
 msgid "Show VC entries at editor menu"
 msgstr "Exibir entradas VC no menu do editor"
 
-#: ../geanyvc/src/geanyvc.c:2188
+#: ../geanyvc/src/geanyvc.c:2239
 msgid "Show entries for VC functions inside editor menu"
 msgstr "Exibir entradas para funções VC dentro do menu do editor"
 
-#: ../geanyvc/src/geanyvc.c:2193
+#: ../geanyvc/src/geanyvc.c:2244
 msgid "Attach menu to menubar"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2195
+#: ../geanyvc/src/geanyvc.c:2246
 msgid ""
 "Whether menu for this plugin are getting placed either inside tools menu or "
 "directly inside Geany's menubar. Will take in account after next start of "
 "GeanyVC"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2203
+#: ../geanyvc/src/geanyvc.c:2254
 msgid "Enable CVS"
 msgstr "Habilitar CVS"
 
-#: ../geanyvc/src/geanyvc.c:2208
+#: ../geanyvc/src/geanyvc.c:2259
 msgid "Enable GIT"
 msgstr "Habilitar GIT"
 
-#: ../geanyvc/src/geanyvc.c:2213
+#: ../geanyvc/src/geanyvc.c:2264
 msgid "Enable Fossil"
 msgstr "Habilitar Fossil"
 
-#: ../geanyvc/src/geanyvc.c:2218
+#: ../geanyvc/src/geanyvc.c:2269
 msgid "Enable SVN"
 msgstr "Habilitar SVN"
 
-#: ../geanyvc/src/geanyvc.c:2223
+#: ../geanyvc/src/geanyvc.c:2274
 msgid "Enable SVK"
 msgstr "Habilitar SVK"
 
-#: ../geanyvc/src/geanyvc.c:2228
+#: ../geanyvc/src/geanyvc.c:2279
 msgid "Enable Bazaar"
 msgstr "Habilitar Bazaar"
 
-#: ../geanyvc/src/geanyvc.c:2233
+#: ../geanyvc/src/geanyvc.c:2284
 msgid "Enable Mercurial"
 msgstr "Habilitar Mercurial"
 
-#: ../geanyvc/src/geanyvc.c:2239
+#: ../geanyvc/src/geanyvc.c:2290
 msgid "Spellcheck language"
 msgstr "Linguagem para verificação ortográfica"
 
 #. Diff of current file
 #. Diff of the current dir
 #. Complete diff of base directory
-#: ../geanyvc/src/geanyvc.c:2368 ../geanyvc/src/geanyvc.c:2463
-#: ../geanyvc/src/geanyvc.c:2503
+#: ../geanyvc/src/geanyvc.c:2419 ../geanyvc/src/geanyvc.c:2514
+#: ../geanyvc/src/geanyvc.c:2554
 msgid "_Diff"
 msgstr "_Diff"
 
-#: ../geanyvc/src/geanyvc.c:2371
+#: ../geanyvc/src/geanyvc.c:2422
 msgid "Make a diff from the current active file"
 msgstr "Faz um diff do arquivo atualmente ativo"
 
 #. Revert current file
 #. Revert current dir
 #. Revert everything
-#: ../geanyvc/src/geanyvc.c:2376 ../geanyvc/src/geanyvc.c:2472
-#: ../geanyvc/src/geanyvc.c:2511
+#: ../geanyvc/src/geanyvc.c:2427 ../geanyvc/src/geanyvc.c:2523
+#: ../geanyvc/src/geanyvc.c:2562
 msgid "_Revert"
 msgstr "_Reverter"
 
-#: ../geanyvc/src/geanyvc.c:2379
+#: ../geanyvc/src/geanyvc.c:2430
 msgid "Restore pristine working copy file (undo local edits)."
 msgstr "Restaura cópia funcional antiga do arquivo (desfaz edições locais)."
 
 #. Blame for current file
-#: ../geanyvc/src/geanyvc.c:2388
+#: ../geanyvc/src/geanyvc.c:2439
 msgid "_Blame"
 msgstr "_Culpar"
 
-#: ../geanyvc/src/geanyvc.c:2391
+#: ../geanyvc/src/geanyvc.c:2442
 msgid "Shows the changes made at one file per revision and author."
 msgstr "Exibe as alterações feitas em um arquivo por revisão e autor."
 
 #. History/log of current file
 #. History/log of the current dir
 #. Complete History/Log of base directory
-#: ../geanyvc/src/geanyvc.c:2398 ../geanyvc/src/geanyvc.c:2482
-#: ../geanyvc/src/geanyvc.c:2523
+#: ../geanyvc/src/geanyvc.c:2449 ../geanyvc/src/geanyvc.c:2533
+#: ../geanyvc/src/geanyvc.c:2574
 msgid "_History (log)"
 msgstr "_Histórico (log)"
 
-#: ../geanyvc/src/geanyvc.c:2401
+#: ../geanyvc/src/geanyvc.c:2452
 msgid "Shows the log of the current file"
 msgstr "Exibe o log do arquivo atual"
 
 #. base version of the current file
-#: ../geanyvc/src/geanyvc.c:2406
+#: ../geanyvc/src/geanyvc.c:2457
 msgid "_Original"
 msgstr "_Original"
 
-#: ../geanyvc/src/geanyvc.c:2409
+#: ../geanyvc/src/geanyvc.c:2460
 #, fuzzy
 msgid "Shows the original of the current file"
 msgstr "Exibe o original do arquivo atual"
 
 #. add current file
-#: ../geanyvc/src/geanyvc.c:2417
+#: ../geanyvc/src/geanyvc.c:2468
 msgid "_Add to Version Control"
 msgstr "_Incluir no Controle de Versões"
 
-#: ../geanyvc/src/geanyvc.c:2419
+#: ../geanyvc/src/geanyvc.c:2470
 msgid "Add file to repository."
 msgstr "Inclui arquivo no repositório."
 
 #. remove current file
-#: ../geanyvc/src/geanyvc.c:2425
+#: ../geanyvc/src/geanyvc.c:2476
 msgid "_Remove from Version Control"
 msgstr "_Remover do Controle de Versões"
 
-#: ../geanyvc/src/geanyvc.c:2427
+#: ../geanyvc/src/geanyvc.c:2478
 msgid "Remove file from repository."
 msgstr "Remove arquivo do repositório."
 
-#: ../geanyvc/src/geanyvc.c:2460
+#: ../geanyvc/src/geanyvc.c:2511
 msgid "_Directory"
 msgstr "_Directório"
 
-#: ../geanyvc/src/geanyvc.c:2466
+#: ../geanyvc/src/geanyvc.c:2517
 msgid "Make a diff from the directory of the current active file"
 msgstr "Cria um diff do diretório do arquivo atualmente ativo"
 
-#: ../geanyvc/src/geanyvc.c:2475
+#: ../geanyvc/src/geanyvc.c:2526
 msgid "Restore original files in the current folder (undo local edits)."
 msgstr "Restaura arquivos originais na pasta atual (desfaz edições locais)."
 
-#: ../geanyvc/src/geanyvc.c:2485
+#: ../geanyvc/src/geanyvc.c:2536
 msgid "Shows the log of the current directory"
 msgstr "Exibe o log do diretório atual"
 
-#: ../geanyvc/src/geanyvc.c:2499
+#: ../geanyvc/src/geanyvc.c:2550
 msgid "_Base Directory"
 msgstr "Diretório _Base"
 
-#: ../geanyvc/src/geanyvc.c:2505
+#: ../geanyvc/src/geanyvc.c:2556
 msgid "Make a diff from the top VC directory"
 msgstr "Cria um diff do diretório topo do CV"
 
-#: ../geanyvc/src/geanyvc.c:2513
+#: ../geanyvc/src/geanyvc.c:2564
 msgid "Revert any local edits."
 msgstr "Reverter quaisquer edições locais."
 
-#: ../geanyvc/src/geanyvc.c:2526
+#: ../geanyvc/src/geanyvc.c:2577
 msgid "Shows the log of the top VC directory"
 msgstr "Exibe o log do diretório topo do CV"
 
-#: ../geanyvc/src/geanyvc.c:2543
+#: ../geanyvc/src/geanyvc.c:2594
 msgid "_VC file Actions"
 msgstr "Ações de arquivo _VC"
 
-#: ../geanyvc/src/geanyvc.c:2552
+#: ../geanyvc/src/geanyvc.c:2603
 msgid "VC _Commit..."
 msgstr "VC _Commit..."
 
-#: ../geanyvc/src/geanyvc.c:2596
+#: ../geanyvc/src/geanyvc.c:2647
 msgid "Show diff of file"
 msgstr "Exibir diff de arquivo"
 
-#: ../geanyvc/src/geanyvc.c:2598
+#: ../geanyvc/src/geanyvc.c:2649
 msgid "Show diff of directory"
 msgstr "Exibir diff de diretório"
 
-#: ../geanyvc/src/geanyvc.c:2600
+#: ../geanyvc/src/geanyvc.c:2651
 msgid "Show diff of basedir"
 msgstr "Exibir diff do diretório base"
 
-#: ../geanyvc/src/geanyvc.c:2603
+#: ../geanyvc/src/geanyvc.c:2654
 msgid "Commit changes"
 msgstr "Submeter alterações"
 
-#: ../geanyvc/src/geanyvc.c:2605
+#: ../geanyvc/src/geanyvc.c:2656
 msgid "Show status"
 msgstr "Exibir estado"
 
-#: ../geanyvc/src/geanyvc.c:2607
+#: ../geanyvc/src/geanyvc.c:2658
 msgid "Revert single file"
 msgstr "Reverter arquivo único"
 
-#: ../geanyvc/src/geanyvc.c:2609
+#: ../geanyvc/src/geanyvc.c:2660
 msgid "Revert directory"
 msgstr "Reverter diretório"
 
-#: ../geanyvc/src/geanyvc.c:2611
+#: ../geanyvc/src/geanyvc.c:2662
 msgid "Revert base directory"
 msgstr "Reverter diretório base"
 
-#: ../geanyvc/src/geanyvc.c:2613
+#: ../geanyvc/src/geanyvc.c:2664
 msgid "Update file"
 msgstr "Atualizar arquivo"
 
-#: ../geanyvc/src/geanyvc.c:2643
+#: ../geanyvc/src/geanyvc.c:2694
 msgid "_VC"
 msgstr "C_V"
 
-#: ../geanyvc/src/geanyvc.c:2650
+#: ../geanyvc/src/geanyvc.c:2701
 #, fuzzy
 msgid "_Version Control"
 msgstr "_Incluir no Controle de Versões"
 
 #. Status of basedir
-#: ../geanyvc/src/geanyvc.c:2672
+#: ../geanyvc/src/geanyvc.c:2723
 msgid "_Status"
 msgstr "E_stado"
 
-#: ../geanyvc/src/geanyvc.c:2674
+#: ../geanyvc/src/geanyvc.c:2725
 msgid "Show status."
 msgstr "Exibe estado."
 
-#: ../geanyvc/src/geanyvc.c:2681
+#: ../geanyvc/src/geanyvc.c:2732
 msgid "Update from remote repository."
 msgstr "Atualizar do repositório remoto."
 
 #. Commit all changes
-#: ../geanyvc/src/geanyvc.c:2686
+#: ../geanyvc/src/geanyvc.c:2737
 msgid "_Commit..."
 msgstr "_Submeter..."
 
-#: ../geanyvc/src/geanyvc.c:2688
+#: ../geanyvc/src/geanyvc.c:2739
 msgid "Commit changes."
 msgstr "Submete alterações."
 
@@ -5122,34 +5122,6 @@ msgstr ""
 
 #: ../geniuspaste/src/geniuspaste.c:959
 msgid "_Paste it!"
-msgstr ""
-
-#: ../git-changebar/data/prefs.ui.h:1
-msgid "_Monitor repository for changes"
-msgstr ""
-
-#: ../git-changebar/data/prefs.ui.h:2
-msgid ""
-"Whether to automatically update the diff in order to maintain it up to date "
-"when the underlying Git repository changes.  This should generally be "
-"enabled for optimal user experience."
-msgstr ""
-
-#: ../git-changebar/data/prefs.ui.h:3
-msgid "_Added lines:"
-msgstr ""
-
-#: ../git-changebar/data/prefs.ui.h:4
-msgid "_Changed lines:"
-msgstr ""
-
-#: ../git-changebar/data/prefs.ui.h:5
-#, fuzzy
-msgid "_Removed lines:"
-msgstr "Remover arquivo"
-
-#: ../git-changebar/data/prefs.ui.h:6
-msgid "Colors"
 msgstr ""
 
 #: ../git-changebar/src/gcb-plugin.c:62
@@ -5341,8 +5313,8 @@ msgstr ""
 #: ../lipsum/src/lipsum.c:184 ../sendmail/src/sendmail.c:396
 #, c-format
 msgid ""
-"Your configuration directory has been successfully moved from \"%s\" to \"%s"
-"\"."
+"Your configuration directory has been successfully moved from \"%s\" to "
+"\"%s\"."
 msgstr ""
 
 #: ../lipsum/src/lipsum.c:199
@@ -5520,7 +5492,7 @@ msgstr "Falha ao carregar configuração: %s"
 msgid "Unable to read value for '%s' key: %s"
 msgstr "Falha ao salvar configuração: %s"
 
-#: ../multiterm/src/tab-label.vala:62 ../treebrowser/src/treebrowser.c:2132
+#: ../multiterm/src/tab-label.vala:62 ../treebrowser/src/treebrowser.c:2137
 #, fuzzy
 msgid "Terminal"
 msgstr "terminado"
@@ -5561,116 +5533,6 @@ msgstr ""
 msgid "Show Overview"
 msgstr "Executar no terminal"
 
-#: ../overview/data/prefs.ui.h:1
-msgid ""
-"The amount to zoom the overview sidebar. This should probably negative if "
-"you want the sidebar zoomed out."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:2
-msgid "Zoom Level:"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:3
-msgid "The width of the overview sidebar."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:4
-msgid "Width:"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:5
-msgid ""
-"The number of lines to scroll at a time when scrolling the overview sidebar."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:6
-msgid "Scroll Lines:"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:7
-#, fuzzy
-msgid "Position on left"
-msgstr "nome da posição"
-
-#: ../overview/data/prefs.ui.h:8
-msgid ""
-"Position the overview bar on the left rather than the right (requires Geany "
-"1.25 or greater)."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:9
-#, fuzzy
-msgid "Hide tooltip"
-msgstr "Exibir dicas de ferramentas."
-
-#: ../overview/data/prefs.ui.h:10
-msgid ""
-"Hide the tooltip that is displayed when mousing over the overview that shows "
-"line, column and position information."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:11
-msgid "Hide editor scrollbar"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:12
-msgid ""
-"Whether to hide Geany's regular editor scrollbar while the overview bar is "
-"visible."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:13
-msgid "Disable overlay"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:14
-msgid ""
-"Turn off drawing overlay, which shows the region of the main editor view "
-"that is currently in view, ontop of the overview bar."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:15 ../scope/data/scope.glade.h:130
-#: ../scope/data/scope_gtk3.glade.h:130
-#, fuzzy
-msgid "Options"
-msgstr "_Opções"
-
-#: ../overview/data/prefs.ui.h:16
-msgid ""
-"The color and opacity of the overlay drawn ontop of the overlay sidebar."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:17
-msgid "Color:"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:18
-msgid ""
-"The color and opacity of the border drawn around the revealed area in the "
-"overview sidebar. Set to the same as Overlay Color to disable."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:19
-#, fuzzy
-msgid "Outline Color:"
-msgstr "Selecionar Cor"
-
-#: ../overview/data/prefs.ui.h:20
-msgid "Draw over visible area"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:21
-msgid ""
-"When checked it will draw the overlay ontop of the area that is visible in "
-"the main editor view, when unchecked, it will do the opposite and draw the "
-"overlay everywhere but the visible area, \"revealing\" the visible part."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:22
-msgid "Overlay"
-msgstr ""
-
 #: ../pairtaghighlighter/src/pair_tag_highlighter.c:43
 msgid "Pair Tag Highlighter"
 msgstr ""
@@ -5698,150 +5560,6 @@ msgstr "Selecionar até o C_olchete Casado"
 #, fuzzy
 msgid "Select To Matching Tag"
 msgstr "Selecionar até o C_olchete Casado"
-
-#: ../pohelper/data/menus.ui.h:1
-msgid "_Translation Helper"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:2
-msgid "_Previous String"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:3 ../pohelper/src/gph-plugin.c:1590
-#, fuzzy
-msgid "Go to previous string"
-msgstr "Retornar para o diálogo anterior."
-
-#: ../pohelper/data/menus.ui.h:4
-msgid "_Next String"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:5 ../pohelper/src/gph-plugin.c:1593
-#, fuzzy
-msgid "Go to next string"
-msgstr "Pula para a próxima linha."
-
-#: ../pohelper/data/menus.ui.h:6
-msgid "Pre_vious Untranslated"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:7 ../pohelper/src/gph-plugin.c:1596
-msgid "Go to previous untranslated string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:8
-msgid "Next _Untranslated"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:9 ../pohelper/src/gph-plugin.c:1599
-msgid "Go to next untranslated string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:10
-msgid "Previous Fu_zzy"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:11 ../pohelper/src/gph-plugin.c:1602
-msgid "Go to previous fuzzily translated string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:12
-msgid "Next _Fuzzy"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:13 ../pohelper/src/gph-plugin.c:1605
-msgid "Go to next fuzzily translated string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:14
-msgid "Previous Untranslated or Fuzz_y"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:15 ../pohelper/src/gph-plugin.c:1608
-msgid "Go to previous untranslated or fuzzy string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:16
-msgid "Next Untranslated _or Fuzzy"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:17 ../pohelper/src/gph-plugin.c:1612
-msgid "Go to next untranslated or fuzzy string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:18 ../pohelper/src/gph-plugin.c:1623
-#, fuzzy
-msgid "Toggle current translation fuzziness"
-msgstr "tipo de documentação"
-
-#: ../pohelper/data/menus.ui.h:19
-msgid "_Toggle Fuzziness"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:20
-msgid "Paste _Message as Translation"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:21
-msgid "Paste the original untranslated string to the translation"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:22 ../pohelper/src/gph-plugin.c:1620
-msgid "Reflow the current translation string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:23
-msgid "_Reflow Translation"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:24 ../pohelper/src/gph-plugin.c:1626
-#, fuzzy
-msgid "Show statistics of the current document"
-msgstr "Verifica a ortografia do documento atual."
-
-#: ../pohelper/data/menus.ui.h:25
-#, fuzzy
-msgid "_Show stats"
-msgstr "Exibir estado"
-
-#: ../pohelper/data/menus.ui.h:26
-msgid ""
-"Whether to update the translation headers (author, revision date, ...) upon "
-"file save"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:27
-msgid "Update _Headers Upon Save"
-msgstr ""
-
-#: ../pohelper/data/stats.ui.h:1
-msgid "Translation statistics"
-msgstr ""
-
-#: ../pohelper/data/stats.ui.h:2
-msgid "Choose a color for translated strings"
-msgstr ""
-
-#: ../pohelper/data/stats.ui.h:3
-msgid "Choose a color for fuzzily translated strings"
-msgstr ""
-
-#: ../pohelper/data/stats.ui.h:4
-msgid "Choose a color for untranslated strings"
-msgstr ""
-
-#: ../pohelper/data/stats.ui.h:5
-#, fuzzy
-msgid "Translated:"
-msgstr "Template:"
-
-#: ../pohelper/data/stats.ui.h:6
-msgid "Fuzzy:"
-msgstr ""
-
-#: ../pohelper/data/stats.ui.h:7
-msgid "Untranslated:"
-msgstr ""
 
 #: ../pohelper/src/gph-plugin.c:40
 msgid "Translation Helper"
@@ -5871,9 +5589,57 @@ msgstr ""
 msgid "%u (%.3g%%)"
 msgstr ""
 
+#: ../pohelper/src/gph-plugin.c:1590
+#, fuzzy
+msgid "Go to previous string"
+msgstr "Retornar para o diálogo anterior."
+
+#: ../pohelper/src/gph-plugin.c:1593
+#, fuzzy
+msgid "Go to next string"
+msgstr "Pula para a próxima linha."
+
+#: ../pohelper/src/gph-plugin.c:1596
+msgid "Go to previous untranslated string"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1599
+msgid "Go to next untranslated string"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1602
+msgid "Go to previous fuzzily translated string"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1605
+msgid "Go to next fuzzily translated string"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1608
+msgid "Go to previous untranslated or fuzzy string"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1612
+msgid "Go to next untranslated or fuzzy string"
+msgstr ""
+
 #: ../pohelper/src/gph-plugin.c:1616
 msgid "Paste original untranslated string to translation"
 msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1620
+msgid "Reflow the current translation string"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1623
+#, fuzzy
+msgid "Toggle current translation fuzziness"
+msgstr "tipo de documentação"
+
+#: ../pohelper/src/gph-plugin.c:1626
+#, fuzzy
+msgid "Show statistics of the current document"
+msgstr "Verifica a ortografia do documento atual."
 
 #: ../pohelper/src/gph-plugin.c:1833
 #, c-format
@@ -6154,7 +5920,7 @@ msgid "Add"
 msgstr "Complementos"
 
 #: ../projectorganizer/src/prjorg-sidebar.c:390
-#: ../treebrowser/src/treebrowser.c:2356
+#: ../treebrowser/src/treebrowser.c:2361
 #, fuzzy
 msgid "New File"
 msgstr "NovoArquivo"
@@ -6832,6 +6598,11 @@ msgstr "Exibir dicas de ferramentas."
 msgid "<b>Others</b>"
 msgstr ""
 
+#: ../scope/data/scope.glade.h:130 ../scope/data/scope_gtk3.glade.h:130
+#, fuzzy
+msgid "Options"
+msgstr "_Opções"
+
 #: ../scope/data/scope.glade.h:131 ../scope/data/scope_gtk3.glade.h:131
 #, fuzzy
 msgid "_Import"
@@ -7455,12 +7226,14 @@ msgid "Checks the spelling of the current document."
 msgstr "Verifica a ortografia do documento atual."
 
 #: ../spellcheck/src/scplugin.c:225
-msgid "Run Spell Check"
+#, fuzzy
+msgid "Run spell check once"
 msgstr "Executar verificação ortográfica"
 
-#: ../spellcheck/src/scplugin.c:228
-msgid "Toggle Check While Typing"
-msgstr "Alternar Verificação ao Digitar"
+#: ../spellcheck/src/scplugin.c:228 ../spellcheck/src/scplugin.c:333
+#, fuzzy
+msgid "Toggle spell check"
+msgstr "Verificar Ortografia"
 
 #. initialise the dialog
 #: ../spellcheck/src/scplugin.c:239
@@ -7488,10 +7261,6 @@ msgstr "Imprime palavras mal escritas e sugestões na janela de mensagens"
 #: ../spellcheck/src/scplugin.c:325
 msgid "<b>Interface</b>"
 msgstr ""
-
-#: ../spellcheck/src/scplugin.c:333
-msgid "Check spelling while typing"
-msgstr "Verificar ortografia ao digitar"
 
 #: ../spellcheck/src/scplugin.c:336
 #, fuzzy
@@ -7527,32 +7296,32 @@ msgstr ""
 msgid "<b>Behavior</b>"
 msgstr ""
 
-#: ../spellcheck/src/gui.c:76
+#: ../spellcheck/src/gui.c:88
 msgid "Spell checking while typing is now enabled"
 msgstr "A verificação ortográfica ao digitar está agora habilitada"
 
-#: ../spellcheck/src/gui.c:78
+#: ../spellcheck/src/gui.c:90
 msgid "Spell checking while typing is now disabled"
 msgstr "A verificação ortográfica ao digitar está agora desabilitada"
 
-#: ../spellcheck/src/gui.c:326
+#: ../spellcheck/src/gui.c:323
 msgid "More..."
 msgstr "Mais..."
 
-#: ../spellcheck/src/gui.c:347
+#: ../spellcheck/src/gui.c:344
 msgid "(No Suggestions)"
 msgstr "(Nenhuma Sugestão)"
 
-#: ../spellcheck/src/gui.c:360
+#: ../spellcheck/src/gui.c:357
 #, c-format
 msgid "Add \"%s\" to Dictionary"
 msgstr "Incluir \"%s\" no Dicionário"
 
-#: ../spellcheck/src/gui.c:368
+#: ../spellcheck/src/gui.c:365
 msgid "Ignore All"
 msgstr "Ignorar Tudo"
 
-#: ../spellcheck/src/gui.c:441
+#: ../spellcheck/src/gui.c:438
 msgid ""
 "Search term is too long to provide\n"
 "spelling suggestions in the editor menu."
@@ -7560,21 +7329,21 @@ msgstr ""
 "Termo de pesquisa é muito longo para fornecer\n"
 "sugestões de ortografia no menu do editor."
 
-#: ../spellcheck/src/gui.c:447
+#: ../spellcheck/src/gui.c:444
 msgid "Perform Spell Check"
 msgstr "Verificar Ortografia"
 
-#: ../spellcheck/src/gui.c:609
+#: ../spellcheck/src/gui.c:606
 #, c-format
 msgid "Default (%s)"
 msgstr "Padrão (%s)"
 
-#: ../spellcheck/src/gui.c:620
-#, c-format
-msgid "Toggle spell check while typing (current language: %s)"
+#: ../spellcheck/src/gui.c:617
+#, fuzzy, c-format
+msgid "Toggle spell check (current language: %s)"
 msgstr "Alternar verificação ortográfica ao digitar (linguagem atual: %s)"
 
-#: ../spellcheck/src/gui.c:698
+#: ../spellcheck/src/gui.c:695
 msgid "Spelling Suggestions"
 msgstr "Sugestões de Ortografia"
 
@@ -7670,145 +7439,145 @@ msgstr "Vazio"
 msgid "Could not execute configured external command '%s' (%s)."
 msgstr "Não pode executar o comando externo configurado '%s' (%s)."
 
-#: ../treebrowser/src/treebrowser.c:1089
+#: ../treebrowser/src/treebrowser.c:1093
 msgid "NewDirectory"
 msgstr "NovoDiretório"
 
-#: ../treebrowser/src/treebrowser.c:1091
+#: ../treebrowser/src/treebrowser.c:1095
 msgid "NewFile"
 msgstr "NovoArquivo"
 
-#: ../treebrowser/src/treebrowser.c:1096
+#: ../treebrowser/src/treebrowser.c:1100
 #, c-format
 msgid ""
 "Target file '%s' exists.\n"
 "Do you really want to replace it with an empty file?"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1142
+#: ../treebrowser/src/treebrowser.c:1146
 #, c-format
 msgid "Do you really want to delete '%s' ?"
 msgstr "Você quer mesmo excluir %s?"
 
-#: ../treebrowser/src/treebrowser.c:1255 ../treebrowser/src/treebrowser.c:1257
+#: ../treebrowser/src/treebrowser.c:1259 ../treebrowser/src/treebrowser.c:1261
 msgid "Go _Up"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1263 ../treebrowser/src/treebrowser.c:1265
+#: ../treebrowser/src/treebrowser.c:1267 ../treebrowser/src/treebrowser.c:1269
 #, fuzzy
 msgid "Set _Path From Document"
 msgstr "Definir caminho para o documento"
 
-#: ../treebrowser/src/treebrowser.c:1271 ../treebrowser/src/treebrowser.c:1273
+#: ../treebrowser/src/treebrowser.c:1275 ../treebrowser/src/treebrowser.c:1277
 #, fuzzy
 msgid "_Open Externally"
 msgstr "Abrir externamente"
 
-#: ../treebrowser/src/treebrowser.c:1279
+#: ../treebrowser/src/treebrowser.c:1283
 #, fuzzy
 msgid "Open _Terminal"
 msgstr "Abrir Terminal"
 
-#: ../treebrowser/src/treebrowser.c:1284 ../treebrowser/src/treebrowser.c:1286
+#: ../treebrowser/src/treebrowser.c:1288 ../treebrowser/src/treebrowser.c:1290
 #, fuzzy
 msgid "Set as _Root"
 msgstr "Definir como raiz"
 
-#: ../treebrowser/src/treebrowser.c:1293 ../treebrowser/src/treebrowser.c:1295
+#: ../treebrowser/src/treebrowser.c:1297 ../treebrowser/src/treebrowser.c:1299
 #, fuzzy
 msgid "Refres_h"
 msgstr "Atualizar"
 
-#: ../treebrowser/src/treebrowser.c:1301 ../treebrowser/src/treebrowser.c:1303
+#: ../treebrowser/src/treebrowser.c:1305 ../treebrowser/src/treebrowser.c:1307
 #, fuzzy
 msgid "_Find in Files"
 msgstr "Pesquisa em Projeto"
 
-#: ../treebrowser/src/treebrowser.c:1313 ../treebrowser/src/treebrowser.c:1315
+#: ../treebrowser/src/treebrowser.c:1317 ../treebrowser/src/treebrowser.c:1319
 #, fuzzy
 msgid "N_ew Folder"
 msgstr "Selecionar Cor"
 
-#: ../treebrowser/src/treebrowser.c:1321 ../treebrowser/src/treebrowser.c:1323
+#: ../treebrowser/src/treebrowser.c:1325 ../treebrowser/src/treebrowser.c:1327
 #, fuzzy
 msgid "_New File"
 msgstr "NovoArquivo"
 
-#: ../treebrowser/src/treebrowser.c:1329 ../treebrowser/src/treebrowser.c:1331
+#: ../treebrowser/src/treebrowser.c:1333 ../treebrowser/src/treebrowser.c:1335
 #, fuzzy
 msgid "Rena_me"
 msgstr "Renomear"
 
-#: ../treebrowser/src/treebrowser.c:1350 ../treebrowser/src/treebrowser.c:1352
+#: ../treebrowser/src/treebrowser.c:1354 ../treebrowser/src/treebrowser.c:1356
 #, c-format
 msgid "Close: %s"
 msgstr "Fechar: %s"
 
-#: ../treebrowser/src/treebrowser.c:1359 ../treebrowser/src/treebrowser.c:1361
+#: ../treebrowser/src/treebrowser.c:1363 ../treebrowser/src/treebrowser.c:1365
 #, fuzzy, c-format
 msgid "Clo_se Child Documents "
 msgstr "Fec_har Outros Documentos"
 
-#: ../treebrowser/src/treebrowser.c:1368 ../treebrowser/src/treebrowser.c:1370
+#: ../treebrowser/src/treebrowser.c:1372 ../treebrowser/src/treebrowser.c:1374
 #, fuzzy
 msgid "_Copy Full Path to Clipboard"
 msgstr "Copiar caminho completo"
 
-#: ../treebrowser/src/treebrowser.c:1381 ../treebrowser/src/treebrowser.c:1383
+#: ../treebrowser/src/treebrowser.c:1385 ../treebrowser/src/treebrowser.c:1387
 #, fuzzy
 msgid "E_xpand All"
 msgstr "Expandir tudo"
 
-#: ../treebrowser/src/treebrowser.c:1389 ../treebrowser/src/treebrowser.c:1391
+#: ../treebrowser/src/treebrowser.c:1393 ../treebrowser/src/treebrowser.c:1395
 #, fuzzy
 msgid "Coll_apse All"
 msgstr "Colapsar tudo"
 
-#: ../treebrowser/src/treebrowser.c:1399
+#: ../treebrowser/src/treebrowser.c:1403
 #, fuzzy
 msgid "Show Boo_kmarks"
 msgstr "Exibir marcadores"
 
-#: ../treebrowser/src/treebrowser.c:1404
+#: ../treebrowser/src/treebrowser.c:1408
 #, fuzzy
 msgid "Sho_w Hidden Files"
 msgstr "Exibir arquivos ocultos"
 
-#: ../treebrowser/src/treebrowser.c:1409
+#: ../treebrowser/src/treebrowser.c:1413
 #, fuzzy
 msgid "Show Tool_bars"
 msgstr "Exibir barras"
 
-#: ../treebrowser/src/treebrowser.c:1747
+#: ../treebrowser/src/treebrowser.c:1751
 #, c-format
 msgid "Target file '%s' exists, do you really want to replace it?"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1883
+#: ../treebrowser/src/treebrowser.c:1887
 msgid "Go up"
 msgstr "Ir para cima"
 
-#: ../treebrowser/src/treebrowser.c:1893 ../treebrowser/src/treebrowser.c:2360
+#: ../treebrowser/src/treebrowser.c:1897 ../treebrowser/src/treebrowser.c:2365
 msgid "Refresh"
 msgstr "Atualizar"
 
-#: ../treebrowser/src/treebrowser.c:1903
+#: ../treebrowser/src/treebrowser.c:1907
 msgid "Home"
 msgstr "Home"
 
-#: ../treebrowser/src/treebrowser.c:1913
+#: ../treebrowser/src/treebrowser.c:1917
 msgid "Set path from document"
 msgstr "Definir caminho para o documento"
 
-#: ../treebrowser/src/treebrowser.c:1923
+#: ../treebrowser/src/treebrowser.c:1927
 msgid "Track path"
 msgstr "Rastrear caminho"
 
-#: ../treebrowser/src/treebrowser.c:1933
+#: ../treebrowser/src/treebrowser.c:1937
 msgid "Hide bars"
 msgstr "Ocultar barras"
 
-#: ../treebrowser/src/treebrowser.c:1943
+#: ../treebrowser/src/treebrowser.c:1947
 msgid ""
 "Filter (*.c;*.h;*.cpp), and if you want temporary filter using the '!' "
 "reverse try for example this '!;*.c;*.h;*.cpp'"
@@ -7816,20 +7585,20 @@ msgstr ""
 "Filtrar (*.c;*.h;*.cpp), e se você quiser filtrar temporariamente usando o "
 "'!' inverso, tente por exemplo isso '!;*.c;*.h;*.cpp'"
 
-#: ../treebrowser/src/treebrowser.c:1948
+#: ../treebrowser/src/treebrowser.c:1952
 msgid "Addressbar for example '/projects/my-project'"
 msgstr "Barra de endereços por exemplo '/projetos/meu-projeto'"
 
-#: ../treebrowser/src/treebrowser.c:1973
+#: ../treebrowser/src/treebrowser.c:1977
 msgid "Tree Browser"
 msgstr "Navegador em Árvore"
 
-#: ../treebrowser/src/treebrowser.c:2114
+#: ../treebrowser/src/treebrowser.c:2118
 msgid "External open command"
 msgstr "Comando de abrir externo"
 
-#: ../treebrowser/src/treebrowser.c:2124
-#, c-format
+#: ../treebrowser/src/treebrowser.c:2129
+#, no-c-format
 msgid ""
 "The command to execute when using \"Open with\". You can use %f and %d "
 "wildcards.\n"
@@ -7843,63 +7612,63 @@ msgstr ""
 "%d será substituído pelo nome do caminho do arquivo selecionado sem o nome "
 "do arquivo"
 
-#: ../treebrowser/src/treebrowser.c:2143
+#: ../treebrowser/src/treebrowser.c:2148
 msgid "The terminal to use with the command \"Open Terminal\""
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2149
+#: ../treebrowser/src/treebrowser.c:2154
 msgid "Toolbar"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2151
+#: ../treebrowser/src/treebrowser.c:2156
 msgid "Hidden"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2152
+#: ../treebrowser/src/treebrowser.c:2157
 msgid "Top"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2153
+#: ../treebrowser/src/treebrowser.c:2158
 msgid "Bottom"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2158
+#: ../treebrowser/src/treebrowser.c:2163
 #, fuzzy
 msgid "If position is changed, the option require plugin restart."
 msgstr "Exibir barras no topo (Exige que o plugin seja reiniciado)"
 
-#: ../treebrowser/src/treebrowser.c:2162
+#: ../treebrowser/src/treebrowser.c:2167
 #, fuzzy
 msgid "Show icons"
 msgstr "Exibir ícones."
 
-#: ../treebrowser/src/treebrowser.c:2164
+#: ../treebrowser/src/treebrowser.c:2169
 msgid "None"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2165
+#: ../treebrowser/src/treebrowser.c:2170
 #, fuzzy
 msgid "Base"
 msgstr "_Base:"
 
-#: ../treebrowser/src/treebrowser.c:2166
+#: ../treebrowser/src/treebrowser.c:2171
 #, fuzzy
 msgid "Content-type"
 msgstr "Conteúdos"
 
-#: ../treebrowser/src/treebrowser.c:2172
+#: ../treebrowser/src/treebrowser.c:2177
 msgid "Show hidden files"
 msgstr "Exibir arquivos ocultos"
 
-#: ../treebrowser/src/treebrowser.c:2181
+#: ../treebrowser/src/treebrowser.c:2186
 msgid "On Windows, this just hide files that are prefixed with '.' (dot)"
 msgstr "No Windows, isso apenas oculta arquivos prefixados com '.' (ponto)"
 
-#: ../treebrowser/src/treebrowser.c:2183
+#: ../treebrowser/src/treebrowser.c:2188
 msgid "Hide object files"
 msgstr "Ocultar arquivos de objeto"
 
-#: ../treebrowser/src/treebrowser.c:2192
+#: ../treebrowser/src/treebrowser.c:2197
 msgid ""
 "Don't show generated object files in the file browser, this includes *.o, *."
 "obj. *.so, *.dll, *.a, *.lib"
@@ -7907,63 +7676,63 @@ msgstr ""
 "Não exibir arquivos de objetos gerados no navegador de arquivos. Isso inclui "
 "*.o, *.obj. *.so, *.dll, *.a, *.lib"
 
-#: ../treebrowser/src/treebrowser.c:2194
+#: ../treebrowser/src/treebrowser.c:2199
 msgid "Reverse filter"
 msgstr "Reverter filtro"
 
-#: ../treebrowser/src/treebrowser.c:2203
+#: ../treebrowser/src/treebrowser.c:2208
 msgid "Follow current document"
 msgstr "Seguir documento atual"
 
-#: ../treebrowser/src/treebrowser.c:2212
+#: ../treebrowser/src/treebrowser.c:2217
 msgid "Single click, open document and focus it"
 msgstr "Clique simples, abrir documento e focá-lo"
 
-#: ../treebrowser/src/treebrowser.c:2221
+#: ../treebrowser/src/treebrowser.c:2226
 msgid "Double click open directory"
 msgstr "Duplo clique abre diretório"
 
-#: ../treebrowser/src/treebrowser.c:2230
+#: ../treebrowser/src/treebrowser.c:2235
 msgid "On delete file, close it if is opened"
 msgstr "Ao excluir arquivo, fechá-lo se ele estiver aberto"
 
-#: ../treebrowser/src/treebrowser.c:2239
+#: ../treebrowser/src/treebrowser.c:2244
 msgid "Focus editor on file open"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2248
+#: ../treebrowser/src/treebrowser.c:2253
 msgid "Show tree lines"
 msgstr "Exibir linhas da árvore"
 
-#: ../treebrowser/src/treebrowser.c:2257
+#: ../treebrowser/src/treebrowser.c:2262
 msgid "Show bookmarks"
 msgstr "Exibir marcadores"
 
-#: ../treebrowser/src/treebrowser.c:2266
+#: ../treebrowser/src/treebrowser.c:2271
 #, fuzzy
 msgid "Open new files"
 msgstr "Abrir arquivo"
 
-#: ../treebrowser/src/treebrowser.c:2350
+#: ../treebrowser/src/treebrowser.c:2355
 #, fuzzy
 msgid "Focus File List"
 msgstr "Focar Lista de Tarefas"
 
-#: ../treebrowser/src/treebrowser.c:2352
+#: ../treebrowser/src/treebrowser.c:2357
 msgid "Focus Path Entry"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2354
+#: ../treebrowser/src/treebrowser.c:2359
 #, fuzzy
 msgid "Rename Object"
 msgstr "Renomear"
 
-#: ../treebrowser/src/treebrowser.c:2358
+#: ../treebrowser/src/treebrowser.c:2363
 #, fuzzy
 msgid "New Folder"
 msgstr "Selecionar Cor"
 
-#: ../treebrowser/src/treebrowser.c:2362
+#: ../treebrowser/src/treebrowser.c:2367
 #, fuzzy
 msgid "Track Current"
 msgstr "Rastrear caminho"
@@ -8671,13 +8440,6 @@ msgstr "NovoDiretório"
 msgid "No workbench opened."
 msgstr ""
 
-#: ../workbench/src/sidebar.c:875
-#, fuzzy, c-format
-msgid "%s: %u Project"
-msgid_plural "%s: %u Projects"
-msgstr[0] "Projeto"
-msgstr[1] "Projeto"
-
 #: ../workbench/src/sidebar.c:886
 msgid ""
 "Add a project using the context menu\n"
@@ -8786,6 +8548,42 @@ msgstr ""
 #: ../xmlsnippets/src/plugin.c:45
 msgid "Autocompletes XML/HTML tags using snippets."
 msgstr ""
+
+#, fuzzy
+#~ msgid "_Removed lines:"
+#~ msgstr "Remover arquivo"
+
+#, fuzzy
+#~ msgid "Position on left"
+#~ msgstr "nome da posição"
+
+#, fuzzy
+#~ msgid "Hide tooltip"
+#~ msgstr "Exibir dicas de ferramentas."
+
+#, fuzzy
+#~ msgid "Outline Color:"
+#~ msgstr "Selecionar Cor"
+
+#, fuzzy
+#~ msgid "_Show stats"
+#~ msgstr "Exibir estado"
+
+#, fuzzy
+#~ msgid "Translated:"
+#~ msgstr "Template:"
+
+#~ msgid "Toggle Check While Typing"
+#~ msgstr "Alternar Verificação ao Digitar"
+
+#~ msgid "Check spelling while typing"
+#~ msgstr "Verificar ortografia ao digitar"
+
+#, fuzzy, c-format
+#~ msgid "%s: %u Project"
+#~ msgid_plural "%s: %u Projects"
+#~ msgstr[0] "Projeto"
+#~ msgstr[1] "Projeto"
 
 #~ msgid "GeanyLaTeX"
 #~ msgstr "GeanyLaTeX"

--- a/po/ru.po
+++ b/po/ru.po
@@ -9,8 +9,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Geany-Plugins 1.30\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-29 19:41+0200\n"
+"Report-Msgid-Bugs-To: https://github.com/geany/geany/issues\n"
+"POT-Creation-Date: 2022-06-28 07:39+0200\n"
 "PO-Revision-Date: 2020-05-01 16:20+1000\n"
 "Last-Translator: Dmitry Unruh <dmitryunruh@googlemail.com>\n"
 "Language-Team: Russian <geany-i18n@uvena.de>\n"
@@ -18,34 +18,34 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
 #: ../addons/src/ao_bookmarklist.c:190
 msgid "(Empty Line)"
 msgstr "(Пустая строка)"
 
-#: ../addons/src/ao_bookmarklist.c:315
+#: ../addons/src/ao_bookmarklist.c:331
 msgid "_Remove Bookmark"
 msgstr "Удалить закладку"
 
 #. Translators: Number is meant at this point.
-#: ../addons/src/ao_bookmarklist.c:342
+#: ../addons/src/ao_bookmarklist.c:358
 msgid "No."
 msgstr "Стр."
 
-#: ../addons/src/ao_bookmarklist.c:350 ../devhelp/src/dhp-object.c:494
+#: ../addons/src/ao_bookmarklist.c:366 ../devhelp/src/dhp-object.c:494
 #: ../devhelp/devhelp/dh-window.c:1142
 msgid "Contents"
 msgstr "Содержание"
 
-#: ../addons/src/ao_bookmarklist.c:383 ../treebrowser/src/treebrowser.c:666
+#: ../addons/src/ao_bookmarklist.c:399 ../treebrowser/src/treebrowser.c:666
 #: ../webhelper/src/gwh-plugin.c:328
 msgid "Bookmarks"
 msgstr "Закладки"
 
 #. complete update
-#: ../addons/src/ao_tasks.c:373 ../geanyvc/src/geanyvc.c:2679
+#: ../addons/src/ao_tasks.c:373 ../geanyvc/src/geanyvc.c:2730
 msgid "_Update"
 msgstr "_Обновить"
 
@@ -167,10 +167,10 @@ msgstr "Скопировать путь до текущего документа
 #: ../addons/src/addons.c:364 ../autoclose/src/autoclose.c:920
 #: ../codenav/src/codenavigation.c:281 ../latex/src/latex.c:208
 #: ../latex/src/latex.c:293 ../geanyprj/src/geanyprj.c:176
-#: ../geanyvc/src/geanyvc.c:2079 ../geniuspaste/src/geniuspaste.c:336
+#: ../geanyvc/src/geanyvc.c:2130 ../geniuspaste/src/geniuspaste.c:336
 #: ../lineoperations/src/lo_prefs.c:58 ../sendmail/src/sendmail.c:128
 #: ../sendmail/src/sendmail.c:293 ../spellcheck/src/scplugin.c:124
-#: ../treebrowser/src/treebrowser.c:2102
+#: ../treebrowser/src/treebrowser.c:2106
 #: ../updatechecker/src/updatechecker.c:262
 msgid "Plugin configuration directory could not be created."
 msgstr "Каталог настроек плагина не может быть создан."
@@ -528,8 +528,8 @@ msgid ""
 msgstr ""
 "Удалять левую и правую скобку при нажатии Shift+BackSpace, как бы далеко они "
 "не находились.\n"
-"Подсказка: чтобы удалить полностью блок с отступом, просто нажмите Shift"
-"+BackSpace рядом с первым символом \"{\" или последним символом \"}\"."
+"Подсказка: чтобы удалить полностью блок с отступом, просто нажмите "
+"Shift+BackSpace рядом с первым символом \"{\" или последним символом \"}\"."
 
 #: ../autoclose/src/autoclose.c:1147
 msgid "Jump on Tab to enclosed char"
@@ -748,7 +748,7 @@ msgstr "~\"Загрузка файла.\\n\""
 msgid "Error loading file"
 msgstr "Ошибка загрузки файла"
 
-#. setting asyncronous mode
+#. setting asynchronous mode
 #. setting null-stop array printing
 #. enable pretty printing
 #: ../debugger/src/dbm_gdb.c:789 ../debugger/src/dbm_gdb.c:792
@@ -1143,7 +1143,7 @@ msgid "A developers' help browser for GNOME"
 msgstr "Просмотр документации для разработчиков"
 
 #. Create the current file Submenu
-#: ../devhelp/devhelp/dh-window.c:759 ../geanyvc/src/geanyvc.c:2660
+#: ../devhelp/devhelp/dh-window.c:759 ../geanyvc/src/geanyvc.c:2711
 msgid "_File"
 msgstr "_Файл"
 
@@ -1177,11 +1177,11 @@ msgstr "Новая вкладка"
 msgid "_Print…"
 msgstr "Печать…"
 
-#: ../devhelp/devhelp/dh-window.c:782 ../devhelp/devhelp/eggfindbar.c:342
+#: ../devhelp/devhelp/dh-window.c:782
 msgid "Find Next"
 msgstr "Найти следующее"
 
-#: ../devhelp/devhelp/dh-window.c:784 ../devhelp/devhelp/eggfindbar.c:329
+#: ../devhelp/devhelp/dh-window.c:784
 msgid "Find Previous"
 msgstr "Найти предыдущее"
 
@@ -1366,7 +1366,7 @@ msgid ""
 "contributing to this plugin?"
 msgstr ""
 
-#: ../geanydoc/src/geanydoc.c:159 ../geanyvc/src/geanyvc.c:442
+#: ../geanydoc/src/geanydoc.c:159 ../geanyvc/src/geanyvc.c:448
 msgid "Could not parse the output of command"
 msgstr "Невозможно проанализировать вывод команды"
 
@@ -3072,7 +3072,7 @@ msgstr ""
 "Ошибка в модуле \"%s\" в функции %s():\n"
 "недостаточно аргументов для команды \"%s\".\n"
 
-#: ../geanylua/glspi_sci.c:637 ../geanylua/glspi_app.c:406
+#: ../geanylua/glspi_sci.c:729 ../geanylua/glspi_app.c:406
 #, c-format
 msgid ""
 "Error in module \"%s\" at function %s():\n"
@@ -3081,7 +3081,7 @@ msgstr ""
 "Ошибка в модуле \"%s\" в функции %s():\n"
 "неизвестная команда \"%s\" в аргументе #1.\n"
 
-#: ../geanylua/glspi_sci.c:781
+#: ../geanylua/glspi_sci.c:924
 #, c-format
 msgid ""
 "Error in module \"%s\" at function %s():\n"
@@ -3092,7 +3092,7 @@ msgstr ""
 " некорректная таблица в аргументе #%d:\n"
 " неизвестный флаг \"%s\" для элемента #%d\n"
 
-#: ../geanylua/glspi_sci.c:785
+#: ../geanylua/glspi_sci.c:928
 msgid "<too large to display>"
 msgstr "<слишком велик для отображения>"
 
@@ -3882,7 +3882,7 @@ msgid "New _Below"
 msgstr "Д_обавить ниже"
 
 #: ../geanymacro/src/geanymacro.c:1824 ../geanymacro/src/geanymacro.c:2120
-#: ../treebrowser/src/treebrowser.c:1338 ../treebrowser/src/treebrowser.c:1340
+#: ../treebrowser/src/treebrowser.c:1342 ../treebrowser/src/treebrowser.c:1344
 msgid "_Delete"
 msgstr "_Удалить"
 
@@ -4155,13 +4155,13 @@ msgstr ""
 "\n"
 "Он позволяет использовать до 10 нумерованных закладок. Чтобы установить "
 "нумерованную закладку, нажмите сочетание клавиш Ctrl+Shift+число от 0 до 9. "
-"Вы увидите маркер рядом с номером строки. Если нажать сочетание Ctrl+Shift"
-"+число на строке, в которой уже есть закладка с таким номером, закладка "
-"удаляется, в противном случае закладка перемещается, если она уже была "
-"назначена на другой строке или создаётся, если она ещё не была установлена. "
-"Возле номера строки отображается только последняя закладка, но можно "
-"устанавливать более одной закладки на одну строку. Чтобы перейти к ранее "
-"установленной закладке, нажмите сочетание клавиш Ctrl+число от 0 до 9."
+"Вы увидите маркер рядом с номером строки. Если нажать сочетание "
+"Ctrl+Shift+число на строке, в которой уже есть закладка с таким номером, "
+"закладка удаляется, в противном случае закладка перемещается, если она уже "
+"была назначена на другой строке или создаётся, если она ещё не была "
+"установлена. Возле номера строки отображается только последняя закладка, но "
+"можно устанавливать более одной закладки на одну строку. Чтобы перейти к "
+"ранее установленной закладке, нажмите сочетание клавиш Ctrl+число от 0 до 9."
 
 #: ../geanynumberedbookmarks/src/geanynumberedbookmarks.c:1408
 msgid "Unable to apply markers as all being used."
@@ -4293,8 +4293,8 @@ msgstr ""
 msgid "a key with fingerprint"
 msgstr "ключ с отпечатком"
 
-#: ../geanypg/src/verify_aux.c:66 ../spellcheck/src/gui.c:610
-#: ../spellcheck/src/gui.c:621
+#: ../geanypg/src/verify_aux.c:66 ../spellcheck/src/gui.c:607
+#: ../spellcheck/src/gui.c:618
 msgid "unknown"
 msgstr "неизвестно"
 
@@ -4602,49 +4602,49 @@ msgid ""
 "contributing to this plugin?"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:501
+#: ../geanyvc/src/geanyvc.c:507
 #, c-format
 msgid "geanyvc: s_spawn_sync error: %s"
 msgstr "geanyvc: ошибка s_spawn_sync: %s"
 
-#: ../geanyvc/src/geanyvc.c:587
+#: ../geanyvc/src/geanyvc.c:593
 #, c-format
 msgid "File %s: action %s executed via %s."
 msgstr "Файл %s: действие %s выполняется через %s."
 
-#: ../geanyvc/src/geanyvc.c:646 ../geanyvc/src/geanyvc.c:657
-#, c-format
-msgid "geanyvc: vcdiff_file_activated: Unable to rename '%s' to '%s'"
+#: ../geanyvc/src/geanyvc.c:633 ../geanyvc/src/geanyvc.c:643
+#, fuzzy, c-format
+msgid "geanyvc: diff_external: Unable to rename '%s' to '%s'"
 msgstr "geanyvc: vcdiff_file_activated: Невозможно переименовать '%s' в '%s'"
 
-#: ../geanyvc/src/geanyvc.c:683 ../geanyvc/src/geanyvc.c:733
+#: ../geanyvc/src/geanyvc.c:698 ../geanyvc/src/geanyvc.c:784
 msgid "No changes were made."
 msgstr "Изменения не были применены."
 
-#: ../geanyvc/src/geanyvc.c:760
+#: ../geanyvc/src/geanyvc.c:811
 msgid "No history available"
 msgstr "История не доступна"
 
-#: ../geanyvc/src/geanyvc.c:953 ../geanyvc/src/geanyvc.c:961
+#: ../geanyvc/src/geanyvc.c:1004 ../geanyvc/src/geanyvc.c:1012
 #, c-format
 msgid "Do you really want to revert: %s?"
 msgstr "Вы действительно хотите отменить изменения: %s?"
 
-#: ../geanyvc/src/geanyvc.c:969
+#: ../geanyvc/src/geanyvc.c:1020
 #, c-format
 msgid "Do you really want to add: %s?"
 msgstr "Вы действительно хотите добавить в репозиторий: %s?"
 
-#: ../geanyvc/src/geanyvc.c:976
+#: ../geanyvc/src/geanyvc.c:1027
 #, c-format
 msgid "Do you really want to remove: %s?"
 msgstr "Вы действительно хотите удалиь из репозитория: %s?"
 
-#: ../geanyvc/src/geanyvc.c:999
+#: ../geanyvc/src/geanyvc.c:1050
 msgid "Do you really want to update?"
 msgstr "Вы действительно хотите обновить из репозитория: %s?"
 
-#: ../geanyvc/src/geanyvc.c:1126
+#: ../geanyvc/src/geanyvc.c:1177
 msgid ""
 "The resulting differences cannot be displayed because the changes are too "
 "big to display here and would slow down the UI significantly.\n"
@@ -4659,48 +4659,48 @@ msgstr ""
 "различий в Geany непосредственно используя меню GeanyVC (Базовый каталог -> "
 "Разница)."
 
-#: ../geanyvc/src/geanyvc.c:1280
+#: ../geanyvc/src/geanyvc.c:1331
 msgid "Commit Y/N"
 msgstr "Фиксировать изменения Да/Нет"
 
-#: ../geanyvc/src/geanyvc.c:1290
+#: ../geanyvc/src/geanyvc.c:1341
 msgid "Status"
 msgstr "Статус"
 
-#: ../geanyvc/src/geanyvc.c:1297
+#: ../geanyvc/src/geanyvc.c:1348
 msgid "Path"
 msgstr "Путь"
 
-#: ../geanyvc/src/geanyvc.c:1414
+#: ../geanyvc/src/geanyvc.c:1465
 msgid "Choose a previous commit message"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1476
+#: ../geanyvc/src/geanyvc.c:1527
 #, c-format
 msgid "Line: %d Column: %d"
 msgstr "Строка: %d позиция: %d"
 
-#: ../geanyvc/src/geanyvc.c:1523
+#: ../geanyvc/src/geanyvc.c:1574
 msgid "Commit"
 msgstr "Фиксировать"
 
-#: ../geanyvc/src/geanyvc.c:1564
+#: ../geanyvc/src/geanyvc.c:1615
 msgid "_De-/select all files"
 msgstr "Все файлы"
 
-#: ../geanyvc/src/geanyvc.c:1608
+#: ../geanyvc/src/geanyvc.c:1659
 msgid "<b>Commit message:</b>"
 msgstr "<b>Комментарий к изменениям:</b>"
 
-#: ../geanyvc/src/geanyvc.c:1632
+#: ../geanyvc/src/geanyvc.c:1683
 msgid "C_ommit"
 msgstr "Ф_иксировать изменения"
 
-#: ../geanyvc/src/geanyvc.c:1740
+#: ../geanyvc/src/geanyvc.c:1791
 msgid "Nothing to commit."
 msgstr "Отсутствуют локальные изменения."
 
-#: ../geanyvc/src/geanyvc.c:1788
+#: ../geanyvc/src/geanyvc.c:1839
 #, c-format
 msgid ""
 "Error initializing GeanyVC spell checking: %s. Check your configuration."
@@ -4708,26 +4708,26 @@ msgstr ""
 "Ошибка инициализации системы проверки правописания: %s. Проверьте настройки "
 "системы."
 
-#: ../geanyvc/src/geanyvc.c:1823
+#: ../geanyvc/src/geanyvc.c:1874
 #, c-format
 msgid "Commit failed (status: %d, error: %s)."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1824
+#: ../geanyvc/src/geanyvc.c:1875
 #, fuzzy
 msgid "Commit failed; see status in the Message window."
 msgstr "Показывать вкладку со списком задач в окне сообщений"
 
-#: ../geanyvc/src/geanyvc.c:1829
+#: ../geanyvc/src/geanyvc.c:1880
 #, fuzzy
 msgid "Changes committed."
 msgstr "Отсутствуют локальные изменения."
 
-#: ../geanyvc/src/geanyvc.c:2151
+#: ../geanyvc/src/geanyvc.c:2202
 msgid "Set Changed-flag for document tabs created by the plugin"
 msgstr "Устанавливать флаг \"изменённый\" для вкладок созданных плагином"
 
-#: ../geanyvc/src/geanyvc.c:2154
+#: ../geanyvc/src/geanyvc.c:2205
 msgid ""
 "If this option is activated, every new by the VC-plugin created document tab "
 "will be marked as changed. Even this option is useful in some cases, it "
@@ -4737,44 +4737,44 @@ msgstr ""
 "как модифицированный. Несмотря на то, что данная опция в некоторых случаях "
 "полезна, она может вызвать большое количество диалогов сохранения файла."
 
-#: ../geanyvc/src/geanyvc.c:2162
+#: ../geanyvc/src/geanyvc.c:2213
 msgid "Confirm adding new files to a VCS"
 msgstr "Подтверждать добавление файлов в репозиторий"
 
-#: ../geanyvc/src/geanyvc.c:2165
+#: ../geanyvc/src/geanyvc.c:2216
 msgid "Shows a confirmation dialog on adding a new (created) file to VCS."
 msgstr ""
 "Показывать диалог подтверждения при добавлении новых файлов в репозиторий"
 
-#: ../geanyvc/src/geanyvc.c:2171
+#: ../geanyvc/src/geanyvc.c:2222
 msgid "Maximize commit dialog"
 msgstr "Разворачивать диалог фиксации изменений"
 
-#: ../geanyvc/src/geanyvc.c:2172
+#: ../geanyvc/src/geanyvc.c:2223
 msgid "Show commit dialog maximize."
 msgstr "Максимизировать диалог фиксации изменений "
 
-#: ../geanyvc/src/geanyvc.c:2178
+#: ../geanyvc/src/geanyvc.c:2229
 msgid "Use external diff viewer"
 msgstr "Использовать внешнюю программу просмотра разницы"
 
-#: ../geanyvc/src/geanyvc.c:2180
+#: ../geanyvc/src/geanyvc.c:2231
 msgid "Use external diff viewer for file diff."
 msgstr "Использовать внешнюю программу просмотра разницы для файла"
 
-#: ../geanyvc/src/geanyvc.c:2186
+#: ../geanyvc/src/geanyvc.c:2237
 msgid "Show VC entries at editor menu"
 msgstr "Показывать пункты системы контроля версий в меню редактора"
 
-#: ../geanyvc/src/geanyvc.c:2188
+#: ../geanyvc/src/geanyvc.c:2239
 msgid "Show entries for VC functions inside editor menu"
 msgstr "Показывать пункты меню системы контроля версий в меню редактора"
 
-#: ../geanyvc/src/geanyvc.c:2193
+#: ../geanyvc/src/geanyvc.c:2244
 msgid "Attach menu to menubar"
 msgstr "Разместить меню на главной панели"
 
-#: ../geanyvc/src/geanyvc.c:2195
+#: ../geanyvc/src/geanyvc.c:2246
 msgid ""
 "Whether menu for this plugin are getting placed either inside tools menu or "
 "directly inside Geany's menubar. Will take in account after next start of "
@@ -4784,213 +4784,213 @@ msgstr ""
 "непосредственно на главной панели меню Geany. Изменения вступают в силу "
 "только после перезапуска расширения GeanyVC"
 
-#: ../geanyvc/src/geanyvc.c:2203
+#: ../geanyvc/src/geanyvc.c:2254
 msgid "Enable CVS"
 msgstr "Включить CVS"
 
-#: ../geanyvc/src/geanyvc.c:2208
+#: ../geanyvc/src/geanyvc.c:2259
 msgid "Enable GIT"
 msgstr "Включить GIT"
 
-#: ../geanyvc/src/geanyvc.c:2213
+#: ../geanyvc/src/geanyvc.c:2264
 msgid "Enable Fossil"
 msgstr "Включить Fossil"
 
-#: ../geanyvc/src/geanyvc.c:2218
+#: ../geanyvc/src/geanyvc.c:2269
 msgid "Enable SVN"
 msgstr "Включить SVN"
 
-#: ../geanyvc/src/geanyvc.c:2223
+#: ../geanyvc/src/geanyvc.c:2274
 msgid "Enable SVK"
 msgstr "Включить SVK"
 
-#: ../geanyvc/src/geanyvc.c:2228
+#: ../geanyvc/src/geanyvc.c:2279
 msgid "Enable Bazaar"
 msgstr "Включить Bazaar"
 
-#: ../geanyvc/src/geanyvc.c:2233
+#: ../geanyvc/src/geanyvc.c:2284
 msgid "Enable Mercurial"
 msgstr "Включить Mercurial"
 
-#: ../geanyvc/src/geanyvc.c:2239
+#: ../geanyvc/src/geanyvc.c:2290
 msgid "Spellcheck language"
 msgstr "Язык проверки орфографии"
 
 #. Diff of current file
 #. Diff of the current dir
 #. Complete diff of base directory
-#: ../geanyvc/src/geanyvc.c:2368 ../geanyvc/src/geanyvc.c:2463
-#: ../geanyvc/src/geanyvc.c:2503
+#: ../geanyvc/src/geanyvc.c:2419 ../geanyvc/src/geanyvc.c:2514
+#: ../geanyvc/src/geanyvc.c:2554
 msgid "_Diff"
 msgstr "_Разница"
 
-#: ../geanyvc/src/geanyvc.c:2371
+#: ../geanyvc/src/geanyvc.c:2422
 msgid "Make a diff from the current active file"
 msgstr "Показать разницу для текущего файла"
 
 #. Revert current file
 #. Revert current dir
 #. Revert everything
-#: ../geanyvc/src/geanyvc.c:2376 ../geanyvc/src/geanyvc.c:2472
-#: ../geanyvc/src/geanyvc.c:2511
+#: ../geanyvc/src/geanyvc.c:2427 ../geanyvc/src/geanyvc.c:2523
+#: ../geanyvc/src/geanyvc.c:2562
 msgid "_Revert"
 msgstr "Отменить изменения"
 
-#: ../geanyvc/src/geanyvc.c:2379
+#: ../geanyvc/src/geanyvc.c:2430
 msgid "Restore pristine working copy file (undo local edits)."
 msgstr "Восстановить файл из рабочей копии (отмена локальных изменений)."
 
 #. Blame for current file
-#: ../geanyvc/src/geanyvc.c:2388
+#: ../geanyvc/src/geanyvc.c:2439
 msgid "_Blame"
 msgstr "_Изменения"
 
-#: ../geanyvc/src/geanyvc.c:2391
+#: ../geanyvc/src/geanyvc.c:2442
 msgid "Shows the changes made at one file per revision and author."
 msgstr "Показать изменения сделанные в файле по номеру ревизии и автору."
 
 #. History/log of current file
 #. History/log of the current dir
 #. Complete History/Log of base directory
-#: ../geanyvc/src/geanyvc.c:2398 ../geanyvc/src/geanyvc.c:2482
-#: ../geanyvc/src/geanyvc.c:2523
+#: ../geanyvc/src/geanyvc.c:2449 ../geanyvc/src/geanyvc.c:2533
+#: ../geanyvc/src/geanyvc.c:2574
 msgid "_History (log)"
 msgstr "_История"
 
-#: ../geanyvc/src/geanyvc.c:2401
+#: ../geanyvc/src/geanyvc.c:2452
 msgid "Shows the log of the current file"
 msgstr "Показать лог для текущего файла"
 
 #. base version of the current file
-#: ../geanyvc/src/geanyvc.c:2406
+#: ../geanyvc/src/geanyvc.c:2457
 msgid "_Original"
 msgstr "_Оригинал"
 
-#: ../geanyvc/src/geanyvc.c:2409
+#: ../geanyvc/src/geanyvc.c:2460
 msgid "Shows the original of the current file"
 msgstr "Показать оригинальный файл из рабочей копии"
 
 #. add current file
-#: ../geanyvc/src/geanyvc.c:2417
+#: ../geanyvc/src/geanyvc.c:2468
 msgid "_Add to Version Control"
 msgstr "Добавить в репозиторий"
 
-#: ../geanyvc/src/geanyvc.c:2419
+#: ../geanyvc/src/geanyvc.c:2470
 msgid "Add file to repository."
 msgstr "Добавить файл в репозиторий"
 
 #. remove current file
-#: ../geanyvc/src/geanyvc.c:2425
+#: ../geanyvc/src/geanyvc.c:2476
 msgid "_Remove from Version Control"
 msgstr "Удалить из репозитория"
 
-#: ../geanyvc/src/geanyvc.c:2427
+#: ../geanyvc/src/geanyvc.c:2478
 msgid "Remove file from repository."
 msgstr "Удалить файл из репозитория"
 
-#: ../geanyvc/src/geanyvc.c:2460
+#: ../geanyvc/src/geanyvc.c:2511
 msgid "_Directory"
 msgstr "_Каталог"
 
-#: ../geanyvc/src/geanyvc.c:2466
+#: ../geanyvc/src/geanyvc.c:2517
 msgid "Make a diff from the directory of the current active file"
 msgstr "Показать разницу для каталога текущего файла"
 
-#: ../geanyvc/src/geanyvc.c:2475
+#: ../geanyvc/src/geanyvc.c:2526
 msgid "Restore original files in the current folder (undo local edits)."
 msgstr "Восстановить файлы в текущем каталоге из рабочей копии"
 
-#: ../geanyvc/src/geanyvc.c:2485
+#: ../geanyvc/src/geanyvc.c:2536
 msgid "Shows the log of the current directory"
 msgstr "Показать лог для текущего каталога"
 
-#: ../geanyvc/src/geanyvc.c:2499
+#: ../geanyvc/src/geanyvc.c:2550
 msgid "_Base Directory"
 msgstr "_Базовый каталог"
 
-#: ../geanyvc/src/geanyvc.c:2505
+#: ../geanyvc/src/geanyvc.c:2556
 msgid "Make a diff from the top VC directory"
 msgstr "Показать разницу для корневого каталога рабочей копии"
 
-#: ../geanyvc/src/geanyvc.c:2513
+#: ../geanyvc/src/geanyvc.c:2564
 msgid "Revert any local edits."
 msgstr "Отменить все локальные изменения."
 
-#: ../geanyvc/src/geanyvc.c:2526
+#: ../geanyvc/src/geanyvc.c:2577
 msgid "Shows the log of the top VC directory"
 msgstr "Показать лог для корневого каталога рабочей копии"
 
-#: ../geanyvc/src/geanyvc.c:2543
+#: ../geanyvc/src/geanyvc.c:2594
 msgid "_VC file Actions"
 msgstr "Контроль версий"
 
-#: ../geanyvc/src/geanyvc.c:2552
+#: ../geanyvc/src/geanyvc.c:2603
 msgid "VC _Commit..."
 msgstr "Фиксировать изменения..."
 
-#: ../geanyvc/src/geanyvc.c:2596
+#: ../geanyvc/src/geanyvc.c:2647
 msgid "Show diff of file"
 msgstr "Показать разницу для файла"
 
-#: ../geanyvc/src/geanyvc.c:2598
+#: ../geanyvc/src/geanyvc.c:2649
 msgid "Show diff of directory"
 msgstr "Показать разницу для каталога"
 
-#: ../geanyvc/src/geanyvc.c:2600
+#: ../geanyvc/src/geanyvc.c:2651
 msgid "Show diff of basedir"
 msgstr "Показать разницу для корневого каталога"
 
-#: ../geanyvc/src/geanyvc.c:2603
+#: ../geanyvc/src/geanyvc.c:2654
 msgid "Commit changes"
 msgstr "Фиксировать локальные изменения"
 
-#: ../geanyvc/src/geanyvc.c:2605
+#: ../geanyvc/src/geanyvc.c:2656
 msgid "Show status"
 msgstr "Показать статус"
 
-#: ../geanyvc/src/geanyvc.c:2607
+#: ../geanyvc/src/geanyvc.c:2658
 msgid "Revert single file"
 msgstr "Отменить изменения для файла"
 
-#: ../geanyvc/src/geanyvc.c:2609
+#: ../geanyvc/src/geanyvc.c:2660
 msgid "Revert directory"
 msgstr "Отменить изменения для каталога"
 
-#: ../geanyvc/src/geanyvc.c:2611
+#: ../geanyvc/src/geanyvc.c:2662
 msgid "Revert base directory"
 msgstr "Отменить изменения для корневого каталога"
 
-#: ../geanyvc/src/geanyvc.c:2613
+#: ../geanyvc/src/geanyvc.c:2664
 msgid "Update file"
 msgstr "Обновить файл"
 
-#: ../geanyvc/src/geanyvc.c:2643
+#: ../geanyvc/src/geanyvc.c:2694
 msgid "_VC"
 msgstr "Контроль версий"
 
-#: ../geanyvc/src/geanyvc.c:2650
+#: ../geanyvc/src/geanyvc.c:2701
 msgid "_Version Control"
 msgstr "Контроль версий"
 
 #. Status of basedir
-#: ../geanyvc/src/geanyvc.c:2672
+#: ../geanyvc/src/geanyvc.c:2723
 msgid "_Status"
 msgstr "_Статус"
 
-#: ../geanyvc/src/geanyvc.c:2674
+#: ../geanyvc/src/geanyvc.c:2725
 msgid "Show status."
 msgstr "Показать статус."
 
-#: ../geanyvc/src/geanyvc.c:2681
+#: ../geanyvc/src/geanyvc.c:2732
 msgid "Update from remote repository."
 msgstr "Обновить из репозитория."
 
 #. Commit all changes
-#: ../geanyvc/src/geanyvc.c:2686
+#: ../geanyvc/src/geanyvc.c:2737
 msgid "_Commit..."
 msgstr "Ф_иксировать..."
 
-#: ../geanyvc/src/geanyvc.c:2688
+#: ../geanyvc/src/geanyvc.c:2739
 msgid "Commit changes."
 msgstr "Фиксировать локальные изменения"
 
@@ -5117,35 +5117,6 @@ msgstr "Отображать опубликованный код в новой �
 #: ../geniuspaste/src/geniuspaste.c:959
 msgid "_Paste it!"
 msgstr "_Опубликовать!"
-
-#: ../git-changebar/data/prefs.ui.h:1
-msgid "_Monitor repository for changes"
-msgstr "_Отслеживать изменения в репозитории"
-
-#: ../git-changebar/data/prefs.ui.h:2
-msgid ""
-"Whether to automatically update the diff in order to maintain it up to date "
-"when the underlying Git repository changes.  This should generally be "
-"enabled for optimal user experience."
-msgstr ""
-"Автоматически обновлять изменения при изменении отслеживаемого репозитория. "
-"Рекомендуется всегда оставлять этот параметр включённым для удобства."
-
-#: ../git-changebar/data/prefs.ui.h:3
-msgid "_Added lines:"
-msgstr "_Добавленные строки:"
-
-#: ../git-changebar/data/prefs.ui.h:4
-msgid "_Changed lines:"
-msgstr "_Изменённые строки:"
-
-#: ../git-changebar/data/prefs.ui.h:5
-msgid "_Removed lines:"
-msgstr "_Удалённые строки:"
-
-#: ../git-changebar/data/prefs.ui.h:6
-msgid "Colors"
-msgstr "Цвета"
 
 #: ../git-changebar/src/gcb-plugin.c:62
 msgid "Git Change Bar"
@@ -5333,8 +5304,8 @@ msgstr ""
 #: ../lipsum/src/lipsum.c:184 ../sendmail/src/sendmail.c:396
 #, c-format
 msgid ""
-"Your configuration directory has been successfully moved from \"%s\" to \"%s"
-"\"."
+"Your configuration directory has been successfully moved from \"%s\" to "
+"\"%s\"."
 msgstr ""
 
 #: ../lipsum/src/lipsum.c:199
@@ -5500,7 +5471,7 @@ msgstr "Невозможно сохранить конфигурацию по у
 msgid "Unable to read value for '%s' key: %s"
 msgstr "Невозможно прочитать значение для '%s' ключ: %s"
 
-#: ../multiterm/src/tab-label.vala:62 ../treebrowser/src/treebrowser.c:2132
+#: ../multiterm/src/tab-label.vala:62 ../treebrowser/src/treebrowser.c:2137
 msgid "Terminal"
 msgstr "Терминал"
 
@@ -5538,128 +5509,6 @@ msgstr "Строка <b>%d</b>, колонка <b>%d</b>, позиция <b>%d</
 msgid "Show Overview"
 msgstr "Показать обзор документа"
 
-#: ../overview/data/prefs.ui.h:1
-msgid ""
-"The amount to zoom the overview sidebar. This should probably negative if "
-"you want the sidebar zoomed out."
-msgstr ""
-"Масштаб обзора документа. Должно быть отрицательным числом для уменьшения "
-"масштаба."
-
-#: ../overview/data/prefs.ui.h:2
-msgid "Zoom Level:"
-msgstr "Масштаб:"
-
-#: ../overview/data/prefs.ui.h:3
-msgid "The width of the overview sidebar."
-msgstr "Ширина обзора документа."
-
-#: ../overview/data/prefs.ui.h:4
-msgid "Width:"
-msgstr "Ширина:"
-
-#: ../overview/data/prefs.ui.h:5
-msgid ""
-"The number of lines to scroll at a time when scrolling the overview sidebar."
-msgstr ""
-"Количество строк, прокручиваемых за раз при прокрутке обзора документа."
-
-#: ../overview/data/prefs.ui.h:6
-msgid "Scroll Lines:"
-msgstr "Прокручивать строк:"
-
-#: ../overview/data/prefs.ui.h:7
-msgid "Position on left"
-msgstr "Слева"
-
-#: ../overview/data/prefs.ui.h:8
-msgid ""
-"Position the overview bar on the left rather than the right (requires Geany "
-"1.25 or greater)."
-msgstr ""
-"Отображать обзор документа слева, а не справа от документа (нужен Geany 1.25 "
-"и выше)"
-
-#: ../overview/data/prefs.ui.h:9
-msgid "Hide tooltip"
-msgstr "Скрыть подсказку"
-
-#: ../overview/data/prefs.ui.h:10
-msgid ""
-"Hide the tooltip that is displayed when mousing over the overview that shows "
-"line, column and position information."
-msgstr ""
-"Скрыть подсказку, отображающую информацию о строке, позиции и колонке при "
-"наведении курсора мыши на обзор документа."
-
-#: ../overview/data/prefs.ui.h:11
-msgid "Hide editor scrollbar"
-msgstr "Скрыть полосу прокрутки"
-
-#: ../overview/data/prefs.ui.h:12
-msgid ""
-"Whether to hide Geany's regular editor scrollbar while the overview bar is "
-"visible."
-msgstr ""
-"Скрывать стандартную полосу прокрутки редактора, когда обзор документа "
-"активен."
-
-#: ../overview/data/prefs.ui.h:13
-msgid "Disable overlay"
-msgstr "Выключить затемнение"
-
-#: ../overview/data/prefs.ui.h:14
-msgid ""
-"Turn off drawing overlay, which shows the region of the main editor view "
-"that is currently in view, ontop of the overview bar."
-msgstr ""
-"Выключает затемнение обзора документа. Затемнение отмечает границы видимого "
-"документа."
-
-#: ../overview/data/prefs.ui.h:15 ../scope/data/scope.glade.h:130
-#: ../scope/data/scope_gtk3.glade.h:130
-msgid "Options"
-msgstr "Параметры"
-
-#: ../overview/data/prefs.ui.h:16
-msgid ""
-"The color and opacity of the overlay drawn ontop of the overlay sidebar."
-msgstr "Цвет и прозрачность затемнения, отображаемого поверх обзора документа."
-
-#: ../overview/data/prefs.ui.h:17
-msgid "Color:"
-msgstr "Цвет:"
-
-#: ../overview/data/prefs.ui.h:18
-msgid ""
-"The color and opacity of the border drawn around the revealed area in the "
-"overview sidebar. Set to the same as Overlay Color to disable."
-msgstr ""
-"Цвет и прозрачность границы затемнения, отображаемого поверх обзора "
-"документа. Установите одинаковое с основным цветом, чтобы выключить."
-
-#: ../overview/data/prefs.ui.h:19
-msgid "Outline Color:"
-msgstr "Цвет границы:"
-
-#: ../overview/data/prefs.ui.h:20
-msgid "Draw over visible area"
-msgstr "Отображать поверх видимой области"
-
-#: ../overview/data/prefs.ui.h:21
-msgid ""
-"When checked it will draw the overlay ontop of the area that is visible in "
-"the main editor view, when unchecked, it will do the opposite and draw the "
-"overlay everywhere but the visible area, \"revealing\" the visible part."
-msgstr ""
-"Если отмечено, затемнение будет отображаться поверх области, которая видна в "
-"редакторе. Если выключено - будет обратный эффект - затемняется область, "
-"которая не видна в редакторе, \"обнажая\" видимую часть."
-
-#: ../overview/data/prefs.ui.h:22
-msgid "Overlay"
-msgstr "Затемнение"
-
 #: ../pairtaghighlighter/src/pair_tag_highlighter.c:43
 msgid "Pair Tag Highlighter"
 msgstr "Подсветка парных тегов"
@@ -5687,146 +5536,6 @@ msgstr "Выделить до парной скобки"
 #, fuzzy
 msgid "Select To Matching Tag"
 msgstr "Выделить до парной скобки"
-
-#: ../pohelper/data/menus.ui.h:1
-msgid "_Translation Helper"
-msgstr "Помощник переводчика"
-
-#: ../pohelper/data/menus.ui.h:2
-msgid "_Previous String"
-msgstr "_Предыдущая строка"
-
-#: ../pohelper/data/menus.ui.h:3 ../pohelper/src/gph-plugin.c:1590
-msgid "Go to previous string"
-msgstr "Перейти к предыдущей строке"
-
-#: ../pohelper/data/menus.ui.h:4
-msgid "_Next String"
-msgstr "_Следующая строка"
-
-#: ../pohelper/data/menus.ui.h:5 ../pohelper/src/gph-plugin.c:1593
-msgid "Go to next string"
-msgstr "Перейти к следующей строке"
-
-#: ../pohelper/data/menus.ui.h:6
-msgid "Pre_vious Untranslated"
-msgstr "П_редыдущая непереведённая"
-
-#: ../pohelper/data/menus.ui.h:7 ../pohelper/src/gph-plugin.c:1596
-msgid "Go to previous untranslated string"
-msgstr "Перейти к предыдущей непереведённой строке"
-
-#: ../pohelper/data/menus.ui.h:8
-msgid "Next _Untranslated"
-msgstr "С_ледующая непереведённая"
-
-#: ../pohelper/data/menus.ui.h:9 ../pohelper/src/gph-plugin.c:1599
-msgid "Go to next untranslated string"
-msgstr "Перейти к следующей непереведённой строке"
-
-#: ../pohelper/data/menus.ui.h:10
-msgid "Previous Fu_zzy"
-msgstr "Предыдущая fu_zzy-строка"
-
-#: ../pohelper/data/menus.ui.h:11 ../pohelper/src/gph-plugin.c:1602
-msgid "Go to previous fuzzily translated string"
-msgstr "Перейти к предыдущей fuzzy-строке"
-
-#: ../pohelper/data/menus.ui.h:12
-msgid "Next _Fuzzy"
-msgstr "Следующая _fuzzy"
-
-#: ../pohelper/data/menus.ui.h:13 ../pohelper/src/gph-plugin.c:1605
-msgid "Go to next fuzzily translated string"
-msgstr "Перейти к следующей fuzzy-строке"
-
-#: ../pohelper/data/menus.ui.h:14
-msgid "Previous Untranslated or Fuzz_y"
-msgstr "Предыдущая непереведённая или fuzz_y-строка"
-
-#: ../pohelper/data/menus.ui.h:15 ../pohelper/src/gph-plugin.c:1608
-msgid "Go to previous untranslated or fuzzy string"
-msgstr "Перейти к предыдущей непереведённой или fuzzy-строке"
-
-#: ../pohelper/data/menus.ui.h:16
-msgid "Next Untranslated _or Fuzzy"
-msgstr "Следующая непереведённая _или fuzzy-строка"
-
-#: ../pohelper/data/menus.ui.h:17 ../pohelper/src/gph-plugin.c:1612
-msgid "Go to next untranslated or fuzzy string"
-msgstr "Перейти к следующей непереведённой или fuzzy-строке"
-
-#: ../pohelper/data/menus.ui.h:18 ../pohelper/src/gph-plugin.c:1623
-msgid "Toggle current translation fuzziness"
-msgstr "Переключить флаг fuzzy у текущего перевода"
-
-#: ../pohelper/data/menus.ui.h:19
-msgid "_Toggle Fuzziness"
-msgstr "П_ереключить флаг fuzzy"
-
-#: ../pohelper/data/menus.ui.h:20
-msgid "Paste _Message as Translation"
-msgstr "_Вставить сообщение как перевод"
-
-#: ../pohelper/data/menus.ui.h:21
-msgid "Paste the original untranslated string to the translation"
-msgstr "Вставить непереведённый оригинал в качестве перевода"
-
-#: ../pohelper/data/menus.ui.h:22 ../pohelper/src/gph-plugin.c:1620
-msgid "Reflow the current translation string"
-msgstr "Форматирует текущую строку перевода"
-
-#: ../pohelper/data/menus.ui.h:23
-msgid "_Reflow Translation"
-msgstr "Пере_форматировать перевод"
-
-#: ../pohelper/data/menus.ui.h:24 ../pohelper/src/gph-plugin.c:1626
-msgid "Show statistics of the current document"
-msgstr "Показать статистику текущего документа"
-
-#: ../pohelper/data/menus.ui.h:25
-msgid "_Show stats"
-msgstr "_Показать статус"
-
-#: ../pohelper/data/menus.ui.h:26
-msgid ""
-"Whether to update the translation headers (author, revision date, ...) upon "
-"file save"
-msgstr ""
-"Обновлять заголовки перевода (автор, дата обновления, ...) при сохранении "
-"файла"
-
-#: ../pohelper/data/menus.ui.h:27
-msgid "Update _Headers Upon Save"
-msgstr "О_бновлять заголовки при сохранении"
-
-#: ../pohelper/data/stats.ui.h:1
-msgid "Translation statistics"
-msgstr "Статистика перевода"
-
-#: ../pohelper/data/stats.ui.h:2
-msgid "Choose a color for translated strings"
-msgstr "Выберите цвет переведенных строк"
-
-#: ../pohelper/data/stats.ui.h:3
-msgid "Choose a color for fuzzily translated strings"
-msgstr "Выберите цвет для fuzzy-строк"
-
-#: ../pohelper/data/stats.ui.h:4
-msgid "Choose a color for untranslated strings"
-msgstr "Выберите цвет для непереведенных строк"
-
-#: ../pohelper/data/stats.ui.h:5
-msgid "Translated:"
-msgstr "Переведено:"
-
-#: ../pohelper/data/stats.ui.h:6
-msgid "Fuzzy:"
-msgstr ""
-
-#: ../pohelper/data/stats.ui.h:7
-msgid "Untranslated:"
-msgstr "Непереведено:"
 
 #: ../pohelper/src/gph-plugin.c:40
 msgid "Translation Helper"
@@ -5856,9 +5565,53 @@ msgstr "<b>Непереведено:</b> %.3g%%"
 msgid "%u (%.3g%%)"
 msgstr ""
 
+#: ../pohelper/src/gph-plugin.c:1590
+msgid "Go to previous string"
+msgstr "Перейти к предыдущей строке"
+
+#: ../pohelper/src/gph-plugin.c:1593
+msgid "Go to next string"
+msgstr "Перейти к следующей строке"
+
+#: ../pohelper/src/gph-plugin.c:1596
+msgid "Go to previous untranslated string"
+msgstr "Перейти к предыдущей непереведённой строке"
+
+#: ../pohelper/src/gph-plugin.c:1599
+msgid "Go to next untranslated string"
+msgstr "Перейти к следующей непереведённой строке"
+
+#: ../pohelper/src/gph-plugin.c:1602
+msgid "Go to previous fuzzily translated string"
+msgstr "Перейти к предыдущей fuzzy-строке"
+
+#: ../pohelper/src/gph-plugin.c:1605
+msgid "Go to next fuzzily translated string"
+msgstr "Перейти к следующей fuzzy-строке"
+
+#: ../pohelper/src/gph-plugin.c:1608
+msgid "Go to previous untranslated or fuzzy string"
+msgstr "Перейти к предыдущей непереведённой или fuzzy-строке"
+
+#: ../pohelper/src/gph-plugin.c:1612
+msgid "Go to next untranslated or fuzzy string"
+msgstr "Перейти к следующей непереведённой или fuzzy-строке"
+
 #: ../pohelper/src/gph-plugin.c:1616
 msgid "Paste original untranslated string to translation"
 msgstr "Скопировать исходную непереведённую строку в перевод"
+
+#: ../pohelper/src/gph-plugin.c:1620
+msgid "Reflow the current translation string"
+msgstr "Форматирует текущую строку перевода"
+
+#: ../pohelper/src/gph-plugin.c:1623
+msgid "Toggle current translation fuzziness"
+msgstr "Переключить флаг fuzzy у текущего перевода"
+
+#: ../pohelper/src/gph-plugin.c:1626
+msgid "Show statistics of the current document"
+msgstr "Показать статистику текущего документа"
 
 #: ../pohelper/src/gph-plugin.c:1833
 #, c-format
@@ -6143,7 +5896,7 @@ msgid "Add"
 msgstr "Добавить"
 
 #: ../projectorganizer/src/prjorg-sidebar.c:390
-#: ../treebrowser/src/treebrowser.c:2356
+#: ../treebrowser/src/treebrowser.c:2361
 #, fuzzy
 msgid "New File"
 msgstr "Новый файл"
@@ -6773,6 +6526,10 @@ msgstr "Показывать подсказки"
 msgid "<b>Others</b>"
 msgstr "<b>Другое</b>"
 
+#: ../scope/data/scope.glade.h:130 ../scope/data/scope_gtk3.glade.h:130
+msgid "Options"
+msgstr "Параметры"
+
 #: ../scope/data/scope.glade.h:131 ../scope/data/scope_gtk3.glade.h:131
 msgid "_Import"
 msgstr "_Импорт"
@@ -7349,12 +7106,14 @@ msgid "Checks the spelling of the current document."
 msgstr "Проверяет орфографию в текущем документе"
 
 #: ../spellcheck/src/scplugin.c:225
-msgid "Run Spell Check"
+#, fuzzy
+msgid "Run spell check once"
 msgstr "Запустить проверку орфографии"
 
-#: ../spellcheck/src/scplugin.c:228
-msgid "Toggle Check While Typing"
-msgstr "Включить/выключить проверку при набора текста"
+#: ../spellcheck/src/scplugin.c:228 ../spellcheck/src/scplugin.c:333
+#, fuzzy
+msgid "Toggle spell check"
+msgstr "Проверка орфографии"
 
 #. initialise the dialog
 #: ../spellcheck/src/scplugin.c:239
@@ -7380,10 +7139,6 @@ msgstr "Выводить неправильное слово и список з�
 #: ../spellcheck/src/scplugin.c:325
 msgid "<b>Interface</b>"
 msgstr "<b>Интерфейс</b>"
-
-#: ../spellcheck/src/scplugin.c:333
-msgid "Check spelling while typing"
-msgstr "Проверять по мере набора текста"
 
 #: ../spellcheck/src/scplugin.c:336
 msgid "Check spelling when opening a document"
@@ -7420,32 +7175,32 @@ msgstr ""
 msgid "<b>Behavior</b>"
 msgstr "<b>Поведение</b>"
 
-#: ../spellcheck/src/gui.c:76
+#: ../spellcheck/src/gui.c:88
 msgid "Spell checking while typing is now enabled"
 msgstr "Проверка орфографии по мере набора текста теперь включена"
 
-#: ../spellcheck/src/gui.c:78
+#: ../spellcheck/src/gui.c:90
 msgid "Spell checking while typing is now disabled"
 msgstr "Проверка орфографии по мере набора текста теперь выключена"
 
-#: ../spellcheck/src/gui.c:326
+#: ../spellcheck/src/gui.c:323
 msgid "More..."
 msgstr "Больше..."
 
-#: ../spellcheck/src/gui.c:347
+#: ../spellcheck/src/gui.c:344
 msgid "(No Suggestions)"
 msgstr "(нет вариантов)"
 
-#: ../spellcheck/src/gui.c:360
+#: ../spellcheck/src/gui.c:357
 #, c-format
 msgid "Add \"%s\" to Dictionary"
 msgstr "Добавить \"%s\" в словарь"
 
-#: ../spellcheck/src/gui.c:368
+#: ../spellcheck/src/gui.c:365
 msgid "Ignore All"
 msgstr "Игнорировать всё"
 
-#: ../spellcheck/src/gui.c:441
+#: ../spellcheck/src/gui.c:438
 msgid ""
 "Search term is too long to provide\n"
 "spelling suggestions in the editor menu."
@@ -7453,21 +7208,21 @@ msgstr ""
 "Образец поиска слишком длинный для того,\n"
 "чтобы поместить список замен в меню редактора."
 
-#: ../spellcheck/src/gui.c:447
+#: ../spellcheck/src/gui.c:444
 msgid "Perform Spell Check"
 msgstr "Выполнить проверку орфограции"
 
-#: ../spellcheck/src/gui.c:609
+#: ../spellcheck/src/gui.c:606
 #, c-format
 msgid "Default (%s)"
 msgstr "По умолчанию (%s)"
 
-#: ../spellcheck/src/gui.c:620
-#, c-format
-msgid "Toggle spell check while typing (current language: %s)"
+#: ../spellcheck/src/gui.c:617
+#, fuzzy, c-format
+msgid "Toggle spell check (current language: %s)"
 msgstr "Включить проверку орфографии по мере набора текста (текущий язык: %s)"
 
-#: ../spellcheck/src/gui.c:698
+#: ../spellcheck/src/gui.c:695
 msgid "Spelling Suggestions"
 msgstr "Варианты замены"
 
@@ -7561,15 +7316,15 @@ msgstr "(Пусто)"
 msgid "Could not execute configured external command '%s' (%s)."
 msgstr "Невозможно выполнить заданную внешнюю команду '%s' (%s)."
 
-#: ../treebrowser/src/treebrowser.c:1089
+#: ../treebrowser/src/treebrowser.c:1093
 msgid "NewDirectory"
 msgstr "Новый каталог"
 
-#: ../treebrowser/src/treebrowser.c:1091
+#: ../treebrowser/src/treebrowser.c:1095
 msgid "NewFile"
 msgstr "Новый файл"
 
-#: ../treebrowser/src/treebrowser.c:1096
+#: ../treebrowser/src/treebrowser.c:1100
 #, fuzzy, c-format
 msgid ""
 "Target file '%s' exists.\n"
@@ -7578,130 +7333,130 @@ msgstr ""
 "Файл '%s' существует\n"
 ", вы действительно хотите заменить его пустым файлом?"
 
-#: ../treebrowser/src/treebrowser.c:1142
+#: ../treebrowser/src/treebrowser.c:1146
 #, c-format
 msgid "Do you really want to delete '%s' ?"
 msgstr "Вы действительно хотите удалить файл '%s' ?"
 
-#: ../treebrowser/src/treebrowser.c:1255 ../treebrowser/src/treebrowser.c:1257
+#: ../treebrowser/src/treebrowser.c:1259 ../treebrowser/src/treebrowser.c:1261
 #, fuzzy
 msgid "Go _Up"
 msgstr "Переместить _вверх"
 
-#: ../treebrowser/src/treebrowser.c:1263 ../treebrowser/src/treebrowser.c:1265
+#: ../treebrowser/src/treebrowser.c:1267 ../treebrowser/src/treebrowser.c:1269
 #, fuzzy
 msgid "Set _Path From Document"
 msgstr "Установить путь из документа"
 
-#: ../treebrowser/src/treebrowser.c:1271 ../treebrowser/src/treebrowser.c:1273
+#: ../treebrowser/src/treebrowser.c:1275 ../treebrowser/src/treebrowser.c:1277
 #, fuzzy
 msgid "_Open Externally"
 msgstr "Открыть используя внешнюю программу"
 
-#: ../treebrowser/src/treebrowser.c:1279
+#: ../treebrowser/src/treebrowser.c:1283
 #, fuzzy
 msgid "Open _Terminal"
 msgstr "Открыть терминал"
 
-#: ../treebrowser/src/treebrowser.c:1284 ../treebrowser/src/treebrowser.c:1286
+#: ../treebrowser/src/treebrowser.c:1288 ../treebrowser/src/treebrowser.c:1290
 #, fuzzy
 msgid "Set as _Root"
 msgstr "Сделать корневым каталогом"
 
-#: ../treebrowser/src/treebrowser.c:1293 ../treebrowser/src/treebrowser.c:1295
+#: ../treebrowser/src/treebrowser.c:1297 ../treebrowser/src/treebrowser.c:1299
 #, fuzzy
 msgid "Refres_h"
 msgstr "Обновить"
 
-#: ../treebrowser/src/treebrowser.c:1301 ../treebrowser/src/treebrowser.c:1303
+#: ../treebrowser/src/treebrowser.c:1305 ../treebrowser/src/treebrowser.c:1307
 msgid "_Find in Files"
 msgstr "Найти в файлах"
 
-#: ../treebrowser/src/treebrowser.c:1313 ../treebrowser/src/treebrowser.c:1315
+#: ../treebrowser/src/treebrowser.c:1317 ../treebrowser/src/treebrowser.c:1319
 #, fuzzy
 msgid "N_ew Folder"
 msgstr "Выберите каталог"
 
-#: ../treebrowser/src/treebrowser.c:1321 ../treebrowser/src/treebrowser.c:1323
+#: ../treebrowser/src/treebrowser.c:1325 ../treebrowser/src/treebrowser.c:1327
 #, fuzzy
 msgid "_New File"
 msgstr "Новый файл"
 
-#: ../treebrowser/src/treebrowser.c:1329 ../treebrowser/src/treebrowser.c:1331
+#: ../treebrowser/src/treebrowser.c:1333 ../treebrowser/src/treebrowser.c:1335
 #, fuzzy
 msgid "Rena_me"
 msgstr "Переименовать"
 
-#: ../treebrowser/src/treebrowser.c:1350 ../treebrowser/src/treebrowser.c:1352
+#: ../treebrowser/src/treebrowser.c:1354 ../treebrowser/src/treebrowser.c:1356
 #, c-format
 msgid "Close: %s"
 msgstr "Закрыть: %s"
 
-#: ../treebrowser/src/treebrowser.c:1359 ../treebrowser/src/treebrowser.c:1361
+#: ../treebrowser/src/treebrowser.c:1363 ../treebrowser/src/treebrowser.c:1365
 #, fuzzy, c-format
 msgid "Clo_se Child Documents "
 msgstr "Закрыть дочерние документы"
 
-#: ../treebrowser/src/treebrowser.c:1368 ../treebrowser/src/treebrowser.c:1370
+#: ../treebrowser/src/treebrowser.c:1372 ../treebrowser/src/treebrowser.c:1374
 #, fuzzy
 msgid "_Copy Full Path to Clipboard"
 msgstr "Скопировать полный путь в буфер обмена"
 
-#: ../treebrowser/src/treebrowser.c:1381 ../treebrowser/src/treebrowser.c:1383
+#: ../treebrowser/src/treebrowser.c:1385 ../treebrowser/src/treebrowser.c:1387
 #, fuzzy
 msgid "E_xpand All"
 msgstr "Развернуть всё"
 
-#: ../treebrowser/src/treebrowser.c:1389 ../treebrowser/src/treebrowser.c:1391
+#: ../treebrowser/src/treebrowser.c:1393 ../treebrowser/src/treebrowser.c:1395
 #, fuzzy
 msgid "Coll_apse All"
 msgstr "Свернуть всё"
 
-#: ../treebrowser/src/treebrowser.c:1399
+#: ../treebrowser/src/treebrowser.c:1403
 #, fuzzy
 msgid "Show Boo_kmarks"
 msgstr "Показывать закладки"
 
-#: ../treebrowser/src/treebrowser.c:1404
+#: ../treebrowser/src/treebrowser.c:1408
 #, fuzzy
 msgid "Sho_w Hidden Files"
 msgstr "Показывать скрытые файлы"
 
-#: ../treebrowser/src/treebrowser.c:1409
+#: ../treebrowser/src/treebrowser.c:1413
 #, fuzzy
 msgid "Show Tool_bars"
 msgstr "Показывать панель инструментов"
 
-#: ../treebrowser/src/treebrowser.c:1747
+#: ../treebrowser/src/treebrowser.c:1751
 #, c-format
 msgid "Target file '%s' exists, do you really want to replace it?"
 msgstr "Файл '%s' существует, вы действительно хотите его заменить?"
 
-#: ../treebrowser/src/treebrowser.c:1883
+#: ../treebrowser/src/treebrowser.c:1887
 msgid "Go up"
 msgstr "Перейти на уровень вверх"
 
-#: ../treebrowser/src/treebrowser.c:1893 ../treebrowser/src/treebrowser.c:2360
+#: ../treebrowser/src/treebrowser.c:1897 ../treebrowser/src/treebrowser.c:2365
 msgid "Refresh"
 msgstr "Обновить"
 
-#: ../treebrowser/src/treebrowser.c:1903
+#: ../treebrowser/src/treebrowser.c:1907
 msgid "Home"
 msgstr "Домой"
 
-#: ../treebrowser/src/treebrowser.c:1913
+#: ../treebrowser/src/treebrowser.c:1917
 msgid "Set path from document"
 msgstr "Установить путь из документа"
 
-#: ../treebrowser/src/treebrowser.c:1923
+#: ../treebrowser/src/treebrowser.c:1927
 msgid "Track path"
 msgstr "Перейти к текущему файлу"
 
-#: ../treebrowser/src/treebrowser.c:1933
+#: ../treebrowser/src/treebrowser.c:1937
 msgid "Hide bars"
 msgstr "Скрыть панель инструментов"
 
-#: ../treebrowser/src/treebrowser.c:1943
+#: ../treebrowser/src/treebrowser.c:1947
 msgid ""
 "Filter (*.c;*.h;*.cpp), and if you want temporary filter using the '!' "
 "reverse try for example this '!;*.c;*.h;*.cpp'"
@@ -7709,20 +7464,20 @@ msgstr ""
 "Фильтр (*.c;*.h;*.cpp). Чтобы инвертировать результаты поиска, используйте "
 "формат '!;*.c;*.h;*.cpp'."
 
-#: ../treebrowser/src/treebrowser.c:1948
+#: ../treebrowser/src/treebrowser.c:1952
 msgid "Addressbar for example '/projects/my-project'"
 msgstr "Строка адреса"
 
-#: ../treebrowser/src/treebrowser.c:1973
+#: ../treebrowser/src/treebrowser.c:1977
 msgid "Tree Browser"
 msgstr "Дерево файлов"
 
-#: ../treebrowser/src/treebrowser.c:2114
+#: ../treebrowser/src/treebrowser.c:2118
 msgid "External open command"
 msgstr "Внешняя команда"
 
-#: ../treebrowser/src/treebrowser.c:2124
-#, c-format
+#: ../treebrowser/src/treebrowser.c:2129
+#, no-c-format
 msgid ""
 "The command to execute when using \"Open with\". You can use %f and %d "
 "wildcards.\n"
@@ -7735,61 +7490,61 @@ msgstr ""
 "%f будет заменено на имя файла включая полный путь\n"
 "%d будет заменено на путь к каталогу текущего файла"
 
-#: ../treebrowser/src/treebrowser.c:2143
+#: ../treebrowser/src/treebrowser.c:2148
 msgid "The terminal to use with the command \"Open Terminal\""
 msgstr "Терминал, используемый командой \"Открыть терминал\""
 
-#: ../treebrowser/src/treebrowser.c:2149
+#: ../treebrowser/src/treebrowser.c:2154
 msgid "Toolbar"
 msgstr "Панель инструментов"
 
-#: ../treebrowser/src/treebrowser.c:2151
+#: ../treebrowser/src/treebrowser.c:2156
 msgid "Hidden"
 msgstr "Скрытая"
 
-#: ../treebrowser/src/treebrowser.c:2152
+#: ../treebrowser/src/treebrowser.c:2157
 msgid "Top"
 msgstr "Верх"
 
-#: ../treebrowser/src/treebrowser.c:2153
+#: ../treebrowser/src/treebrowser.c:2158
 msgid "Bottom"
 msgstr "Низ"
 
-#: ../treebrowser/src/treebrowser.c:2158
+#: ../treebrowser/src/treebrowser.c:2163
 msgid "If position is changed, the option require plugin restart."
 msgstr "Изменение положения требует перезапуска плагина"
 
-#: ../treebrowser/src/treebrowser.c:2162
+#: ../treebrowser/src/treebrowser.c:2167
 msgid "Show icons"
 msgstr "Показывать иконки"
 
-#: ../treebrowser/src/treebrowser.c:2164
+#: ../treebrowser/src/treebrowser.c:2169
 msgid "None"
 msgstr "Нет"
 
-#: ../treebrowser/src/treebrowser.c:2165
+#: ../treebrowser/src/treebrowser.c:2170
 msgid "Base"
 msgstr "Базовые"
 
-#: ../treebrowser/src/treebrowser.c:2166
+#: ../treebrowser/src/treebrowser.c:2171
 msgid "Content-type"
 msgstr "Тип файла"
 
-#: ../treebrowser/src/treebrowser.c:2172
+#: ../treebrowser/src/treebrowser.c:2177
 msgid "Show hidden files"
 msgstr "Показывать скрытые файлы"
 
-#: ../treebrowser/src/treebrowser.c:2181
+#: ../treebrowser/src/treebrowser.c:2186
 msgid "On Windows, this just hide files that are prefixed with '.' (dot)"
 msgstr ""
 "В ОС Windows, эта опция скрывает файлы, имена которых начинаются с символа "
 "'.' (dot)"
 
-#: ../treebrowser/src/treebrowser.c:2183
+#: ../treebrowser/src/treebrowser.c:2188
 msgid "Hide object files"
 msgstr "Не показывать объектные файлы"
 
-#: ../treebrowser/src/treebrowser.c:2192
+#: ../treebrowser/src/treebrowser.c:2197
 msgid ""
 "Don't show generated object files in the file browser, this includes *.o, *."
 "obj. *.so, *.dll, *.a, *.lib"
@@ -7797,60 +7552,60 @@ msgstr ""
 "Не показывать объектные файлы (*.o, *.obj. *.so, *.dll, *.a, *.lib) в дереве "
 "файлов"
 
-#: ../treebrowser/src/treebrowser.c:2194
+#: ../treebrowser/src/treebrowser.c:2199
 msgid "Reverse filter"
 msgstr "Инвертировать фильтр"
 
-#: ../treebrowser/src/treebrowser.c:2203
+#: ../treebrowser/src/treebrowser.c:2208
 msgid "Follow current document"
 msgstr "Следовать пути текущего документа"
 
-#: ../treebrowser/src/treebrowser.c:2212
+#: ../treebrowser/src/treebrowser.c:2217
 msgid "Single click, open document and focus it"
 msgstr "Одиночный клик открывает документ"
 
-#: ../treebrowser/src/treebrowser.c:2221
+#: ../treebrowser/src/treebrowser.c:2226
 msgid "Double click open directory"
 msgstr "Двойной клик открывает каталог"
 
-#: ../treebrowser/src/treebrowser.c:2230
+#: ../treebrowser/src/treebrowser.c:2235
 msgid "On delete file, close it if is opened"
 msgstr "При удалении файла, закрывать его если открыт"
 
-#: ../treebrowser/src/treebrowser.c:2239
+#: ../treebrowser/src/treebrowser.c:2244
 msgid "Focus editor on file open"
 msgstr "Передать фокус редактору при открытии файла"
 
-#: ../treebrowser/src/treebrowser.c:2248
+#: ../treebrowser/src/treebrowser.c:2253
 msgid "Show tree lines"
 msgstr "Показывать соединительные линии"
 
-#: ../treebrowser/src/treebrowser.c:2257
+#: ../treebrowser/src/treebrowser.c:2262
 msgid "Show bookmarks"
 msgstr "Показывать закладки"
 
-#: ../treebrowser/src/treebrowser.c:2266
+#: ../treebrowser/src/treebrowser.c:2271
 msgid "Open new files"
 msgstr "Открыть новый файл"
 
-#: ../treebrowser/src/treebrowser.c:2350
+#: ../treebrowser/src/treebrowser.c:2355
 msgid "Focus File List"
 msgstr "Перейти к списку файлов"
 
-#: ../treebrowser/src/treebrowser.c:2352
+#: ../treebrowser/src/treebrowser.c:2357
 msgid "Focus Path Entry"
 msgstr "Перейти к строке адреса"
 
-#: ../treebrowser/src/treebrowser.c:2354
+#: ../treebrowser/src/treebrowser.c:2359
 msgid "Rename Object"
 msgstr "Переименовать объект"
 
-#: ../treebrowser/src/treebrowser.c:2358
+#: ../treebrowser/src/treebrowser.c:2363
 #, fuzzy
 msgid "New Folder"
 msgstr "Выберите каталог"
 
-#: ../treebrowser/src/treebrowser.c:2362
+#: ../treebrowser/src/treebrowser.c:2367
 #, fuzzy
 msgid "Track Current"
 msgstr "Перейти к текущему файлу"
@@ -8563,14 +8318,6 @@ msgstr "Новый каталог"
 msgid "No workbench opened."
 msgstr ""
 
-#: ../workbench/src/sidebar.c:875
-#, fuzzy, c-format
-msgid "%s: %u Project"
-msgid_plural "%s: %u Projects"
-msgstr[0] "Проект"
-msgstr[1] "Проект"
-msgstr[2] "Проект"
-
 #: ../workbench/src/sidebar.c:886
 msgid ""
 "Add a project using the context menu\n"
@@ -8678,6 +8425,212 @@ msgstr "XML Сниппеты"
 #: ../xmlsnippets/src/plugin.c:45
 msgid "Autocompletes XML/HTML tags using snippets."
 msgstr "Автоматически завершает XML/HTML теги с использованием сниппетов"
+
+#~ msgid "_Monitor repository for changes"
+#~ msgstr "_Отслеживать изменения в репозитории"
+
+#~ msgid ""
+#~ "Whether to automatically update the diff in order to maintain it up to "
+#~ "date when the underlying Git repository changes.  This should generally "
+#~ "be enabled for optimal user experience."
+#~ msgstr ""
+#~ "Автоматически обновлять изменения при изменении отслеживаемого "
+#~ "репозитория. Рекомендуется всегда оставлять этот параметр включённым для "
+#~ "удобства."
+
+#~ msgid "_Added lines:"
+#~ msgstr "_Добавленные строки:"
+
+#~ msgid "_Changed lines:"
+#~ msgstr "_Изменённые строки:"
+
+#~ msgid "_Removed lines:"
+#~ msgstr "_Удалённые строки:"
+
+#~ msgid "Colors"
+#~ msgstr "Цвета"
+
+#~ msgid ""
+#~ "The amount to zoom the overview sidebar. This should probably negative if "
+#~ "you want the sidebar zoomed out."
+#~ msgstr ""
+#~ "Масштаб обзора документа. Должно быть отрицательным числом для уменьшения "
+#~ "масштаба."
+
+#~ msgid "Zoom Level:"
+#~ msgstr "Масштаб:"
+
+#~ msgid "The width of the overview sidebar."
+#~ msgstr "Ширина обзора документа."
+
+#~ msgid "Width:"
+#~ msgstr "Ширина:"
+
+#~ msgid ""
+#~ "The number of lines to scroll at a time when scrolling the overview "
+#~ "sidebar."
+#~ msgstr ""
+#~ "Количество строк, прокручиваемых за раз при прокрутке обзора документа."
+
+#~ msgid "Scroll Lines:"
+#~ msgstr "Прокручивать строк:"
+
+#~ msgid "Position on left"
+#~ msgstr "Слева"
+
+#~ msgid ""
+#~ "Position the overview bar on the left rather than the right (requires "
+#~ "Geany 1.25 or greater)."
+#~ msgstr ""
+#~ "Отображать обзор документа слева, а не справа от документа (нужен Geany "
+#~ "1.25 и выше)"
+
+#~ msgid "Hide tooltip"
+#~ msgstr "Скрыть подсказку"
+
+#~ msgid ""
+#~ "Hide the tooltip that is displayed when mousing over the overview that "
+#~ "shows line, column and position information."
+#~ msgstr ""
+#~ "Скрыть подсказку, отображающую информацию о строке, позиции и колонке при "
+#~ "наведении курсора мыши на обзор документа."
+
+#~ msgid "Hide editor scrollbar"
+#~ msgstr "Скрыть полосу прокрутки"
+
+#~ msgid ""
+#~ "Whether to hide Geany's regular editor scrollbar while the overview bar "
+#~ "is visible."
+#~ msgstr ""
+#~ "Скрывать стандартную полосу прокрутки редактора, когда обзор документа "
+#~ "активен."
+
+#~ msgid "Disable overlay"
+#~ msgstr "Выключить затемнение"
+
+#~ msgid ""
+#~ "Turn off drawing overlay, which shows the region of the main editor view "
+#~ "that is currently in view, ontop of the overview bar."
+#~ msgstr ""
+#~ "Выключает затемнение обзора документа. Затемнение отмечает границы "
+#~ "видимого документа."
+
+#~ msgid ""
+#~ "The color and opacity of the overlay drawn ontop of the overlay sidebar."
+#~ msgstr ""
+#~ "Цвет и прозрачность затемнения, отображаемого поверх обзора документа."
+
+#~ msgid "Color:"
+#~ msgstr "Цвет:"
+
+#~ msgid ""
+#~ "The color and opacity of the border drawn around the revealed area in the "
+#~ "overview sidebar. Set to the same as Overlay Color to disable."
+#~ msgstr ""
+#~ "Цвет и прозрачность границы затемнения, отображаемого поверх обзора "
+#~ "документа. Установите одинаковое с основным цветом, чтобы выключить."
+
+#~ msgid "Outline Color:"
+#~ msgstr "Цвет границы:"
+
+#~ msgid "Draw over visible area"
+#~ msgstr "Отображать поверх видимой области"
+
+#~ msgid ""
+#~ "When checked it will draw the overlay ontop of the area that is visible "
+#~ "in the main editor view, when unchecked, it will do the opposite and draw "
+#~ "the overlay everywhere but the visible area, \"revealing\" the visible "
+#~ "part."
+#~ msgstr ""
+#~ "Если отмечено, затемнение будет отображаться поверх области, которая "
+#~ "видна в редакторе. Если выключено - будет обратный эффект - затемняется "
+#~ "область, которая не видна в редакторе, \"обнажая\" видимую часть."
+
+#~ msgid "Overlay"
+#~ msgstr "Затемнение"
+
+#~ msgid "_Translation Helper"
+#~ msgstr "Помощник переводчика"
+
+#~ msgid "_Previous String"
+#~ msgstr "_Предыдущая строка"
+
+#~ msgid "_Next String"
+#~ msgstr "_Следующая строка"
+
+#~ msgid "Pre_vious Untranslated"
+#~ msgstr "П_редыдущая непереведённая"
+
+#~ msgid "Next _Untranslated"
+#~ msgstr "С_ледующая непереведённая"
+
+#~ msgid "Previous Fu_zzy"
+#~ msgstr "Предыдущая fu_zzy-строка"
+
+#~ msgid "Next _Fuzzy"
+#~ msgstr "Следующая _fuzzy"
+
+#~ msgid "Previous Untranslated or Fuzz_y"
+#~ msgstr "Предыдущая непереведённая или fuzz_y-строка"
+
+#~ msgid "Next Untranslated _or Fuzzy"
+#~ msgstr "Следующая непереведённая _или fuzzy-строка"
+
+#~ msgid "_Toggle Fuzziness"
+#~ msgstr "П_ереключить флаг fuzzy"
+
+#~ msgid "Paste _Message as Translation"
+#~ msgstr "_Вставить сообщение как перевод"
+
+#~ msgid "Paste the original untranslated string to the translation"
+#~ msgstr "Вставить непереведённый оригинал в качестве перевода"
+
+#~ msgid "_Reflow Translation"
+#~ msgstr "Пере_форматировать перевод"
+
+#~ msgid "_Show stats"
+#~ msgstr "_Показать статус"
+
+#~ msgid ""
+#~ "Whether to update the translation headers (author, revision date, ...) "
+#~ "upon file save"
+#~ msgstr ""
+#~ "Обновлять заголовки перевода (автор, дата обновления, ...) при сохранении "
+#~ "файла"
+
+#~ msgid "Update _Headers Upon Save"
+#~ msgstr "О_бновлять заголовки при сохранении"
+
+#~ msgid "Translation statistics"
+#~ msgstr "Статистика перевода"
+
+#~ msgid "Choose a color for translated strings"
+#~ msgstr "Выберите цвет переведенных строк"
+
+#~ msgid "Choose a color for fuzzily translated strings"
+#~ msgstr "Выберите цвет для fuzzy-строк"
+
+#~ msgid "Choose a color for untranslated strings"
+#~ msgstr "Выберите цвет для непереведенных строк"
+
+#~ msgid "Translated:"
+#~ msgstr "Переведено:"
+
+#~ msgid "Untranslated:"
+#~ msgstr "Непереведено:"
+
+#~ msgid "Toggle Check While Typing"
+#~ msgstr "Включить/выключить проверку при набора текста"
+
+#~ msgid "Check spelling while typing"
+#~ msgstr "Проверять по мере набора текста"
+
+#, fuzzy, c-format
+#~ msgid "%s: %u Project"
+#~ msgid_plural "%s: %u Projects"
+#~ msgstr[0] "Проект"
+#~ msgstr[1] "Проект"
+#~ msgstr[2] "Проект"
 
 #~ msgid "GeanyLaTeX"
 #~ msgstr "GeanyLaTeX"

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,8 +7,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Geany-Plugins 1.30\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-29 19:41+0200\n"
+"Report-Msgid-Bugs-To: https://github.com/geany/geany/issues\n"
+"POT-Creation-Date: 2022-06-28 07:39+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Muha Aliss <muhaaliss@pm.me>\n"
 "Language-Team: Muha Aliss <muhaaliss@gmail.com>\n"
@@ -24,27 +24,27 @@ msgstr ""
 msgid "(Empty Line)"
 msgstr "(Boş Satır)"
 
-#: ../addons/src/ao_bookmarklist.c:315
+#: ../addons/src/ao_bookmarklist.c:331
 msgid "_Remove Bookmark"
 msgstr "Yer İmini _Kaldır"
 
 #. Translators: Number is meant at this point.
-#: ../addons/src/ao_bookmarklist.c:342
+#: ../addons/src/ao_bookmarklist.c:358
 msgid "No."
 msgstr "No."
 
-#: ../addons/src/ao_bookmarklist.c:350 ../devhelp/src/dhp-object.c:494
+#: ../addons/src/ao_bookmarklist.c:366 ../devhelp/src/dhp-object.c:494
 #: ../devhelp/devhelp/dh-window.c:1142
 msgid "Contents"
 msgstr "İçerik"
 
-#: ../addons/src/ao_bookmarklist.c:383 ../treebrowser/src/treebrowser.c:666
+#: ../addons/src/ao_bookmarklist.c:399 ../treebrowser/src/treebrowser.c:666
 #: ../webhelper/src/gwh-plugin.c:328
 msgid "Bookmarks"
 msgstr "Yer İmleri"
 
 #. complete update
-#: ../addons/src/ao_tasks.c:373 ../geanyvc/src/geanyvc.c:2679
+#: ../addons/src/ao_tasks.c:373 ../geanyvc/src/geanyvc.c:2730
 msgid "_Update"
 msgstr "_Güncelle"
 
@@ -165,10 +165,10 @@ msgstr "Geçerli belgenin dosya yolunu panoya kopyala"
 #: ../addons/src/addons.c:364 ../autoclose/src/autoclose.c:920
 #: ../codenav/src/codenavigation.c:281 ../latex/src/latex.c:208
 #: ../latex/src/latex.c:293 ../geanyprj/src/geanyprj.c:176
-#: ../geanyvc/src/geanyvc.c:2079 ../geniuspaste/src/geniuspaste.c:336
+#: ../geanyvc/src/geanyvc.c:2130 ../geniuspaste/src/geniuspaste.c:336
 #: ../lineoperations/src/lo_prefs.c:58 ../sendmail/src/sendmail.c:128
 #: ../sendmail/src/sendmail.c:293 ../spellcheck/src/scplugin.c:124
-#: ../treebrowser/src/treebrowser.c:2102
+#: ../treebrowser/src/treebrowser.c:2106
 #: ../updatechecker/src/updatechecker.c:262
 msgid "Plugin configuration directory could not be created."
 msgstr "Eklenti düzenleme dizini oluşturulamadı."
@@ -738,7 +738,7 @@ msgstr "~\"Hedef dosya yükleniyor.\\n\""
 msgid "Error loading file"
 msgstr "Dosya yüklenirken hata"
 
-#. setting asyncronous mode
+#. setting asynchronous mode
 #. setting null-stop array printing
 #. enable pretty printing
 #: ../debugger/src/dbm_gdb.c:789 ../debugger/src/dbm_gdb.c:792
@@ -1135,7 +1135,7 @@ msgid "A developers' help browser for GNOME"
 msgstr ""
 
 #. Create the current file Submenu
-#: ../devhelp/devhelp/dh-window.c:759 ../geanyvc/src/geanyvc.c:2660
+#: ../devhelp/devhelp/dh-window.c:759 ../geanyvc/src/geanyvc.c:2711
 msgid "_File"
 msgstr "_Dosya"
 
@@ -1169,11 +1169,11 @@ msgstr "Yeni _Sekme"
 msgid "_Print…"
 msgstr "_Yazdır…"
 
-#: ../devhelp/devhelp/dh-window.c:782 ../devhelp/devhelp/eggfindbar.c:342
+#: ../devhelp/devhelp/dh-window.c:782
 msgid "Find Next"
 msgstr "Sonrakini Bul"
 
-#: ../devhelp/devhelp/dh-window.c:784 ../devhelp/devhelp/eggfindbar.c:329
+#: ../devhelp/devhelp/dh-window.c:784
 msgid "Find Previous"
 msgstr "Öncekini Bul"
 
@@ -1358,7 +1358,7 @@ msgid ""
 "contributing to this plugin?"
 msgstr ""
 
-#: ../geanydoc/src/geanydoc.c:159 ../geanyvc/src/geanyvc.c:442
+#: ../geanydoc/src/geanydoc.c:159 ../geanyvc/src/geanyvc.c:448
 msgid "Could not parse the output of command"
 msgstr "Komutun çıktısı ayrıştırılamadı"
 
@@ -3034,14 +3034,14 @@ msgstr ""
 "\"%s\" modülü %s() fonksiyonunda hata:\n"
 "\"%s\" komutu için yeterli argüman girilmedi.\n"
 
-#: ../geanylua/glspi_sci.c:637 ../geanylua/glspi_app.c:406
+#: ../geanylua/glspi_sci.c:729 ../geanylua/glspi_app.c:406
 #, c-format
 msgid ""
 "Error in module \"%s\" at function %s():\n"
 "unknown command \"%s\" given for argument #1.\n"
 msgstr ""
 
-#: ../geanylua/glspi_sci.c:781
+#: ../geanylua/glspi_sci.c:924
 #, c-format
 msgid ""
 "Error in module \"%s\" at function %s():\n"
@@ -3052,7 +3052,7 @@ msgstr ""
 " geçersiz argüman #%d:\n"
 " \"%s\" geçersiz bayrak, #%d elementi için\n"
 
-#: ../geanylua/glspi_sci.c:785
+#: ../geanylua/glspi_sci.c:928
 msgid "<too large to display>"
 msgstr "<gösterilemeyecek kadar uzun>"
 
@@ -3811,7 +3811,7 @@ msgid "New _Below"
 msgstr ""
 
 #: ../geanymacro/src/geanymacro.c:1824 ../geanymacro/src/geanymacro.c:2120
-#: ../treebrowser/src/treebrowser.c:1338 ../treebrowser/src/treebrowser.c:1340
+#: ../treebrowser/src/treebrowser.c:1342 ../treebrowser/src/treebrowser.c:1344
 msgid "_Delete"
 msgstr "_Sil"
 
@@ -4210,8 +4210,8 @@ msgstr ""
 msgid "a key with fingerprint"
 msgstr ""
 
-#: ../geanypg/src/verify_aux.c:66 ../spellcheck/src/gui.c:610
-#: ../spellcheck/src/gui.c:621
+#: ../geanypg/src/verify_aux.c:66 ../spellcheck/src/gui.c:607
+#: ../spellcheck/src/gui.c:618
 msgid "unknown"
 msgstr "bilinmeyen"
 
@@ -4512,50 +4512,50 @@ msgid ""
 "contributing to this plugin?"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:501
+#: ../geanyvc/src/geanyvc.c:507
 #, c-format
 msgid "geanyvc: s_spawn_sync error: %s"
 msgstr "geanyvc: s_spawn_sync hatası: %s"
 
-#: ../geanyvc/src/geanyvc.c:587
+#: ../geanyvc/src/geanyvc.c:593
 #, c-format
 msgid "File %s: action %s executed via %s."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:646 ../geanyvc/src/geanyvc.c:657
+#: ../geanyvc/src/geanyvc.c:633 ../geanyvc/src/geanyvc.c:643
 #, fuzzy, c-format
-msgid "geanyvc: vcdiff_file_activated: Unable to rename '%s' to '%s'"
+msgid "geanyvc: diff_external: Unable to rename '%s' to '%s'"
 msgstr ""
 "geanyvc: vcdiff_file_activated: '%s' değerini yeniden adlandırırken hata '%s'"
 
-#: ../geanyvc/src/geanyvc.c:683 ../geanyvc/src/geanyvc.c:733
+#: ../geanyvc/src/geanyvc.c:698 ../geanyvc/src/geanyvc.c:784
 msgid "No changes were made."
 msgstr "Hiç değişiklik yapılmadı."
 
-#: ../geanyvc/src/geanyvc.c:760
+#: ../geanyvc/src/geanyvc.c:811
 msgid "No history available"
 msgstr "Geçmiş yok"
 
-#: ../geanyvc/src/geanyvc.c:953 ../geanyvc/src/geanyvc.c:961
+#: ../geanyvc/src/geanyvc.c:1004 ../geanyvc/src/geanyvc.c:1012
 #, c-format
 msgid "Do you really want to revert: %s?"
 msgstr "Gerçekten geri almak istiyor musunuz: %s?"
 
-#: ../geanyvc/src/geanyvc.c:969
+#: ../geanyvc/src/geanyvc.c:1020
 #, c-format
 msgid "Do you really want to add: %s?"
 msgstr "Gerçekten eklemek istiyor musunuz: %s ?"
 
-#: ../geanyvc/src/geanyvc.c:976
+#: ../geanyvc/src/geanyvc.c:1027
 #, c-format
 msgid "Do you really want to remove: %s?"
 msgstr "Gerçekten kaldırmak istiyor musunuz: %s ?"
 
-#: ../geanyvc/src/geanyvc.c:999
+#: ../geanyvc/src/geanyvc.c:1050
 msgid "Do you really want to update?"
 msgstr "Gerçekten güncellemek istiyor musunuz?"
 
-#: ../geanyvc/src/geanyvc.c:1126
+#: ../geanyvc/src/geanyvc.c:1177
 msgid ""
 "The resulting differences cannot be displayed because the changes are too "
 "big to display here and would slow down the UI significantly.\n"
@@ -4564,48 +4564,48 @@ msgid ""
 "Geany directly by using the GeanyVC menu (Base Directory -> Diff)."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1280
+#: ../geanyvc/src/geanyvc.c:1331
 msgid "Commit Y/N"
 msgstr "Teslim et Y/N"
 
-#: ../geanyvc/src/geanyvc.c:1290
+#: ../geanyvc/src/geanyvc.c:1341
 msgid "Status"
 msgstr "Durum"
 
-#: ../geanyvc/src/geanyvc.c:1297
+#: ../geanyvc/src/geanyvc.c:1348
 msgid "Path"
 msgstr "Yol"
 
-#: ../geanyvc/src/geanyvc.c:1414
+#: ../geanyvc/src/geanyvc.c:1465
 msgid "Choose a previous commit message"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1476
+#: ../geanyvc/src/geanyvc.c:1527
 #, c-format
 msgid "Line: %d Column: %d"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1523
+#: ../geanyvc/src/geanyvc.c:1574
 msgid "Commit"
 msgstr "Teslim et"
 
-#: ../geanyvc/src/geanyvc.c:1564
+#: ../geanyvc/src/geanyvc.c:1615
 msgid "_De-/select all files"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1608
+#: ../geanyvc/src/geanyvc.c:1659
 msgid "<b>Commit message:</b>"
 msgstr "<b>Teslim mesajı:</b>"
 
-#: ../geanyvc/src/geanyvc.c:1632
+#: ../geanyvc/src/geanyvc.c:1683
 msgid "C_ommit"
 msgstr "G_önder"
 
-#: ../geanyvc/src/geanyvc.c:1740
+#: ../geanyvc/src/geanyvc.c:1791
 msgid "Nothing to commit."
 msgstr "Teslim edilecek bir şey yok."
 
-#: ../geanyvc/src/geanyvc.c:1788
+#: ../geanyvc/src/geanyvc.c:1839
 #, c-format
 msgid ""
 "Error initializing GeanyVC spell checking: %s. Check your configuration."
@@ -4613,282 +4613,282 @@ msgstr ""
 "GeanyVC yazım denetimi başlatılırken hata oluştu: %s. Konfigürasyonunuzu "
 "kontrol edin."
 
-#: ../geanyvc/src/geanyvc.c:1823
+#: ../geanyvc/src/geanyvc.c:1874
 #, c-format
 msgid "Commit failed (status: %d, error: %s)."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1824
+#: ../geanyvc/src/geanyvc.c:1875
 msgid "Commit failed; see status in the Message window."
 msgstr "Teslim hatası; Mesajlar penceresinden detaylara bakın"
 
-#: ../geanyvc/src/geanyvc.c:1829
+#: ../geanyvc/src/geanyvc.c:1880
 msgid "Changes committed."
 msgstr "Değişiklikler teslim edildi."
 
-#: ../geanyvc/src/geanyvc.c:2151
+#: ../geanyvc/src/geanyvc.c:2202
 msgid "Set Changed-flag for document tabs created by the plugin"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2154
+#: ../geanyvc/src/geanyvc.c:2205
 msgid ""
 "If this option is activated, every new by the VC-plugin created document tab "
 "will be marked as changed. Even this option is useful in some cases, it "
 "could cause a big number of annoying \"Do you want to save\"-dialogs."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2162
+#: ../geanyvc/src/geanyvc.c:2213
 #, fuzzy
 msgid "Confirm adding new files to a VCS"
 msgstr "Bir VCS'ye yeni dosyalar eklemeyi onaylayın"
 
-#: ../geanyvc/src/geanyvc.c:2165
+#: ../geanyvc/src/geanyvc.c:2216
 msgid "Shows a confirmation dialog on adding a new (created) file to VCS."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2171
+#: ../geanyvc/src/geanyvc.c:2222
 msgid "Maximize commit dialog"
 msgstr "Teslim diyaloğunu büyüt"
 
-#: ../geanyvc/src/geanyvc.c:2172
+#: ../geanyvc/src/geanyvc.c:2223
 msgid "Show commit dialog maximize."
 msgstr "Teslim diyaloğunu geniş göster."
 
-#: ../geanyvc/src/geanyvc.c:2178
+#: ../geanyvc/src/geanyvc.c:2229
 msgid "Use external diff viewer"
 msgstr "Harici diff görüntüleyici kullan"
 
-#: ../geanyvc/src/geanyvc.c:2180
+#: ../geanyvc/src/geanyvc.c:2231
 msgid "Use external diff viewer for file diff."
 msgstr "Dosya değişiklikleri için harici bir diff izleyici kullan."
 
-#: ../geanyvc/src/geanyvc.c:2186
+#: ../geanyvc/src/geanyvc.c:2237
 msgid "Show VC entries at editor menu"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2188
+#: ../geanyvc/src/geanyvc.c:2239
 msgid "Show entries for VC functions inside editor menu"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2193
+#: ../geanyvc/src/geanyvc.c:2244
 msgid "Attach menu to menubar"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2195
+#: ../geanyvc/src/geanyvc.c:2246
 msgid ""
 "Whether menu for this plugin are getting placed either inside tools menu or "
 "directly inside Geany's menubar. Will take in account after next start of "
 "GeanyVC"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2203
+#: ../geanyvc/src/geanyvc.c:2254
 msgid "Enable CVS"
 msgstr "CVS'i etkinleştir"
 
-#: ../geanyvc/src/geanyvc.c:2208
+#: ../geanyvc/src/geanyvc.c:2259
 msgid "Enable GIT"
 msgstr "GIT'i etkinleştir"
 
-#: ../geanyvc/src/geanyvc.c:2213
+#: ../geanyvc/src/geanyvc.c:2264
 msgid "Enable Fossil"
 msgstr "Fossil'i etkinleştir"
 
-#: ../geanyvc/src/geanyvc.c:2218
+#: ../geanyvc/src/geanyvc.c:2269
 msgid "Enable SVN"
 msgstr "SVN'i etkinleştir"
 
-#: ../geanyvc/src/geanyvc.c:2223
+#: ../geanyvc/src/geanyvc.c:2274
 msgid "Enable SVK"
 msgstr "SVK'yı etkinleştir"
 
-#: ../geanyvc/src/geanyvc.c:2228
+#: ../geanyvc/src/geanyvc.c:2279
 msgid "Enable Bazaar"
 msgstr "Bazaar'ı Etkinleştir"
 
-#: ../geanyvc/src/geanyvc.c:2233
+#: ../geanyvc/src/geanyvc.c:2284
 msgid "Enable Mercurial"
 msgstr "Mercurial'i Etkinleştir"
 
-#: ../geanyvc/src/geanyvc.c:2239
+#: ../geanyvc/src/geanyvc.c:2290
 msgid "Spellcheck language"
 msgstr "İmla denetimi dili"
 
 #. Diff of current file
 #. Diff of the current dir
 #. Complete diff of base directory
-#: ../geanyvc/src/geanyvc.c:2368 ../geanyvc/src/geanyvc.c:2463
-#: ../geanyvc/src/geanyvc.c:2503
+#: ../geanyvc/src/geanyvc.c:2419 ../geanyvc/src/geanyvc.c:2514
+#: ../geanyvc/src/geanyvc.c:2554
 msgid "_Diff"
 msgstr "_Diff"
 
-#: ../geanyvc/src/geanyvc.c:2371
+#: ../geanyvc/src/geanyvc.c:2422
 msgid "Make a diff from the current active file"
 msgstr "Şimdiki aktif dosyadan bir diff dosyası oluştur"
 
 #. Revert current file
 #. Revert current dir
 #. Revert everything
-#: ../geanyvc/src/geanyvc.c:2376 ../geanyvc/src/geanyvc.c:2472
-#: ../geanyvc/src/geanyvc.c:2511
+#: ../geanyvc/src/geanyvc.c:2427 ../geanyvc/src/geanyvc.c:2523
+#: ../geanyvc/src/geanyvc.c:2562
 msgid "_Revert"
 msgstr "_Eskiye dön"
 
-#: ../geanyvc/src/geanyvc.c:2379
+#: ../geanyvc/src/geanyvc.c:2430
 msgid "Restore pristine working copy file (undo local edits)."
 msgstr ""
 
 #. Blame for current file
-#: ../geanyvc/src/geanyvc.c:2388
+#: ../geanyvc/src/geanyvc.c:2439
 msgid "_Blame"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2391
+#: ../geanyvc/src/geanyvc.c:2442
 msgid "Shows the changes made at one file per revision and author."
 msgstr ""
 
 #. History/log of current file
 #. History/log of the current dir
 #. Complete History/Log of base directory
-#: ../geanyvc/src/geanyvc.c:2398 ../geanyvc/src/geanyvc.c:2482
-#: ../geanyvc/src/geanyvc.c:2523
+#: ../geanyvc/src/geanyvc.c:2449 ../geanyvc/src/geanyvc.c:2533
+#: ../geanyvc/src/geanyvc.c:2574
 msgid "_History (log)"
 msgstr "_Geçmiş (kayıt)"
 
-#: ../geanyvc/src/geanyvc.c:2401
+#: ../geanyvc/src/geanyvc.c:2452
 msgid "Shows the log of the current file"
 msgstr "Mevcut dosyanın kayıtlarını gösterir"
 
 #. base version of the current file
-#: ../geanyvc/src/geanyvc.c:2406
+#: ../geanyvc/src/geanyvc.c:2457
 msgid "_Original"
 msgstr "_Orijinal"
 
-#: ../geanyvc/src/geanyvc.c:2409
+#: ../geanyvc/src/geanyvc.c:2460
 msgid "Shows the original of the current file"
 msgstr "Mevcut dosyanın orijinalini gösterir"
 
 #. add current file
-#: ../geanyvc/src/geanyvc.c:2417
+#: ../geanyvc/src/geanyvc.c:2468
 msgid "_Add to Version Control"
 msgstr "S_ürüm Kontrolüne Ekle"
 
-#: ../geanyvc/src/geanyvc.c:2419
+#: ../geanyvc/src/geanyvc.c:2470
 msgid "Add file to repository."
 msgstr "Dosyayı depoya ekle."
 
 #. remove current file
-#: ../geanyvc/src/geanyvc.c:2425
+#: ../geanyvc/src/geanyvc.c:2476
 msgid "_Remove from Version Control"
 msgstr "Sürüm Kontrolünden _Çıkart"
 
-#: ../geanyvc/src/geanyvc.c:2427
+#: ../geanyvc/src/geanyvc.c:2478
 msgid "Remove file from repository."
 msgstr "Dosyayı depodan kaldır."
 
-#: ../geanyvc/src/geanyvc.c:2460
+#: ../geanyvc/src/geanyvc.c:2511
 msgid "_Directory"
 msgstr "_Dizin"
 
-#: ../geanyvc/src/geanyvc.c:2466
+#: ../geanyvc/src/geanyvc.c:2517
 msgid "Make a diff from the directory of the current active file"
 msgstr "Şimdiki aktif dosyanın dizininden bir diff dosyası oluştur"
 
-#: ../geanyvc/src/geanyvc.c:2475
+#: ../geanyvc/src/geanyvc.c:2526
 msgid "Restore original files in the current folder (undo local edits)."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2485
+#: ../geanyvc/src/geanyvc.c:2536
 msgid "Shows the log of the current directory"
 msgstr "Mevcut klasörün kayıtlarını gösterir"
 
-#: ../geanyvc/src/geanyvc.c:2499
+#: ../geanyvc/src/geanyvc.c:2550
 msgid "_Base Directory"
 msgstr "_Temel Dizin"
 
-#: ../geanyvc/src/geanyvc.c:2505
+#: ../geanyvc/src/geanyvc.c:2556
 msgid "Make a diff from the top VC directory"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2513
+#: ../geanyvc/src/geanyvc.c:2564
 msgid "Revert any local edits."
 msgstr "Tüm yerel değişiklikleri geri al."
 
-#: ../geanyvc/src/geanyvc.c:2526
+#: ../geanyvc/src/geanyvc.c:2577
 msgid "Shows the log of the top VC directory"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2543
+#: ../geanyvc/src/geanyvc.c:2594
 #, fuzzy
 msgid "_VC file Actions"
 msgstr "_VC dosyası İşlemleri"
 
-#: ../geanyvc/src/geanyvc.c:2552
+#: ../geanyvc/src/geanyvc.c:2603
 msgid "VC _Commit..."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2596
+#: ../geanyvc/src/geanyvc.c:2647
 msgid "Show diff of file"
 msgstr "Dosyanın farkını göster"
 
-#: ../geanyvc/src/geanyvc.c:2598
+#: ../geanyvc/src/geanyvc.c:2649
 msgid "Show diff of directory"
 msgstr "Dizinin farkını göster"
 
-#: ../geanyvc/src/geanyvc.c:2600
+#: ../geanyvc/src/geanyvc.c:2651
 msgid "Show diff of basedir"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2603
+#: ../geanyvc/src/geanyvc.c:2654
 msgid "Commit changes"
 msgstr "Değişiklikleri uygula"
 
-#: ../geanyvc/src/geanyvc.c:2605
+#: ../geanyvc/src/geanyvc.c:2656
 msgid "Show status"
 msgstr "Durumu göster"
 
-#: ../geanyvc/src/geanyvc.c:2607
+#: ../geanyvc/src/geanyvc.c:2658
 msgid "Revert single file"
 msgstr "Tek dosyayı eski haline getir"
 
-#: ../geanyvc/src/geanyvc.c:2609
+#: ../geanyvc/src/geanyvc.c:2660
 msgid "Revert directory"
 msgstr "Dizini eski haline getir"
 
-#: ../geanyvc/src/geanyvc.c:2611
+#: ../geanyvc/src/geanyvc.c:2662
 msgid "Revert base directory"
 msgstr "Temel dizini eski haline getir"
 
-#: ../geanyvc/src/geanyvc.c:2613
+#: ../geanyvc/src/geanyvc.c:2664
 msgid "Update file"
 msgstr "Dosyayı güncelle"
 
-#: ../geanyvc/src/geanyvc.c:2643
+#: ../geanyvc/src/geanyvc.c:2694
 msgid "_VC"
 msgstr "_VC"
 
-#: ../geanyvc/src/geanyvc.c:2650
+#: ../geanyvc/src/geanyvc.c:2701
 msgid "_Version Control"
 msgstr "_Sürüm Kontrolü"
 
 #. Status of basedir
-#: ../geanyvc/src/geanyvc.c:2672
+#: ../geanyvc/src/geanyvc.c:2723
 msgid "_Status"
 msgstr "_Durum"
 
-#: ../geanyvc/src/geanyvc.c:2674
+#: ../geanyvc/src/geanyvc.c:2725
 msgid "Show status."
 msgstr "Durumu göster."
 
-#: ../geanyvc/src/geanyvc.c:2681
+#: ../geanyvc/src/geanyvc.c:2732
 msgid "Update from remote repository."
 msgstr "Uzak depodan güncelle."
 
 #. Commit all changes
-#: ../geanyvc/src/geanyvc.c:2686
+#: ../geanyvc/src/geanyvc.c:2737
 msgid "_Commit..."
 msgstr "_Teslim Et..."
 
-#: ../geanyvc/src/geanyvc.c:2688
+#: ../geanyvc/src/geanyvc.c:2739
 msgid "Commit changes."
 msgstr "Değişiklikleri uygula."
 
@@ -5002,37 +5002,6 @@ msgstr ""
 #: ../geniuspaste/src/geniuspaste.c:959
 msgid "_Paste it!"
 msgstr "_Yapıştır!"
-
-#: ../git-changebar/data/prefs.ui.h:1
-msgid "_Monitor repository for changes"
-msgstr ""
-
-#: ../git-changebar/data/prefs.ui.h:2
-#, fuzzy
-msgid ""
-"Whether to automatically update the diff in order to maintain it up to date "
-"when the underlying Git repository changes.  This should generally be "
-"enabled for optimal user experience."
-msgstr ""
-"Temel Git deposu değiştiğinde güncel tutmak için farkın otomatik olarak "
-"güncellenip güncellenmeyeceği. Bu genellikle en iyi kullanıcı deneyimi için "
-"etkinleştirilmelidir."
-
-#: ../git-changebar/data/prefs.ui.h:3
-msgid "_Added lines:"
-msgstr "_Eklenen satırlar:"
-
-#: ../git-changebar/data/prefs.ui.h:4
-msgid "_Changed lines:"
-msgstr "_Değiştirilen satırlar:"
-
-#: ../git-changebar/data/prefs.ui.h:5
-msgid "_Removed lines:"
-msgstr "_Kaldırılan satırlar:"
-
-#: ../git-changebar/data/prefs.ui.h:6
-msgid "Colors"
-msgstr "Renkler"
 
 #: ../git-changebar/src/gcb-plugin.c:62
 msgid "Git Change Bar"
@@ -5211,8 +5180,8 @@ msgstr ""
 #: ../lipsum/src/lipsum.c:184 ../sendmail/src/sendmail.c:396
 #, c-format
 msgid ""
-"Your configuration directory has been successfully moved from \"%s\" to \"%s"
-"\"."
+"Your configuration directory has been successfully moved from \"%s\" to "
+"\"%s\"."
 msgstr ""
 
 #: ../lipsum/src/lipsum.c:199
@@ -5375,7 +5344,7 @@ msgstr "Varsayılan yapılandırma dosyası yazılamıyor: %s"
 msgid "Unable to read value for '%s' key: %s"
 msgstr "'%s' tuşunun değeri okunamıyor: %s"
 
-#: ../multiterm/src/tab-label.vala:62 ../treebrowser/src/treebrowser.c:2132
+#: ../multiterm/src/tab-label.vala:62 ../treebrowser/src/treebrowser.c:2137
 msgid "Terminal"
 msgstr "Uçbirim"
 
@@ -5413,114 +5382,6 @@ msgstr ""
 msgid "Show Overview"
 msgstr "Genel Bakışı Göster"
 
-#: ../overview/data/prefs.ui.h:1
-msgid ""
-"The amount to zoom the overview sidebar. This should probably negative if "
-"you want the sidebar zoomed out."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:2
-msgid "Zoom Level:"
-msgstr "Yakınlaştırma seviyesi:"
-
-#: ../overview/data/prefs.ui.h:3
-msgid "The width of the overview sidebar."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:4
-msgid "Width:"
-msgstr "Genişlik:"
-
-#: ../overview/data/prefs.ui.h:5
-msgid ""
-"The number of lines to scroll at a time when scrolling the overview sidebar."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:6
-msgid "Scroll Lines:"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:7
-msgid "Position on left"
-msgstr "Soldaki konum"
-
-#: ../overview/data/prefs.ui.h:8
-msgid ""
-"Position the overview bar on the left rather than the right (requires Geany "
-"1.25 or greater)."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:9
-msgid "Hide tooltip"
-msgstr "Araç ipucunu gizle"
-
-#: ../overview/data/prefs.ui.h:10
-msgid ""
-"Hide the tooltip that is displayed when mousing over the overview that shows "
-"line, column and position information."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:11
-msgid "Hide editor scrollbar"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:12
-msgid ""
-"Whether to hide Geany's regular editor scrollbar while the overview bar is "
-"visible."
-msgstr ""
-"Genel bakış görünür durumdayken Geany'nin normal düzenleyici kaydırma "
-"çubuğunun gizlenip gizlenmeyeceği."
-
-#: ../overview/data/prefs.ui.h:13
-msgid "Disable overlay"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:14
-msgid ""
-"Turn off drawing overlay, which shows the region of the main editor view "
-"that is currently in view, ontop of the overview bar."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:15 ../scope/data/scope.glade.h:130
-#: ../scope/data/scope_gtk3.glade.h:130
-msgid "Options"
-msgstr "Seçenekler"
-
-#: ../overview/data/prefs.ui.h:16
-msgid ""
-"The color and opacity of the overlay drawn ontop of the overlay sidebar."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:17
-msgid "Color:"
-msgstr "Renk:"
-
-#: ../overview/data/prefs.ui.h:18
-msgid ""
-"The color and opacity of the border drawn around the revealed area in the "
-"overview sidebar. Set to the same as Overlay Color to disable."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:19
-msgid "Outline Color:"
-msgstr "Anahat Rengi:"
-
-#: ../overview/data/prefs.ui.h:20
-msgid "Draw over visible area"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:21
-msgid ""
-"When checked it will draw the overlay ontop of the area that is visible in "
-"the main editor view, when unchecked, it will do the opposite and draw the "
-"overlay everywhere but the visible area, \"revealing\" the visible part."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:22
-msgid "Overlay"
-msgstr ""
-
 #: ../pairtaghighlighter/src/pair_tag_highlighter.c:43
 msgid "Pair Tag Highlighter"
 msgstr ""
@@ -5546,147 +5407,6 @@ msgstr ""
 #, fuzzy
 msgid "Select To Matching Tag"
 msgstr "Eşleşen _Ayracı Seç"
-
-#: ../pohelper/data/menus.ui.h:1
-msgid "_Translation Helper"
-msgstr "_Çeviri Yardımcısı"
-
-#: ../pohelper/data/menus.ui.h:2
-msgid "_Previous String"
-msgstr "Önce_ki Yazı"
-
-#: ../pohelper/data/menus.ui.h:3 ../pohelper/src/gph-plugin.c:1590
-msgid "Go to previous string"
-msgstr "Önceki metne git"
-
-#: ../pohelper/data/menus.ui.h:4
-msgid "_Next String"
-msgstr "_Sonraki Yazı"
-
-#: ../pohelper/data/menus.ui.h:5 ../pohelper/src/gph-plugin.c:1593
-msgid "Go to next string"
-msgstr "Sonraki metne git"
-
-#: ../pohelper/data/menus.ui.h:6
-msgid "Pre_vious Untranslated"
-msgstr "Ön_ceki Çevirilmemiş"
-
-#: ../pohelper/data/menus.ui.h:7 ../pohelper/src/gph-plugin.c:1596
-msgid "Go to previous untranslated string"
-msgstr "Bir önceki çevirilmemiş yazıya git"
-
-#: ../pohelper/data/menus.ui.h:8
-msgid "Next _Untranslated"
-msgstr "Son_raki Çevirilmemiş"
-
-#: ../pohelper/data/menus.ui.h:9 ../pohelper/src/gph-plugin.c:1599
-msgid "Go to next untranslated string"
-msgstr "Bir sonraki çevirilmemiş yazıya git"
-
-#: ../pohelper/data/menus.ui.h:10
-msgid "Previous Fu_zzy"
-msgstr "_Önceki Bulanık"
-
-#: ../pohelper/data/menus.ui.h:11 ../pohelper/src/gph-plugin.c:1602
-msgid "Go to previous fuzzily translated string"
-msgstr "Bir önceki bulanık çeviriye git"
-
-#: ../pohelper/data/menus.ui.h:12
-msgid "Next _Fuzzy"
-msgstr "Sonraki _Bulanık"
-
-#: ../pohelper/data/menus.ui.h:13 ../pohelper/src/gph-plugin.c:1605
-msgid "Go to next fuzzily translated string"
-msgstr "Bir sonraki bulanık çeviriye git"
-
-#: ../pohelper/data/menus.ui.h:14
-msgid "Previous Untranslated or Fuzz_y"
-msgstr "Önceki Çevirilmemiş veya B_ulanık"
-
-#: ../pohelper/data/menus.ui.h:15 ../pohelper/src/gph-plugin.c:1608
-msgid "Go to previous untranslated or fuzzy string"
-msgstr "Önceki çevirilmemiş veya bulanık çeviriye git"
-
-#: ../pohelper/data/menus.ui.h:16
-msgid "Next Untranslated _or Fuzzy"
-msgstr "Sonraki Çe_virilmemiş veya Bulanık"
-
-#: ../pohelper/data/menus.ui.h:17 ../pohelper/src/gph-plugin.c:1612
-msgid "Go to next untranslated or fuzzy string"
-msgstr "Sonraki çevirilmemiş veya bulanık çeviriye git"
-
-#: ../pohelper/data/menus.ui.h:18 ../pohelper/src/gph-plugin.c:1623
-msgid "Toggle current translation fuzziness"
-msgstr "Mevcut çeviriyi bulanık olarak işaretle veya bulanıklığı kaldır"
-
-#: ../pohelper/data/menus.ui.h:19
-msgid "_Toggle Fuzziness"
-msgstr "Bulanıklığı _Değiştir"
-
-#: ../pohelper/data/menus.ui.h:20
-msgid "Paste _Message as Translation"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:21
-msgid "Paste the original untranslated string to the translation"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:22 ../pohelper/src/gph-plugin.c:1620
-msgid "Reflow the current translation string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:23
-msgid "_Reflow Translation"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:24 ../pohelper/src/gph-plugin.c:1626
-msgid "Show statistics of the current document"
-msgstr "Geçerli belgenin istatistiklerini göster"
-
-#: ../pohelper/data/menus.ui.h:25
-msgid "_Show stats"
-msgstr "İstatistikleri _göster"
-
-#: ../pohelper/data/menus.ui.h:26
-msgid ""
-"Whether to update the translation headers (author, revision date, ...) upon "
-"file save"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:27
-msgid "Update _Headers Upon Save"
-msgstr "Kayıt Sonrasında _Başlıkları Güncelle"
-
-#: ../pohelper/data/stats.ui.h:1
-msgid "Translation statistics"
-msgstr "Çeviri istatistikleri"
-
-#: ../pohelper/data/stats.ui.h:2
-#, fuzzy
-msgid "Choose a color for translated strings"
-msgstr "Çevrilmiş dizeler için bir renk seçin"
-
-#: ../pohelper/data/stats.ui.h:3
-#, fuzzy
-msgid "Choose a color for fuzzily translated strings"
-msgstr "Düzgünce çevrilmiş dizeler için bir renk seçin"
-
-#: ../pohelper/data/stats.ui.h:4
-#, fuzzy
-msgid "Choose a color for untranslated strings"
-msgstr "Çevrilmemiş dizeler için bir renk seçin"
-
-#: ../pohelper/data/stats.ui.h:5
-msgid "Translated:"
-msgstr "Çevriri:"
-
-#: ../pohelper/data/stats.ui.h:6
-msgid "Fuzzy:"
-msgstr "Bulanık:"
-
-#: ../pohelper/data/stats.ui.h:7
-msgid "Untranslated:"
-msgstr "Çevrilmemiş:"
 
 #: ../pohelper/src/gph-plugin.c:40
 msgid "Translation Helper"
@@ -5716,9 +5436,53 @@ msgstr "<b>Çevrilmemiş:</b> %.3g%%"
 msgid "%u (%.3g%%)"
 msgstr "%u (%.3g%%)"
 
+#: ../pohelper/src/gph-plugin.c:1590
+msgid "Go to previous string"
+msgstr "Önceki metne git"
+
+#: ../pohelper/src/gph-plugin.c:1593
+msgid "Go to next string"
+msgstr "Sonraki metne git"
+
+#: ../pohelper/src/gph-plugin.c:1596
+msgid "Go to previous untranslated string"
+msgstr "Bir önceki çevirilmemiş yazıya git"
+
+#: ../pohelper/src/gph-plugin.c:1599
+msgid "Go to next untranslated string"
+msgstr "Bir sonraki çevirilmemiş yazıya git"
+
+#: ../pohelper/src/gph-plugin.c:1602
+msgid "Go to previous fuzzily translated string"
+msgstr "Bir önceki bulanık çeviriye git"
+
+#: ../pohelper/src/gph-plugin.c:1605
+msgid "Go to next fuzzily translated string"
+msgstr "Bir sonraki bulanık çeviriye git"
+
+#: ../pohelper/src/gph-plugin.c:1608
+msgid "Go to previous untranslated or fuzzy string"
+msgstr "Önceki çevirilmemiş veya bulanık çeviriye git"
+
+#: ../pohelper/src/gph-plugin.c:1612
+msgid "Go to next untranslated or fuzzy string"
+msgstr "Sonraki çevirilmemiş veya bulanık çeviriye git"
+
 #: ../pohelper/src/gph-plugin.c:1616
 msgid "Paste original untranslated string to translation"
 msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1620
+msgid "Reflow the current translation string"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1623
+msgid "Toggle current translation fuzziness"
+msgstr "Mevcut çeviriyi bulanık olarak işaretle veya bulanıklığı kaldır"
+
+#: ../pohelper/src/gph-plugin.c:1626
+msgid "Show statistics of the current document"
+msgstr "Geçerli belgenin istatistiklerini göster"
 
 #: ../pohelper/src/gph-plugin.c:1833
 #, fuzzy, c-format
@@ -5982,7 +5746,7 @@ msgid "Add"
 msgstr "Ekle"
 
 #: ../projectorganizer/src/prjorg-sidebar.c:390
-#: ../treebrowser/src/treebrowser.c:2356
+#: ../treebrowser/src/treebrowser.c:2361
 msgid "New File"
 msgstr "Yeni Dosya"
 
@@ -6598,6 +6362,10 @@ msgstr "_Tooltips'i göster"
 msgid "<b>Others</b>"
 msgstr "<b>Diğerleri</b>"
 
+#: ../scope/data/scope.glade.h:130 ../scope/data/scope_gtk3.glade.h:130
+msgid "Options"
+msgstr "Seçenekler"
+
 #: ../scope/data/scope.glade.h:131 ../scope/data/scope_gtk3.glade.h:131
 msgid "_Import"
 msgstr "_İçe aktar"
@@ -7167,12 +6935,14 @@ msgid "Checks the spelling of the current document."
 msgstr "Mevcut belgenin imla denetimini yapar."
 
 #: ../spellcheck/src/scplugin.c:225
-msgid "Run Spell Check"
+#, fuzzy
+msgid "Run spell check once"
 msgstr "İmla Denetimi Yap"
 
-#: ../spellcheck/src/scplugin.c:228
-msgid "Toggle Check While Typing"
-msgstr "Yazarken Kontrol Et"
+#: ../spellcheck/src/scplugin.c:228 ../spellcheck/src/scplugin.c:333
+#, fuzzy
+msgid "Toggle spell check"
+msgstr "İmla Denetimi"
 
 #. initialise the dialog
 #: ../spellcheck/src/scplugin.c:239
@@ -7198,10 +6968,6 @@ msgstr ""
 #: ../spellcheck/src/scplugin.c:325
 msgid "<b>Interface</b>"
 msgstr "<b>Arayüz</b>"
-
-#: ../spellcheck/src/scplugin.c:333
-msgid "Check spelling while typing"
-msgstr "Yazma sırasında imla denetimi yap"
 
 #: ../spellcheck/src/scplugin.c:336
 msgid "Check spelling when opening a document"
@@ -7233,52 +6999,52 @@ msgstr ""
 msgid "<b>Behavior</b>"
 msgstr "<b>Davranış</b>"
 
-#: ../spellcheck/src/gui.c:76
+#: ../spellcheck/src/gui.c:88
 msgid "Spell checking while typing is now enabled"
 msgstr "Yazarken imla denetimi artık aktif"
 
-#: ../spellcheck/src/gui.c:78
+#: ../spellcheck/src/gui.c:90
 msgid "Spell checking while typing is now disabled"
 msgstr "Yazarken imla denetimi artık pasif"
 
-#: ../spellcheck/src/gui.c:326
+#: ../spellcheck/src/gui.c:323
 msgid "More..."
 msgstr "Daha fazla..."
 
-#: ../spellcheck/src/gui.c:347
+#: ../spellcheck/src/gui.c:344
 msgid "(No Suggestions)"
 msgstr "(Öneri Yok)"
 
-#: ../spellcheck/src/gui.c:360
+#: ../spellcheck/src/gui.c:357
 #, c-format
 msgid "Add \"%s\" to Dictionary"
 msgstr "Sözlüğe \"%s\" ekle"
 
-#: ../spellcheck/src/gui.c:368
+#: ../spellcheck/src/gui.c:365
 msgid "Ignore All"
 msgstr "Tümünü Yoksay"
 
-#: ../spellcheck/src/gui.c:441
+#: ../spellcheck/src/gui.c:438
 msgid ""
 "Search term is too long to provide\n"
 "spelling suggestions in the editor menu."
 msgstr ""
 
-#: ../spellcheck/src/gui.c:447
+#: ../spellcheck/src/gui.c:444
 msgid "Perform Spell Check"
 msgstr "İmla Denetimi Uygula"
 
-#: ../spellcheck/src/gui.c:609
+#: ../spellcheck/src/gui.c:606
 #, c-format
 msgid "Default (%s)"
 msgstr "Varsayılan (%s)"
 
-#: ../spellcheck/src/gui.c:620
-#, c-format
-msgid "Toggle spell check while typing (current language: %s)"
+#: ../spellcheck/src/gui.c:617
+#, fuzzy, c-format
+msgid "Toggle spell check (current language: %s)"
 msgstr "Yazarken imla denetimini uygula (şu anda ayarlı dil: %s)"
 
-#: ../spellcheck/src/gui.c:698
+#: ../spellcheck/src/gui.c:695
 msgid "Spelling Suggestions"
 msgstr "İmla Denetimi Önerileri"
 
@@ -7373,15 +7139,15 @@ msgstr "(Boş)"
 msgid "Could not execute configured external command '%s' (%s)."
 msgstr "Ayarlanmış harici komut çalıştırılamadı '%s' (%s)."
 
-#: ../treebrowser/src/treebrowser.c:1089
+#: ../treebrowser/src/treebrowser.c:1093
 msgid "NewDirectory"
 msgstr "YeniDizin"
 
-#: ../treebrowser/src/treebrowser.c:1091
+#: ../treebrowser/src/treebrowser.c:1095
 msgid "NewFile"
 msgstr "YeniDosya"
 
-#: ../treebrowser/src/treebrowser.c:1096
+#: ../treebrowser/src/treebrowser.c:1100
 #, c-format
 msgid ""
 "Target file '%s' exists.\n"
@@ -7390,134 +7156,134 @@ msgstr ""
 "Hedef dosya '%s' var.\n"
 "Onu gerçekten boş bir dosya ile değiştirmek mi istiyorsunuz?"
 
-#: ../treebrowser/src/treebrowser.c:1142
+#: ../treebrowser/src/treebrowser.c:1146
 #, c-format
 msgid "Do you really want to delete '%s' ?"
 msgstr "Gerçekten silmek istiyor musunuz: '%s' ?"
 
-#: ../treebrowser/src/treebrowser.c:1255 ../treebrowser/src/treebrowser.c:1257
+#: ../treebrowser/src/treebrowser.c:1259 ../treebrowser/src/treebrowser.c:1261
 msgid "Go _Up"
 msgstr "_Yukarı git"
 
-#: ../treebrowser/src/treebrowser.c:1263 ../treebrowser/src/treebrowser.c:1265
+#: ../treebrowser/src/treebrowser.c:1267 ../treebrowser/src/treebrowser.c:1269
 msgid "Set _Path From Document"
 msgstr "Yolu belgeden ayarla"
 
-#: ../treebrowser/src/treebrowser.c:1271 ../treebrowser/src/treebrowser.c:1273
+#: ../treebrowser/src/treebrowser.c:1275 ../treebrowser/src/treebrowser.c:1277
 msgid "_Open Externally"
 msgstr "Harici Olarak _Aç"
 
-#: ../treebrowser/src/treebrowser.c:1279
+#: ../treebrowser/src/treebrowser.c:1283
 msgid "Open _Terminal"
 msgstr "_Terminali Aç"
 
-#: ../treebrowser/src/treebrowser.c:1284 ../treebrowser/src/treebrowser.c:1286
+#: ../treebrowser/src/treebrowser.c:1288 ../treebrowser/src/treebrowser.c:1290
 msgid "Set as _Root"
 msgstr "_Kök olarak ata"
 
-#: ../treebrowser/src/treebrowser.c:1293 ../treebrowser/src/treebrowser.c:1295
+#: ../treebrowser/src/treebrowser.c:1297 ../treebrowser/src/treebrowser.c:1299
 msgid "Refres_h"
 msgstr "Yenil_e"
 
-#: ../treebrowser/src/treebrowser.c:1301 ../treebrowser/src/treebrowser.c:1303
+#: ../treebrowser/src/treebrowser.c:1305 ../treebrowser/src/treebrowser.c:1307
 msgid "_Find in Files"
 msgstr "Dosy_alarda Ara"
 
-#: ../treebrowser/src/treebrowser.c:1313 ../treebrowser/src/treebrowser.c:1315
+#: ../treebrowser/src/treebrowser.c:1317 ../treebrowser/src/treebrowser.c:1319
 msgid "N_ew Folder"
 msgstr "Y_eni Dosya"
 
-#: ../treebrowser/src/treebrowser.c:1321 ../treebrowser/src/treebrowser.c:1323
+#: ../treebrowser/src/treebrowser.c:1325 ../treebrowser/src/treebrowser.c:1327
 msgid "_New File"
 msgstr "_Yeni Dosya"
 
-#: ../treebrowser/src/treebrowser.c:1329 ../treebrowser/src/treebrowser.c:1331
+#: ../treebrowser/src/treebrowser.c:1333 ../treebrowser/src/treebrowser.c:1335
 msgid "Rena_me"
 msgstr "Yeniden adlan_dır"
 
-#: ../treebrowser/src/treebrowser.c:1350 ../treebrowser/src/treebrowser.c:1352
+#: ../treebrowser/src/treebrowser.c:1354 ../treebrowser/src/treebrowser.c:1356
 #, c-format
 msgid "Close: %s"
 msgstr "Kapat: %s"
 
-#: ../treebrowser/src/treebrowser.c:1359 ../treebrowser/src/treebrowser.c:1361
+#: ../treebrowser/src/treebrowser.c:1363 ../treebrowser/src/treebrowser.c:1365
 #, c-format
 msgid "Clo_se Child Documents "
 msgstr "Alt Dosyaları Kap_at "
 
-#: ../treebrowser/src/treebrowser.c:1368 ../treebrowser/src/treebrowser.c:1370
+#: ../treebrowser/src/treebrowser.c:1372 ../treebrowser/src/treebrowser.c:1374
 msgid "_Copy Full Path to Clipboard"
 msgstr "Tam Yolu Panoya _Kopyala"
 
-#: ../treebrowser/src/treebrowser.c:1381 ../treebrowser/src/treebrowser.c:1383
+#: ../treebrowser/src/treebrowser.c:1385 ../treebrowser/src/treebrowser.c:1387
 msgid "E_xpand All"
 msgstr "Hepsini g_enişlet"
 
-#: ../treebrowser/src/treebrowser.c:1389 ../treebrowser/src/treebrowser.c:1391
+#: ../treebrowser/src/treebrowser.c:1393 ../treebrowser/src/treebrowser.c:1395
 msgid "Coll_apse All"
 msgstr "Hepsini Dara_lt"
 
-#: ../treebrowser/src/treebrowser.c:1399
+#: ../treebrowser/src/treebrowser.c:1403
 msgid "Show Boo_kmarks"
 msgstr "Yer im_lerini göster"
 
-#: ../treebrowser/src/treebrowser.c:1404
+#: ../treebrowser/src/treebrowser.c:1408
 msgid "Sho_w Hidden Files"
 msgstr "Gizli Dosyaları Gös_ter"
 
-#: ../treebrowser/src/treebrowser.c:1409
+#: ../treebrowser/src/treebrowser.c:1413
 msgid "Show Tool_bars"
 msgstr "Araç Çubuk_larını Göster"
 
-#: ../treebrowser/src/treebrowser.c:1747
+#: ../treebrowser/src/treebrowser.c:1751
 #, c-format
 msgid "Target file '%s' exists, do you really want to replace it?"
 msgstr "Hedef dosya '%s' zaten var, üzerine yazmak istiyor musunuz?"
 
-#: ../treebrowser/src/treebrowser.c:1883
+#: ../treebrowser/src/treebrowser.c:1887
 msgid "Go up"
 msgstr "Yukarı git"
 
-#: ../treebrowser/src/treebrowser.c:1893 ../treebrowser/src/treebrowser.c:2360
+#: ../treebrowser/src/treebrowser.c:1897 ../treebrowser/src/treebrowser.c:2365
 msgid "Refresh"
 msgstr "Yenile"
 
-#: ../treebrowser/src/treebrowser.c:1903
+#: ../treebrowser/src/treebrowser.c:1907
 msgid "Home"
 msgstr "Ev"
 
-#: ../treebrowser/src/treebrowser.c:1913
+#: ../treebrowser/src/treebrowser.c:1917
 msgid "Set path from document"
 msgstr "Yolu belgeden ayarla"
 
-#: ../treebrowser/src/treebrowser.c:1923
+#: ../treebrowser/src/treebrowser.c:1927
 msgid "Track path"
 msgstr "Parça yolu"
 
-#: ../treebrowser/src/treebrowser.c:1933
+#: ../treebrowser/src/treebrowser.c:1937
 msgid "Hide bars"
 msgstr "Çubukları gizle"
 
-#: ../treebrowser/src/treebrowser.c:1943
+#: ../treebrowser/src/treebrowser.c:1947
 msgid ""
 "Filter (*.c;*.h;*.cpp), and if you want temporary filter using the '!' "
 "reverse try for example this '!;*.c;*.h;*.cpp'"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1948
+#: ../treebrowser/src/treebrowser.c:1952
 msgid "Addressbar for example '/projects/my-project'"
 msgstr "Adres satırı, örneğin '/projeler/benim-projem'"
 
-#: ../treebrowser/src/treebrowser.c:1973
+#: ../treebrowser/src/treebrowser.c:1977
 msgid "Tree Browser"
 msgstr "Ağaç Gezgini"
 
-#: ../treebrowser/src/treebrowser.c:2114
+#: ../treebrowser/src/treebrowser.c:2118
 msgid "External open command"
 msgstr "Harici açma komutu"
 
-#: ../treebrowser/src/treebrowser.c:2124
-#, c-format
+#: ../treebrowser/src/treebrowser.c:2129
+#, no-c-format
 msgid ""
 "The command to execute when using \"Open with\". You can use %f and %d "
 "wildcards.\n"
@@ -7526,61 +7292,61 @@ msgid ""
 "filename"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2143
+#: ../treebrowser/src/treebrowser.c:2148
 msgid "The terminal to use with the command \"Open Terminal\""
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2149
+#: ../treebrowser/src/treebrowser.c:2154
 msgid "Toolbar"
 msgstr "Araç Çubuğu"
 
-#: ../treebrowser/src/treebrowser.c:2151
+#: ../treebrowser/src/treebrowser.c:2156
 msgid "Hidden"
 msgstr "Gizli"
 
-#: ../treebrowser/src/treebrowser.c:2152
+#: ../treebrowser/src/treebrowser.c:2157
 msgid "Top"
 msgstr "Üstte"
 
-#: ../treebrowser/src/treebrowser.c:2153
+#: ../treebrowser/src/treebrowser.c:2158
 msgid "Bottom"
 msgstr "Sonda"
 
-#: ../treebrowser/src/treebrowser.c:2158
+#: ../treebrowser/src/treebrowser.c:2163
 msgid "If position is changed, the option require plugin restart."
 msgstr "Eğer pozisyon değişirse eklentinin tekrar başlatılması gerekmektedir."
 
-#: ../treebrowser/src/treebrowser.c:2162
+#: ../treebrowser/src/treebrowser.c:2167
 msgid "Show icons"
 msgstr "Simgeleri göster"
 
-#: ../treebrowser/src/treebrowser.c:2164
+#: ../treebrowser/src/treebrowser.c:2169
 msgid "None"
 msgstr "Hiçbiri"
 
-#: ../treebrowser/src/treebrowser.c:2165
+#: ../treebrowser/src/treebrowser.c:2170
 msgid "Base"
 msgstr "Temel"
 
-#: ../treebrowser/src/treebrowser.c:2166
+#: ../treebrowser/src/treebrowser.c:2171
 msgid "Content-type"
 msgstr "İçerik-türü"
 
-#: ../treebrowser/src/treebrowser.c:2172
+#: ../treebrowser/src/treebrowser.c:2177
 msgid "Show hidden files"
 msgstr "Gizli dosyaları göster"
 
-#: ../treebrowser/src/treebrowser.c:2181
+#: ../treebrowser/src/treebrowser.c:2186
 msgid "On Windows, this just hide files that are prefixed with '.' (dot)"
 msgstr ""
 "Windows'da bu sadece '.' (nokta) ile başlayan dosyaların görünmemesini "
 "sağlar."
 
-#: ../treebrowser/src/treebrowser.c:2183
+#: ../treebrowser/src/treebrowser.c:2188
 msgid "Hide object files"
 msgstr "Nesne dosyalarını gizle"
 
-#: ../treebrowser/src/treebrowser.c:2192
+#: ../treebrowser/src/treebrowser.c:2197
 msgid ""
 "Don't show generated object files in the file browser, this includes *.o, *."
 "obj. *.so, *.dll, *.a, *.lib"
@@ -7588,59 +7354,59 @@ msgstr ""
 "Dahili oluşturulmuş dosyaları dosya tarayıcıda göstermez, bu *.o, *.obj. *."
 "so, *.dll, *.a, *.lib dosyalarını içerir"
 
-#: ../treebrowser/src/treebrowser.c:2194
+#: ../treebrowser/src/treebrowser.c:2199
 msgid "Reverse filter"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2203
+#: ../treebrowser/src/treebrowser.c:2208
 msgid "Follow current document"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2212
+#: ../treebrowser/src/treebrowser.c:2217
 msgid "Single click, open document and focus it"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2221
+#: ../treebrowser/src/treebrowser.c:2226
 msgid "Double click open directory"
 msgstr "Dizini açmak için çift tık"
 
-#: ../treebrowser/src/treebrowser.c:2230
+#: ../treebrowser/src/treebrowser.c:2235
 msgid "On delete file, close it if is opened"
 msgstr "Silme tuşu, eğer açık ise kapat"
 
-#: ../treebrowser/src/treebrowser.c:2239
+#: ../treebrowser/src/treebrowser.c:2244
 msgid "Focus editor on file open"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2248
+#: ../treebrowser/src/treebrowser.c:2253
 msgid "Show tree lines"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2257
+#: ../treebrowser/src/treebrowser.c:2262
 msgid "Show bookmarks"
 msgstr "Yer imlerini göster"
 
-#: ../treebrowser/src/treebrowser.c:2266
+#: ../treebrowser/src/treebrowser.c:2271
 msgid "Open new files"
 msgstr "Yeni dosya aç"
 
-#: ../treebrowser/src/treebrowser.c:2350
+#: ../treebrowser/src/treebrowser.c:2355
 msgid "Focus File List"
 msgstr "Dosya Listesini Odakla"
 
-#: ../treebrowser/src/treebrowser.c:2352
+#: ../treebrowser/src/treebrowser.c:2357
 msgid "Focus Path Entry"
 msgstr "Yol Yazımını Odakla"
 
-#: ../treebrowser/src/treebrowser.c:2354
+#: ../treebrowser/src/treebrowser.c:2359
 msgid "Rename Object"
 msgstr "Nesneyi Yeniden adlandır"
 
-#: ../treebrowser/src/treebrowser.c:2358
+#: ../treebrowser/src/treebrowser.c:2363
 msgid "New Folder"
 msgstr "Yeni Dosya"
 
-#: ../treebrowser/src/treebrowser.c:2362
+#: ../treebrowser/src/treebrowser.c:2367
 msgid "Track Current"
 msgstr ""
 
@@ -8314,13 +8080,6 @@ msgstr "Dizin yok"
 msgid "No workbench opened."
 msgstr ""
 
-#: ../workbench/src/sidebar.c:875
-#, c-format
-msgid "%s: %u Project"
-msgid_plural "%s: %u Projects"
-msgstr[0] "%s: %u Proje"
-msgstr[1] "%s: %u Proje"
-
 #: ../workbench/src/sidebar.c:886
 msgid ""
 "Add a project using the context menu\n"
@@ -8431,6 +8190,125 @@ msgstr "XML Snippets"
 #: ../xmlsnippets/src/plugin.c:45
 msgid "Autocompletes XML/HTML tags using snippets."
 msgstr ""
+
+#, fuzzy
+#~ msgid ""
+#~ "Whether to automatically update the diff in order to maintain it up to "
+#~ "date when the underlying Git repository changes.  This should generally "
+#~ "be enabled for optimal user experience."
+#~ msgstr ""
+#~ "Temel Git deposu değiştiğinde güncel tutmak için farkın otomatik olarak "
+#~ "güncellenip güncellenmeyeceği. Bu genellikle en iyi kullanıcı deneyimi "
+#~ "için etkinleştirilmelidir."
+
+#~ msgid "_Added lines:"
+#~ msgstr "_Eklenen satırlar:"
+
+#~ msgid "_Changed lines:"
+#~ msgstr "_Değiştirilen satırlar:"
+
+#~ msgid "_Removed lines:"
+#~ msgstr "_Kaldırılan satırlar:"
+
+#~ msgid "Colors"
+#~ msgstr "Renkler"
+
+#~ msgid "Zoom Level:"
+#~ msgstr "Yakınlaştırma seviyesi:"
+
+#~ msgid "Width:"
+#~ msgstr "Genişlik:"
+
+#~ msgid "Position on left"
+#~ msgstr "Soldaki konum"
+
+#~ msgid "Hide tooltip"
+#~ msgstr "Araç ipucunu gizle"
+
+#~ msgid ""
+#~ "Whether to hide Geany's regular editor scrollbar while the overview bar "
+#~ "is visible."
+#~ msgstr ""
+#~ "Genel bakış görünür durumdayken Geany'nin normal düzenleyici kaydırma "
+#~ "çubuğunun gizlenip gizlenmeyeceği."
+
+#~ msgid "Color:"
+#~ msgstr "Renk:"
+
+#~ msgid "Outline Color:"
+#~ msgstr "Anahat Rengi:"
+
+#~ msgid "_Translation Helper"
+#~ msgstr "_Çeviri Yardımcısı"
+
+#~ msgid "_Previous String"
+#~ msgstr "Önce_ki Yazı"
+
+#~ msgid "_Next String"
+#~ msgstr "_Sonraki Yazı"
+
+#~ msgid "Pre_vious Untranslated"
+#~ msgstr "Ön_ceki Çevirilmemiş"
+
+#~ msgid "Next _Untranslated"
+#~ msgstr "Son_raki Çevirilmemiş"
+
+#~ msgid "Previous Fu_zzy"
+#~ msgstr "_Önceki Bulanık"
+
+#~ msgid "Next _Fuzzy"
+#~ msgstr "Sonraki _Bulanık"
+
+#~ msgid "Previous Untranslated or Fuzz_y"
+#~ msgstr "Önceki Çevirilmemiş veya B_ulanık"
+
+#~ msgid "Next Untranslated _or Fuzzy"
+#~ msgstr "Sonraki Çe_virilmemiş veya Bulanık"
+
+#~ msgid "_Toggle Fuzziness"
+#~ msgstr "Bulanıklığı _Değiştir"
+
+#~ msgid "_Show stats"
+#~ msgstr "İstatistikleri _göster"
+
+#~ msgid "Update _Headers Upon Save"
+#~ msgstr "Kayıt Sonrasında _Başlıkları Güncelle"
+
+#~ msgid "Translation statistics"
+#~ msgstr "Çeviri istatistikleri"
+
+#, fuzzy
+#~ msgid "Choose a color for translated strings"
+#~ msgstr "Çevrilmiş dizeler için bir renk seçin"
+
+#, fuzzy
+#~ msgid "Choose a color for fuzzily translated strings"
+#~ msgstr "Düzgünce çevrilmiş dizeler için bir renk seçin"
+
+#, fuzzy
+#~ msgid "Choose a color for untranslated strings"
+#~ msgstr "Çevrilmemiş dizeler için bir renk seçin"
+
+#~ msgid "Translated:"
+#~ msgstr "Çevriri:"
+
+#~ msgid "Fuzzy:"
+#~ msgstr "Bulanık:"
+
+#~ msgid "Untranslated:"
+#~ msgstr "Çevrilmemiş:"
+
+#~ msgid "Toggle Check While Typing"
+#~ msgstr "Yazarken Kontrol Et"
+
+#~ msgid "Check spelling while typing"
+#~ msgstr "Yazma sırasında imla denetimi yap"
+
+#, c-format
+#~ msgid "%s: %u Project"
+#~ msgid_plural "%s: %u Projects"
+#~ msgstr[0] "%s: %u Proje"
+#~ msgstr[1] "%s: %u Proje"
 
 #~ msgid "GeanyLaTeX"
 #~ msgstr "GeanyLaTeX"

--- a/po/uk.po
+++ b/po/uk.po
@@ -6,8 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Geany-Plugins 1.38\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-29 19:41+0200\n"
+"Report-Msgid-Bugs-To: https://github.com/geany/geany/issues\n"
+"POT-Creation-Date: 2022-06-28 07:39+0200\n"
 "PO-Revision-Date: 2020-05-01 16:20+1000\n"
 "Last-Translator: Artur Shepilko <nomadbyte@gmail.com>\n"
 "Language-Team: Ukrainian <geany-i18n@uvena.de>\n"
@@ -15,34 +15,34 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
 #: ../addons/src/ao_bookmarklist.c:190
 msgid "(Empty Line)"
 msgstr "(Пустий рядок)"
 
-#: ../addons/src/ao_bookmarklist.c:315
+#: ../addons/src/ao_bookmarklist.c:331
 msgid "_Remove Bookmark"
 msgstr "_Скасувати закладку"
 
 #. Translators: Number is meant at this point.
-#: ../addons/src/ao_bookmarklist.c:342
+#: ../addons/src/ao_bookmarklist.c:358
 msgid "No."
 msgstr "Рядок"
 
-#: ../addons/src/ao_bookmarklist.c:350 ../devhelp/src/dhp-object.c:494
+#: ../addons/src/ao_bookmarklist.c:366 ../devhelp/src/dhp-object.c:494
 #: ../devhelp/devhelp/dh-window.c:1142
 msgid "Contents"
 msgstr "Зміст"
 
-#: ../addons/src/ao_bookmarklist.c:383 ../treebrowser/src/treebrowser.c:666
+#: ../addons/src/ao_bookmarklist.c:399 ../treebrowser/src/treebrowser.c:666
 #: ../webhelper/src/gwh-plugin.c:328
 msgid "Bookmarks"
 msgstr "Закладки"
 
 #. complete update
-#: ../addons/src/ao_tasks.c:373 ../geanyvc/src/geanyvc.c:2679
+#: ../addons/src/ao_tasks.c:373 ../geanyvc/src/geanyvc.c:2730
 msgid "_Update"
 msgstr "_Оновити"
 
@@ -162,10 +162,10 @@ msgstr "Копіювати шлях до поточного документа �
 #: ../addons/src/addons.c:364 ../autoclose/src/autoclose.c:920
 #: ../codenav/src/codenavigation.c:281 ../latex/src/latex.c:208
 #: ../latex/src/latex.c:293 ../geanyprj/src/geanyprj.c:176
-#: ../geanyvc/src/geanyvc.c:2079 ../geniuspaste/src/geniuspaste.c:336
+#: ../geanyvc/src/geanyvc.c:2130 ../geniuspaste/src/geniuspaste.c:336
 #: ../lineoperations/src/lo_prefs.c:58 ../sendmail/src/sendmail.c:128
 #: ../sendmail/src/sendmail.c:293 ../spellcheck/src/scplugin.c:124
-#: ../treebrowser/src/treebrowser.c:2102
+#: ../treebrowser/src/treebrowser.c:2106
 #: ../updatechecker/src/updatechecker.c:262
 msgid "Plugin configuration directory could not be created."
 msgstr "Не вдалось створити каталог конфігурації плаґіну."
@@ -512,8 +512,8 @@ msgid ""
 "Tip: to completely remove indented block just Shift+BackSpace first \"{\" or "
 "last \"}\"."
 msgstr ""
-"Видалення обох символів огородження одним натисканням комбінації Shift"
-"+Backspace.\n"
+"Видалення обох символів огородження одним натисканням комбінації "
+"Shift+Backspace.\n"
 "Зручно для автоматичного видалення дужок та відступів блока."
 
 #: ../autoclose/src/autoclose.c:1147
@@ -733,7 +733,7 @@ msgstr ""
 msgid "Error loading file"
 msgstr "Не вдалось завантажити програму"
 
-#. setting asyncronous mode
+#. setting asynchronous mode
 #. setting null-stop array printing
 #. enable pretty printing
 #: ../debugger/src/dbm_gdb.c:789 ../debugger/src/dbm_gdb.c:792
@@ -1127,7 +1127,7 @@ msgid "A developers' help browser for GNOME"
 msgstr "Браузер документації програмування для GNOME"
 
 #. Create the current file Submenu
-#: ../devhelp/devhelp/dh-window.c:759 ../geanyvc/src/geanyvc.c:2660
+#: ../devhelp/devhelp/dh-window.c:759 ../geanyvc/src/geanyvc.c:2711
 msgid "_File"
 msgstr "_Файл"
 
@@ -1161,11 +1161,11 @@ msgstr "Відкрити нову в_кладку"
 msgid "_Print…"
 msgstr "Д_рукувати..."
 
-#: ../devhelp/devhelp/dh-window.c:782 ../devhelp/devhelp/eggfindbar.c:342
+#: ../devhelp/devhelp/dh-window.c:782
 msgid "Find Next"
 msgstr "Знайти наступне"
 
-#: ../devhelp/devhelp/dh-window.c:784 ../devhelp/devhelp/eggfindbar.c:329
+#: ../devhelp/devhelp/dh-window.c:784
 msgid "Find Previous"
 msgstr "Знайти попереднє"
 
@@ -1354,7 +1354,7 @@ msgstr ""
 "ваших зусиль для розвитку цього плаґіну, будь ласка, зв'яжіться з командою "
 "розробників Geany."
 
-#: ../geanydoc/src/geanydoc.c:159 ../geanyvc/src/geanyvc.c:442
+#: ../geanydoc/src/geanydoc.c:159 ../geanyvc/src/geanyvc.c:448
 msgid "Could not parse the output of command"
 msgstr "Не вдалось проаналізувати вихідні дані команди"
 
@@ -3049,14 +3049,14 @@ msgid ""
 "not enough arguments for command \"%s\".\n"
 msgstr ""
 
-#: ../geanylua/glspi_sci.c:637 ../geanylua/glspi_app.c:406
+#: ../geanylua/glspi_sci.c:729 ../geanylua/glspi_app.c:406
 #, c-format
 msgid ""
 "Error in module \"%s\" at function %s():\n"
 "unknown command \"%s\" given for argument #1.\n"
 msgstr ""
 
-#: ../geanylua/glspi_sci.c:781
+#: ../geanylua/glspi_sci.c:924
 #, c-format
 msgid ""
 "Error in module \"%s\" at function %s():\n"
@@ -3064,7 +3064,7 @@ msgid ""
 " unknown flag \"%s\" for element #%d\n"
 msgstr ""
 
-#: ../geanylua/glspi_sci.c:785
+#: ../geanylua/glspi_sci.c:928
 msgid "<too large to display>"
 msgstr "<занадто великий для показу>"
 
@@ -3654,8 +3654,9 @@ msgid ""
 "Manager under the Tools menu, selecting this plugin, and clicking "
 "Preferences. "
 msgstr ""
-"Ви можете змінити настройки за замовчуванням, вибравши \"Диспетчер плаґінів"
-"\" у меню \"Інструменти\", і відкривши \"Параметри\" для цього плаґіна. "
+"Ви можете змінити настройки за замовчуванням, вибравши \"Диспетчер "
+"плаґінів\" у меню \"Інструменти\", і відкривши \"Параметри\" для цього "
+"плаґіна. "
 
 #: ../geanymacro/src/geanymacro.c:883
 msgid "You can change:\n"
@@ -3836,7 +3837,7 @@ msgid "New _Below"
 msgstr "Д_одати нижче"
 
 #: ../geanymacro/src/geanymacro.c:1824 ../geanymacro/src/geanymacro.c:2120
-#: ../treebrowser/src/treebrowser.c:1338 ../treebrowser/src/treebrowser.c:1340
+#: ../treebrowser/src/treebrowser.c:1342 ../treebrowser/src/treebrowser.c:1344
 msgid "_Delete"
 msgstr "_Видалити"
 
@@ -4110,12 +4111,12 @@ msgstr ""
 "\n"
 "Дозволяє використовувати до 10 пронумерованих закладок. Щоб встановити "
 "пронумеровану закладку, натисніть комбінацію клавіш Ctrl+Shift+номер [0-9]. "
-"Ви побачите маркер поруч із номером рядка. Повторне натискання Ctrl+Shift"
-"+номер на рядку, який уже має цей номер закладки, видалить її. Інакше, "
-"закладку буде переміщено на цей рядок або створено її наново. Рядок може "
-"мати більше ніж одну закладку, але показано буде лише останню встановлену "
-"закладку. Щоб перейти до встановленої закладки, натисніть відповідно Ctrl"
-"+номер [0-9] закладки."
+"Ви побачите маркер поруч із номером рядка. Повторне натискання "
+"Ctrl+Shift+номер на рядку, який уже має цей номер закладки, видалить її. "
+"Інакше, закладку буде переміщено на цей рядок або створено її наново. Рядок "
+"може мати більше ніж одну закладку, але показано буде лише останню "
+"встановлену закладку. Щоб перейти до встановленої закладки, натисніть "
+"відповідно Ctrl+номер [0-9] закладки."
 
 #: ../geanynumberedbookmarks/src/geanynumberedbookmarks.c:1408
 msgid "Unable to apply markers as all being used."
@@ -4252,8 +4253,8 @@ msgstr ""
 msgid "a key with fingerprint"
 msgstr "ключ із відбитком"
 
-#: ../geanypg/src/verify_aux.c:66 ../spellcheck/src/gui.c:610
-#: ../spellcheck/src/gui.c:621
+#: ../geanypg/src/verify_aux.c:66 ../spellcheck/src/gui.c:607
+#: ../spellcheck/src/gui.c:618
 msgid "unknown"
 msgstr "невідома"
 
@@ -4570,49 +4571,49 @@ msgstr ""
 "ваших зусиль для розвитку цього плаґіну, будь ласка, зв'яжіться з командою "
 "розробників Geany."
 
-#: ../geanyvc/src/geanyvc.c:501
+#: ../geanyvc/src/geanyvc.c:507
 #, c-format
 msgid "geanyvc: s_spawn_sync error: %s"
 msgstr "geanyvc: помилка s_spawn_sync: %s"
 
-#: ../geanyvc/src/geanyvc.c:587
+#: ../geanyvc/src/geanyvc.c:593
 #, c-format
 msgid "File %s: action %s executed via %s."
 msgstr "Файл %s: команда %s виконана програмою %s."
 
-#: ../geanyvc/src/geanyvc.c:646 ../geanyvc/src/geanyvc.c:657
-#, c-format
-msgid "geanyvc: vcdiff_file_activated: Unable to rename '%s' to '%s'"
+#: ../geanyvc/src/geanyvc.c:633 ../geanyvc/src/geanyvc.c:643
+#, fuzzy, c-format
+msgid "geanyvc: diff_external: Unable to rename '%s' to '%s'"
 msgstr "geanyvc: vcdiff_file_activate: Не вдалось перейменувати ' %s' у ' %s'"
 
-#: ../geanyvc/src/geanyvc.c:683 ../geanyvc/src/geanyvc.c:733
+#: ../geanyvc/src/geanyvc.c:698 ../geanyvc/src/geanyvc.c:784
 msgid "No changes were made."
 msgstr "Без змін."
 
-#: ../geanyvc/src/geanyvc.c:760
+#: ../geanyvc/src/geanyvc.c:811
 msgid "No history available"
 msgstr "Історія не доступна"
 
-#: ../geanyvc/src/geanyvc.c:953 ../geanyvc/src/geanyvc.c:961
+#: ../geanyvc/src/geanyvc.c:1004 ../geanyvc/src/geanyvc.c:1012
 #, c-format
 msgid "Do you really want to revert: %s?"
 msgstr "Ви дійсно хочете скасувати зміни у файлі: %s?"
 
-#: ../geanyvc/src/geanyvc.c:969
+#: ../geanyvc/src/geanyvc.c:1020
 #, c-format
 msgid "Do you really want to add: %s?"
 msgstr "Ви дійсно хочете додати у репозиторій файл: %s?"
 
-#: ../geanyvc/src/geanyvc.c:976
+#: ../geanyvc/src/geanyvc.c:1027
 #, c-format
 msgid "Do you really want to remove: %s?"
 msgstr "Ви дійсно хочете видалити із репозиторію файл: %s?"
 
-#: ../geanyvc/src/geanyvc.c:999
+#: ../geanyvc/src/geanyvc.c:1050
 msgid "Do you really want to update?"
 msgstr "Ви дійсно хочете оновити до найновішої версії?"
 
-#: ../geanyvc/src/geanyvc.c:1126
+#: ../geanyvc/src/geanyvc.c:1177
 msgid ""
 "The resulting differences cannot be displayed because the changes are too "
 "big to display here and would slow down the UI significantly.\n"
@@ -4627,48 +4628,48 @@ msgstr ""
 "список відмінностей безпосередньо з меню Контроль версій (Базовий каталог -> "
 "Порівняти)."
 
-#: ../geanyvc/src/geanyvc.c:1280
+#: ../geanyvc/src/geanyvc.c:1331
 msgid "Commit Y/N"
 msgstr "Фіксувати"
 
-#: ../geanyvc/src/geanyvc.c:1290
+#: ../geanyvc/src/geanyvc.c:1341
 msgid "Status"
 msgstr "Статус"
 
-#: ../geanyvc/src/geanyvc.c:1297
+#: ../geanyvc/src/geanyvc.c:1348
 msgid "Path"
 msgstr "Файл"
 
-#: ../geanyvc/src/geanyvc.c:1414
+#: ../geanyvc/src/geanyvc.c:1465
 msgid "Choose a previous commit message"
 msgstr "Нещодавні коментарі"
 
-#: ../geanyvc/src/geanyvc.c:1476
+#: ../geanyvc/src/geanyvc.c:1527
 #, c-format
 msgid "Line: %d Column: %d"
 msgstr "рядок: %d стовпець: %d"
 
-#: ../geanyvc/src/geanyvc.c:1523
+#: ../geanyvc/src/geanyvc.c:1574
 msgid "Commit"
 msgstr "Фіксувати зміни"
 
-#: ../geanyvc/src/geanyvc.c:1564
+#: ../geanyvc/src/geanyvc.c:1615
 msgid "_De-/select all files"
 msgstr "Усі файли"
 
-#: ../geanyvc/src/geanyvc.c:1608
+#: ../geanyvc/src/geanyvc.c:1659
 msgid "<b>Commit message:</b>"
 msgstr "<b>Коментар:</b>"
 
-#: ../geanyvc/src/geanyvc.c:1632
+#: ../geanyvc/src/geanyvc.c:1683
 msgid "C_ommit"
 msgstr "_Фіксувати зміни"
 
-#: ../geanyvc/src/geanyvc.c:1740
+#: ../geanyvc/src/geanyvc.c:1791
 msgid "Nothing to commit."
 msgstr "Без змін."
 
-#: ../geanyvc/src/geanyvc.c:1788
+#: ../geanyvc/src/geanyvc.c:1839
 #, c-format
 msgid ""
 "Error initializing GeanyVC spell checking: %s. Check your configuration."
@@ -4676,26 +4677,26 @@ msgstr ""
 "Помилка ініціалізації системи перевірки правопису:%s. Перевірте настройки "
 "системи."
 
-#: ../geanyvc/src/geanyvc.c:1823
+#: ../geanyvc/src/geanyvc.c:1874
 #, c-format
 msgid "Commit failed (status: %d, error: %s)."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1824
+#: ../geanyvc/src/geanyvc.c:1875
 #, fuzzy
 msgid "Commit failed; see status in the Message window."
 msgstr "Вкладка зі списком завдань у вікні повідомлень"
 
-#: ../geanyvc/src/geanyvc.c:1829
+#: ../geanyvc/src/geanyvc.c:1880
 #, fuzzy
 msgid "Changes committed."
 msgstr "Без змін."
 
-#: ../geanyvc/src/geanyvc.c:2151
+#: ../geanyvc/src/geanyvc.c:2202
 msgid "Set Changed-flag for document tabs created by the plugin"
 msgstr "Позначати документи у вкладках, створених плаґіном, як змінені"
 
-#: ../geanyvc/src/geanyvc.c:2154
+#: ../geanyvc/src/geanyvc.c:2205
 msgid ""
 "If this option is activated, every new by the VC-plugin created document tab "
 "will be marked as changed. Even this option is useful in some cases, it "
@@ -4706,43 +4707,43 @@ msgstr ""
 "корисною, але це може спричинити надмірну кількість запитів на збереження "
 "файлу."
 
-#: ../geanyvc/src/geanyvc.c:2162
+#: ../geanyvc/src/geanyvc.c:2213
 msgid "Confirm adding new files to a VCS"
 msgstr "Підтверджувати додавання файлу у репозиторій"
 
-#: ../geanyvc/src/geanyvc.c:2165
+#: ../geanyvc/src/geanyvc.c:2216
 msgid "Shows a confirmation dialog on adding a new (created) file to VCS."
 msgstr "Показувати діалог підтвердження при додаванні файлу у репозиторій."
 
-#: ../geanyvc/src/geanyvc.c:2171
+#: ../geanyvc/src/geanyvc.c:2222
 msgid "Maximize commit dialog"
 msgstr "Розгортати діалог фіксації змін"
 
-#: ../geanyvc/src/geanyvc.c:2172
+#: ../geanyvc/src/geanyvc.c:2223
 msgid "Show commit dialog maximize."
 msgstr "Максимізувати діалогове вікно фіксації змін."
 
-#: ../geanyvc/src/geanyvc.c:2178
+#: ../geanyvc/src/geanyvc.c:2229
 msgid "Use external diff viewer"
 msgstr "Використовувати зовнішню програму порівняння файлів"
 
-#: ../geanyvc/src/geanyvc.c:2180
+#: ../geanyvc/src/geanyvc.c:2231
 msgid "Use external diff viewer for file diff."
 msgstr "Використовувати зовнішню програму перегляду змін у файлі."
 
-#: ../geanyvc/src/geanyvc.c:2186
+#: ../geanyvc/src/geanyvc.c:2237
 msgid "Show VC entries at editor menu"
 msgstr "Показувати меню \"Зміни\" у контекстному меню редактора"
 
-#: ../geanyvc/src/geanyvc.c:2188
+#: ../geanyvc/src/geanyvc.c:2239
 msgid "Show entries for VC functions inside editor menu"
 msgstr "Показувати команди меню \"Зміни\" у контекстному меню редактора."
 
-#: ../geanyvc/src/geanyvc.c:2193
+#: ../geanyvc/src/geanyvc.c:2244
 msgid "Attach menu to menubar"
 msgstr "Приєднати меню до головної панелі"
 
-#: ../geanyvc/src/geanyvc.c:2195
+#: ../geanyvc/src/geanyvc.c:2246
 msgid ""
 "Whether menu for this plugin are getting placed either inside tools menu or "
 "directly inside Geany's menubar. Will take in account after next start of "
@@ -4752,68 +4753,68 @@ msgstr ""
 "головній панелі меню Geany. Набуває чинності після перезапуску плаґіна "
 "GeanyVC."
 
-#: ../geanyvc/src/geanyvc.c:2203
+#: ../geanyvc/src/geanyvc.c:2254
 msgid "Enable CVS"
 msgstr "CVS"
 
-#: ../geanyvc/src/geanyvc.c:2208
+#: ../geanyvc/src/geanyvc.c:2259
 msgid "Enable GIT"
 msgstr "Git"
 
-#: ../geanyvc/src/geanyvc.c:2213
+#: ../geanyvc/src/geanyvc.c:2264
 msgid "Enable Fossil"
 msgstr "Fossil"
 
-#: ../geanyvc/src/geanyvc.c:2218
+#: ../geanyvc/src/geanyvc.c:2269
 msgid "Enable SVN"
 msgstr "Subversion (SVN)"
 
-#: ../geanyvc/src/geanyvc.c:2223
+#: ../geanyvc/src/geanyvc.c:2274
 msgid "Enable SVK"
 msgstr "SVK"
 
-#: ../geanyvc/src/geanyvc.c:2228
+#: ../geanyvc/src/geanyvc.c:2279
 msgid "Enable Bazaar"
 msgstr "Bazaar"
 
-#: ../geanyvc/src/geanyvc.c:2233
+#: ../geanyvc/src/geanyvc.c:2284
 msgid "Enable Mercurial"
 msgstr "Mercurial"
 
-#: ../geanyvc/src/geanyvc.c:2239
+#: ../geanyvc/src/geanyvc.c:2290
 msgid "Spellcheck language"
 msgstr "Мова для перевірки правопису"
 
 #. Diff of current file
 #. Diff of the current dir
 #. Complete diff of base directory
-#: ../geanyvc/src/geanyvc.c:2368 ../geanyvc/src/geanyvc.c:2463
-#: ../geanyvc/src/geanyvc.c:2503
+#: ../geanyvc/src/geanyvc.c:2419 ../geanyvc/src/geanyvc.c:2514
+#: ../geanyvc/src/geanyvc.c:2554
 msgid "_Diff"
 msgstr "_Порівняти"
 
-#: ../geanyvc/src/geanyvc.c:2371
+#: ../geanyvc/src/geanyvc.c:2422
 msgid "Make a diff from the current active file"
 msgstr "Показати відмінності поточного файлу від оригіналу."
 
 #. Revert current file
 #. Revert current dir
 #. Revert everything
-#: ../geanyvc/src/geanyvc.c:2376 ../geanyvc/src/geanyvc.c:2472
-#: ../geanyvc/src/geanyvc.c:2511
+#: ../geanyvc/src/geanyvc.c:2427 ../geanyvc/src/geanyvc.c:2523
+#: ../geanyvc/src/geanyvc.c:2562
 msgid "_Revert"
 msgstr "_Скасувати зміни"
 
-#: ../geanyvc/src/geanyvc.c:2379
+#: ../geanyvc/src/geanyvc.c:2430
 msgid "Restore pristine working copy file (undo local edits)."
 msgstr "Відновити файл з робочої копії (скасувати локальні зміни)."
 
 #. Blame for current file
-#: ../geanyvc/src/geanyvc.c:2388
+#: ../geanyvc/src/geanyvc.c:2439
 msgid "_Blame"
 msgstr "_Анотація"
 
-#: ../geanyvc/src/geanyvc.c:2391
+#: ../geanyvc/src/geanyvc.c:2442
 msgid "Shows the changes made at one file per revision and author."
 msgstr ""
 "Показати ім'я автора та номер версії останньої зміни для кожного рядка файлу."
@@ -4821,147 +4822,147 @@ msgstr ""
 #. History/log of current file
 #. History/log of the current dir
 #. Complete History/Log of base directory
-#: ../geanyvc/src/geanyvc.c:2398 ../geanyvc/src/geanyvc.c:2482
-#: ../geanyvc/src/geanyvc.c:2523
+#: ../geanyvc/src/geanyvc.c:2449 ../geanyvc/src/geanyvc.c:2533
+#: ../geanyvc/src/geanyvc.c:2574
 msgid "_History (log)"
 msgstr "_Історія"
 
-#: ../geanyvc/src/geanyvc.c:2401
+#: ../geanyvc/src/geanyvc.c:2452
 msgid "Shows the log of the current file"
 msgstr "Показати журнал змін для поточного файлу."
 
 #. base version of the current file
-#: ../geanyvc/src/geanyvc.c:2406
+#: ../geanyvc/src/geanyvc.c:2457
 msgid "_Original"
 msgstr "_Оригінал"
 
-#: ../geanyvc/src/geanyvc.c:2409
+#: ../geanyvc/src/geanyvc.c:2460
 msgid "Shows the original of the current file"
 msgstr "Показати оригінальний файл з робочої копії."
 
 #. add current file
-#: ../geanyvc/src/geanyvc.c:2417
+#: ../geanyvc/src/geanyvc.c:2468
 msgid "_Add to Version Control"
 msgstr "_Додати у репозиторій"
 
-#: ../geanyvc/src/geanyvc.c:2419
+#: ../geanyvc/src/geanyvc.c:2470
 msgid "Add file to repository."
 msgstr "Додати файл у репозиторій."
 
 #. remove current file
-#: ../geanyvc/src/geanyvc.c:2425
+#: ../geanyvc/src/geanyvc.c:2476
 msgid "_Remove from Version Control"
 msgstr "_Видалити із репозиторію"
 
-#: ../geanyvc/src/geanyvc.c:2427
+#: ../geanyvc/src/geanyvc.c:2478
 msgid "Remove file from repository."
 msgstr "Видалити файл із репозиторію."
 
-#: ../geanyvc/src/geanyvc.c:2460
+#: ../geanyvc/src/geanyvc.c:2511
 msgid "_Directory"
 msgstr "_Каталог"
 
-#: ../geanyvc/src/geanyvc.c:2466
+#: ../geanyvc/src/geanyvc.c:2517
 msgid "Make a diff from the directory of the current active file"
 msgstr "Показати відмінності для каталогу поточного файлу."
 
-#: ../geanyvc/src/geanyvc.c:2475
+#: ../geanyvc/src/geanyvc.c:2526
 msgid "Restore original files in the current folder (undo local edits)."
 msgstr ""
 "Відновити оригінали усіх файлів з каталогу поточного файлу робочої копії "
 "(скасувати локальні зміни)."
 
-#: ../geanyvc/src/geanyvc.c:2485
+#: ../geanyvc/src/geanyvc.c:2536
 msgid "Shows the log of the current directory"
 msgstr "Показати журнал змін для базового каталогу репозиторію."
 
-#: ../geanyvc/src/geanyvc.c:2499
+#: ../geanyvc/src/geanyvc.c:2550
 msgid "_Base Directory"
 msgstr "_Базовий каталог"
 
-#: ../geanyvc/src/geanyvc.c:2505
+#: ../geanyvc/src/geanyvc.c:2556
 msgid "Make a diff from the top VC directory"
 msgstr "Показати відмінності для базового каталогу репозиторію."
 
-#: ../geanyvc/src/geanyvc.c:2513
+#: ../geanyvc/src/geanyvc.c:2564
 msgid "Revert any local edits."
 msgstr "Скасувати усі локальні зміни."
 
-#: ../geanyvc/src/geanyvc.c:2526
+#: ../geanyvc/src/geanyvc.c:2577
 msgid "Shows the log of the top VC directory"
 msgstr "Показати журнал змін для каталогу поточного файлу."
 
-#: ../geanyvc/src/geanyvc.c:2543
+#: ../geanyvc/src/geanyvc.c:2594
 msgid "_VC file Actions"
 msgstr "З_міни"
 
-#: ../geanyvc/src/geanyvc.c:2552
+#: ../geanyvc/src/geanyvc.c:2603
 msgid "VC _Commit..."
 msgstr "Фіксувати _зміни..."
 
-#: ../geanyvc/src/geanyvc.c:2596
+#: ../geanyvc/src/geanyvc.c:2647
 msgid "Show diff of file"
 msgstr "Показати зміни для файлу"
 
-#: ../geanyvc/src/geanyvc.c:2598
+#: ../geanyvc/src/geanyvc.c:2649
 msgid "Show diff of directory"
 msgstr "Показати зміни для каталогу"
 
-#: ../geanyvc/src/geanyvc.c:2600
+#: ../geanyvc/src/geanyvc.c:2651
 msgid "Show diff of basedir"
 msgstr "Показати зміни для базового каталогу"
 
-#: ../geanyvc/src/geanyvc.c:2603
+#: ../geanyvc/src/geanyvc.c:2654
 msgid "Commit changes"
 msgstr "Фіксувати зміни"
 
-#: ../geanyvc/src/geanyvc.c:2605
+#: ../geanyvc/src/geanyvc.c:2656
 msgid "Show status"
 msgstr "Показати статус"
 
-#: ../geanyvc/src/geanyvc.c:2607
+#: ../geanyvc/src/geanyvc.c:2658
 msgid "Revert single file"
 msgstr "Скасувати зміни для файлу"
 
-#: ../geanyvc/src/geanyvc.c:2609
+#: ../geanyvc/src/geanyvc.c:2660
 msgid "Revert directory"
 msgstr "Скасувати зміни для каталогу"
 
-#: ../geanyvc/src/geanyvc.c:2611
+#: ../geanyvc/src/geanyvc.c:2662
 msgid "Revert base directory"
 msgstr "Скасувати зміни для базового каталогу"
 
-#: ../geanyvc/src/geanyvc.c:2613
+#: ../geanyvc/src/geanyvc.c:2664
 msgid "Update file"
 msgstr "Оновити"
 
-#: ../geanyvc/src/geanyvc.c:2643
+#: ../geanyvc/src/geanyvc.c:2694
 msgid "_VC"
 msgstr "З_міни"
 
-#: ../geanyvc/src/geanyvc.c:2650
+#: ../geanyvc/src/geanyvc.c:2701
 msgid "_Version Control"
 msgstr "З_міни"
 
 #. Status of basedir
-#: ../geanyvc/src/geanyvc.c:2672
+#: ../geanyvc/src/geanyvc.c:2723
 msgid "_Status"
 msgstr "_Статус"
 
-#: ../geanyvc/src/geanyvc.c:2674
+#: ../geanyvc/src/geanyvc.c:2725
 msgid "Show status."
 msgstr "Показати статус."
 
-#: ../geanyvc/src/geanyvc.c:2681
+#: ../geanyvc/src/geanyvc.c:2732
 msgid "Update from remote repository."
 msgstr "Оновити з віддаленого репозиторію."
 
 #. Commit all changes
-#: ../geanyvc/src/geanyvc.c:2686
+#: ../geanyvc/src/geanyvc.c:2737
 msgid "_Commit..."
 msgstr "Фіксува_ти..."
 
-#: ../geanyvc/src/geanyvc.c:2688
+#: ../geanyvc/src/geanyvc.c:2739
 msgid "Commit changes."
 msgstr "Фіксувати локальні зміни."
 
@@ -5086,35 +5087,6 @@ msgstr "Показувати сторінку публікації у новій
 #: ../geniuspaste/src/geniuspaste.c:959
 msgid "_Paste it!"
 msgstr "_Опублікувати на pastebin"
-
-#: ../git-changebar/data/prefs.ui.h:1
-msgid "_Monitor repository for changes"
-msgstr "_Стежити за змінами у репозиторію"
-
-#: ../git-changebar/data/prefs.ui.h:2
-msgid ""
-"Whether to automatically update the diff in order to maintain it up to date "
-"when the underlying Git repository changes.  This should generally be "
-"enabled for optimal user experience."
-msgstr ""
-"Автоматично оновлювати показані відмінності у разі нових змін у репозиторію "
-"Git. Для оптимальної роботи, залиште цю опцію увімкненою."
-
-#: ../git-changebar/data/prefs.ui.h:3
-msgid "_Added lines:"
-msgstr "_Додані рядки:"
-
-#: ../git-changebar/data/prefs.ui.h:4
-msgid "_Changed lines:"
-msgstr "_Змінені рядки:"
-
-#: ../git-changebar/data/prefs.ui.h:5
-msgid "_Removed lines:"
-msgstr "_Видалені рядки:"
-
-#: ../git-changebar/data/prefs.ui.h:6
-msgid "Colors"
-msgstr "Колір"
 
 #: ../git-changebar/src/gcb-plugin.c:62
 msgid "Git Change Bar"
@@ -5304,8 +5276,8 @@ msgstr ""
 #: ../lipsum/src/lipsum.c:184 ../sendmail/src/sendmail.c:396
 #, c-format
 msgid ""
-"Your configuration directory has been successfully moved from \"%s\" to \"%s"
-"\"."
+"Your configuration directory has been successfully moved from \"%s\" to "
+"\"%s\"."
 msgstr "Каталог конфігурації успішно переміщено з \"%s\" у \"%s\"."
 
 #: ../lipsum/src/lipsum.c:199
@@ -5470,7 +5442,7 @@ msgstr ""
 msgid "Unable to read value for '%s' key: %s"
 msgstr ""
 
-#: ../multiterm/src/tab-label.vala:62 ../treebrowser/src/treebrowser.c:2132
+#: ../multiterm/src/tab-label.vala:62 ../treebrowser/src/treebrowser.c:2137
 msgid "Terminal"
 msgstr "Термінал"
 
@@ -5508,127 +5480,6 @@ msgstr "рядок: <b>%d</b>, стовпець: <b>%d</b>, позиція: <b>%
 msgid "Show Overview"
 msgstr "Показати панель огляду документа"
 
-#: ../overview/data/prefs.ui.h:1
-msgid ""
-"The amount to zoom the overview sidebar. This should probably negative if "
-"you want the sidebar zoomed out."
-msgstr ""
-"Масштабування панелі огляду. Для зменшеного виду встановіть від’ємне "
-"значення."
-
-#: ../overview/data/prefs.ui.h:2
-msgid "Zoom Level:"
-msgstr "Масштаб:"
-
-#: ../overview/data/prefs.ui.h:3
-msgid "The width of the overview sidebar."
-msgstr "Ширина панелі огляду (пікселі)."
-
-#: ../overview/data/prefs.ui.h:4
-msgid "Width:"
-msgstr "Ширина:"
-
-#: ../overview/data/prefs.ui.h:5
-msgid ""
-"The number of lines to scroll at a time when scrolling the overview sidebar."
-msgstr "Скільки рядків документа прокручувати під час прокрутки панелі огляду."
-
-#: ../overview/data/prefs.ui.h:6
-msgid "Scroll Lines:"
-msgstr "Прокручувати рядків:"
-
-#: ../overview/data/prefs.ui.h:7
-msgid "Position on left"
-msgstr "Зліва"
-
-#: ../overview/data/prefs.ui.h:8
-msgid ""
-"Position the overview bar on the left rather than the right (requires Geany "
-"1.25 or greater)."
-msgstr ""
-"Розмістити панель огляду ліворуч, а не праворуч (потребує Geany версії 1.25 "
-"або вище)."
-
-#: ../overview/data/prefs.ui.h:9
-msgid "Hide tooltip"
-msgstr "Приховати підказку"
-
-#: ../overview/data/prefs.ui.h:10
-msgid ""
-"Hide the tooltip that is displayed when mousing over the overview that shows "
-"line, column and position information."
-msgstr ""
-"Приховати підказку, яка з'являється при наведенні вказівника миші на огляд. "
-"Підказка містить інформацію про рядок, стовпець та позицію у документі."
-
-#: ../overview/data/prefs.ui.h:11
-msgid "Hide editor scrollbar"
-msgstr "Приховати смугу прокрутки"
-
-#: ../overview/data/prefs.ui.h:12
-msgid ""
-"Whether to hide Geany's regular editor scrollbar while the overview bar is "
-"visible."
-msgstr ""
-"Приховувати звичайну смугу прокрутки редактора Geany, поки видно панель "
-"огляду."
-
-#: ../overview/data/prefs.ui.h:13
-msgid "Disable overlay"
-msgstr "Не показувати рамку перегляду"
-
-#: ../overview/data/prefs.ui.h:14
-msgid ""
-"Turn off drawing overlay, which shows the region of the main editor view "
-"that is currently in view, ontop of the overview bar."
-msgstr ""
-"Вимкнути додання рамки поверх панелі огляду щоби позначити поточну область "
-"перегляду."
-
-#: ../overview/data/prefs.ui.h:15 ../scope/data/scope.glade.h:130
-#: ../scope/data/scope_gtk3.glade.h:130
-msgid "Options"
-msgstr "Параметри"
-
-#: ../overview/data/prefs.ui.h:16
-msgid ""
-"The color and opacity of the overlay drawn ontop of the overlay sidebar."
-msgstr "Колір і прозорість рамки поточної області перегляду."
-
-#: ../overview/data/prefs.ui.h:17
-msgid "Color:"
-msgstr "Колір:"
-
-#: ../overview/data/prefs.ui.h:18
-msgid ""
-"The color and opacity of the border drawn around the revealed area in the "
-"overview sidebar. Set to the same as Overlay Color to disable."
-msgstr ""
-"Колір і прозорість контуру навколо поточної області перегляду на бічній "
-"панелі огляду. Щоби вимкнути, встановіть той самий колір, що й для рамки "
-"перегляду."
-
-#: ../overview/data/prefs.ui.h:19
-msgid "Outline Color:"
-msgstr "Колір контуру:"
-
-#: ../overview/data/prefs.ui.h:20
-msgid "Draw over visible area"
-msgstr "Затіняти видиму область"
-
-#: ../overview/data/prefs.ui.h:21
-msgid ""
-"When checked it will draw the overlay ontop of the area that is visible in "
-"the main editor view, when unchecked, it will do the opposite and draw the "
-"overlay everywhere but the visible area, \"revealing\" the visible part."
-msgstr ""
-"Затіняти поточну область перегляду. Інакше, накладена рамка буде затінювати "
-"панель скрізь, крім видимої області, позначаючи таким чином видиму область."
-
-#: ../overview/data/prefs.ui.h:22
-msgid "Overlay"
-msgstr "Затінення"
-
 #: ../pairtaghighlighter/src/pair_tag_highlighter.c:43
 msgid "Pair Tag Highlighter"
 msgstr "Позначення XML-елемента"
@@ -5652,148 +5503,6 @@ msgstr "Перейти до парного тегу"
 #: ../pairtaghighlighter/src/pair_tag_highlighter.c:504
 msgid "Select To Matching Tag"
 msgstr "Виділити елемент"
-
-#: ../pohelper/data/menus.ui.h:1
-msgid "_Translation Helper"
-msgstr "Помічник перекладача"
-
-#: ../pohelper/data/menus.ui.h:2
-msgid "_Previous String"
-msgstr "_Попередній сегмент"
-
-#: ../pohelper/data/menus.ui.h:3 ../pohelper/src/gph-plugin.c:1590
-msgid "Go to previous string"
-msgstr "Перейти до попереднього сегмента"
-
-#: ../pohelper/data/menus.ui.h:4
-msgid "_Next String"
-msgstr "_Наступний сегмент"
-
-#: ../pohelper/data/menus.ui.h:5 ../pohelper/src/gph-plugin.c:1593
-msgid "Go to next string"
-msgstr "Перейти до наступного сегмента"
-
-#: ../pohelper/data/menus.ui.h:6
-msgid "Pre_vious Untranslated"
-msgstr "Попередній неперекладений"
-
-#: ../pohelper/data/menus.ui.h:7 ../pohelper/src/gph-plugin.c:1596
-msgid "Go to previous untranslated string"
-msgstr "Перейти до попереднього неперекладеного сегмента"
-
-#: ../pohelper/data/menus.ui.h:8
-msgid "Next _Untranslated"
-msgstr "Наступний _неперекладений"
-
-#: ../pohelper/data/menus.ui.h:9 ../pohelper/src/gph-plugin.c:1599
-msgid "Go to next untranslated string"
-msgstr "Перейти до наступного неперекладеного сегмента"
-
-#: ../pohelper/data/menus.ui.h:10
-msgid "Previous Fu_zzy"
-msgstr "Попередній fu_zzy"
-
-#: ../pohelper/data/menus.ui.h:11 ../pohelper/src/gph-plugin.c:1602
-msgid "Go to previous fuzzily translated string"
-msgstr "Перейти до попереднього нечітко перекладеного сегмента"
-
-#: ../pohelper/data/menus.ui.h:12
-msgid "Next _Fuzzy"
-msgstr "Наступний _fuzzy"
-
-#: ../pohelper/data/menus.ui.h:13 ../pohelper/src/gph-plugin.c:1605
-msgid "Go to next fuzzily translated string"
-msgstr "Перейти до наступного нечітко перекладеного рядка"
-
-#: ../pohelper/data/menus.ui.h:14
-msgid "Previous Untranslated or Fuzz_y"
-msgstr "Попередній неперекладений або fuzz_y"
-
-#: ../pohelper/data/menus.ui.h:15 ../pohelper/src/gph-plugin.c:1608
-msgid "Go to previous untranslated or fuzzy string"
-msgstr ""
-"Перейти до попереднього неперекладеного або нечітко перекладеного сегмента"
-
-#: ../pohelper/data/menus.ui.h:16
-msgid "Next Untranslated _or Fuzzy"
-msgstr "Наступний неперекладений _або fuzzy"
-
-#: ../pohelper/data/menus.ui.h:17 ../pohelper/src/gph-plugin.c:1612
-msgid "Go to next untranslated or fuzzy string"
-msgstr ""
-"Перейти до наступного неперекладеного або нечіткого перекладеного сегмента"
-
-#: ../pohelper/data/menus.ui.h:18 ../pohelper/src/gph-plugin.c:1623
-msgid "Toggle current translation fuzziness"
-msgstr "Встановити маркер нечіткості для поточного сегмента"
-
-#: ../pohelper/data/menus.ui.h:19
-msgid "_Toggle Fuzziness"
-msgstr "_Позначити / Скасувати як fuzzy"
-
-#: ../pohelper/data/menus.ui.h:20
-msgid "Paste _Message as Translation"
-msgstr "Вставити _оригінал як переклад"
-
-#: ../pohelper/data/menus.ui.h:21
-msgid "Paste the original untranslated string to the translation"
-msgstr "Вставити неперекладений текст в текст перекладу сегмента"
-
-#: ../pohelper/data/menus.ui.h:22 ../pohelper/src/gph-plugin.c:1620
-msgid "Reflow the current translation string"
-msgstr "Форматування поточного перекладу сегмента"
-
-#: ../pohelper/data/menus.ui.h:23
-msgid "_Reflow Translation"
-msgstr "_Форматувати переклад"
-
-#: ../pohelper/data/menus.ui.h:24 ../pohelper/src/gph-plugin.c:1626
-msgid "Show statistics of the current document"
-msgstr "Показати статистику поточного документа"
-
-#: ../pohelper/data/menus.ui.h:25
-msgid "_Show stats"
-msgstr "_Статистика"
-
-#: ../pohelper/data/menus.ui.h:26
-msgid ""
-"Whether to update the translation headers (author, revision date, ...) upon "
-"file save"
-msgstr ""
-"Оновлювати заголовки (автор, дата редакції та інше) при збереженні файлу "
-"переклада."
-
-#: ../pohelper/data/menus.ui.h:27
-msgid "Update _Headers Upon Save"
-msgstr "_Оновлювати заголовки"
-
-#: ../pohelper/data/stats.ui.h:1
-msgid "Translation statistics"
-msgstr "Статистика перекладу"
-
-#: ../pohelper/data/stats.ui.h:2
-msgid "Choose a color for translated strings"
-msgstr "Колір для перекладених рядків"
-
-#: ../pohelper/data/stats.ui.h:3
-msgid "Choose a color for fuzzily translated strings"
-msgstr "Колір для fuzzy рядків"
-
-#: ../pohelper/data/stats.ui.h:4
-msgid "Choose a color for untranslated strings"
-msgstr "Колір для неперекладених рядків"
-
-#: ../pohelper/data/stats.ui.h:5
-msgid "Translated:"
-msgstr "Перекладено:"
-
-#: ../pohelper/data/stats.ui.h:6
-msgid "Fuzzy:"
-msgstr ""
-
-#: ../pohelper/data/stats.ui.h:7
-msgid "Untranslated:"
-msgstr "Не перекладено:"
 
 #: ../pohelper/src/gph-plugin.c:40
 msgid "Translation Helper"
@@ -5823,9 +5532,55 @@ msgstr "<b>Не перекладено:</b> %.3g%%"
 msgid "%u (%.3g%%)"
 msgstr ""
 
+#: ../pohelper/src/gph-plugin.c:1590
+msgid "Go to previous string"
+msgstr "Перейти до попереднього сегмента"
+
+#: ../pohelper/src/gph-plugin.c:1593
+msgid "Go to next string"
+msgstr "Перейти до наступного сегмента"
+
+#: ../pohelper/src/gph-plugin.c:1596
+msgid "Go to previous untranslated string"
+msgstr "Перейти до попереднього неперекладеного сегмента"
+
+#: ../pohelper/src/gph-plugin.c:1599
+msgid "Go to next untranslated string"
+msgstr "Перейти до наступного неперекладеного сегмента"
+
+#: ../pohelper/src/gph-plugin.c:1602
+msgid "Go to previous fuzzily translated string"
+msgstr "Перейти до попереднього нечітко перекладеного сегмента"
+
+#: ../pohelper/src/gph-plugin.c:1605
+msgid "Go to next fuzzily translated string"
+msgstr "Перейти до наступного нечітко перекладеного рядка"
+
+#: ../pohelper/src/gph-plugin.c:1608
+msgid "Go to previous untranslated or fuzzy string"
+msgstr ""
+"Перейти до попереднього неперекладеного або нечітко перекладеного сегмента"
+
+#: ../pohelper/src/gph-plugin.c:1612
+msgid "Go to next untranslated or fuzzy string"
+msgstr ""
+"Перейти до наступного неперекладеного або нечіткого перекладеного сегмента"
+
 #: ../pohelper/src/gph-plugin.c:1616
 msgid "Paste original untranslated string to translation"
 msgstr "Вставити неперекладений текст до перекладу"
+
+#: ../pohelper/src/gph-plugin.c:1620
+msgid "Reflow the current translation string"
+msgstr "Форматування поточного перекладу сегмента"
+
+#: ../pohelper/src/gph-plugin.c:1623
+msgid "Toggle current translation fuzziness"
+msgstr "Встановити маркер нечіткості для поточного сегмента"
+
+#: ../pohelper/src/gph-plugin.c:1626
+msgid "Show statistics of the current document"
+msgstr "Показати статистику поточного документа"
 
 #: ../pohelper/src/gph-plugin.c:1833
 #, c-format
@@ -6113,7 +5868,7 @@ msgid "Add"
 msgstr "Додати"
 
 #: ../projectorganizer/src/prjorg-sidebar.c:390
-#: ../treebrowser/src/treebrowser.c:2356
+#: ../treebrowser/src/treebrowser.c:2361
 msgid "New File"
 msgstr "Створити файл"
 
@@ -6723,6 +6478,10 @@ msgstr "Показувати _підказки"
 msgid "<b>Others</b>"
 msgstr "<b>Інше</b>"
 
+#: ../scope/data/scope.glade.h:130 ../scope/data/scope_gtk3.glade.h:130
+msgid "Options"
+msgstr "Параметри"
+
 #: ../scope/data/scope.glade.h:131 ../scope/data/scope_gtk3.glade.h:131
 msgid "_Import"
 msgstr "_Імпортувати"
@@ -7302,12 +7061,14 @@ msgid "Checks the spelling of the current document."
 msgstr "Перевірка правопису у поточному документі."
 
 #: ../spellcheck/src/scplugin.c:225
-msgid "Run Spell Check"
+#, fuzzy
+msgid "Run spell check once"
 msgstr "Перевірити правопис"
 
-#: ../spellcheck/src/scplugin.c:228
-msgid "Toggle Check While Typing"
-msgstr "Перевіряти під час набору тексту"
+#: ../spellcheck/src/scplugin.c:228 ../spellcheck/src/scplugin.c:333
+#, fuzzy
+msgid "Toggle spell check"
+msgstr "Перевірка правопису"
 
 #. initialise the dialog
 #: ../spellcheck/src/scplugin.c:239
@@ -7333,10 +7094,6 @@ msgstr "Показувати неправильне слово і варіант
 #: ../spellcheck/src/scplugin.c:325
 msgid "<b>Interface</b>"
 msgstr "<b>Інтерфейс</b>"
-
-#: ../spellcheck/src/scplugin.c:333
-msgid "Check spelling while typing"
-msgstr "Перевіряти правопис наживо (під час набору тексту)"
 
 #: ../spellcheck/src/scplugin.c:336
 msgid "Check spelling when opening a document"
@@ -7373,32 +7130,32 @@ msgstr ""
 msgid "<b>Behavior</b>"
 msgstr "<b>Робота</b>"
 
-#: ../spellcheck/src/gui.c:76
+#: ../spellcheck/src/gui.c:88
 msgid "Spell checking while typing is now enabled"
 msgstr "Перевірка правопису наживо увімкнена."
 
-#: ../spellcheck/src/gui.c:78
+#: ../spellcheck/src/gui.c:90
 msgid "Spell checking while typing is now disabled"
 msgstr "Перевірка правопису наживо вимкнена."
 
-#: ../spellcheck/src/gui.c:326
+#: ../spellcheck/src/gui.c:323
 msgid "More..."
 msgstr "Додатково"
 
-#: ../spellcheck/src/gui.c:347
+#: ../spellcheck/src/gui.c:344
 msgid "(No Suggestions)"
 msgstr "(варіантів немає)"
 
-#: ../spellcheck/src/gui.c:360
+#: ../spellcheck/src/gui.c:357
 #, c-format
 msgid "Add \"%s\" to Dictionary"
 msgstr "Додати \"%s\" до словника"
 
-#: ../spellcheck/src/gui.c:368
+#: ../spellcheck/src/gui.c:365
 msgid "Ignore All"
 msgstr "Ігнорувати все"
 
-#: ../spellcheck/src/gui.c:441
+#: ../spellcheck/src/gui.c:438
 msgid ""
 "Search term is too long to provide\n"
 "spelling suggestions in the editor menu."
@@ -7406,21 +7163,21 @@ msgstr ""
 "Фрагмент занадто довгий для надання варіантів його написання в контекстному "
 "меню."
 
-#: ../spellcheck/src/gui.c:447
+#: ../spellcheck/src/gui.c:444
 msgid "Perform Spell Check"
 msgstr "Перевірити правопис"
 
-#: ../spellcheck/src/gui.c:609
+#: ../spellcheck/src/gui.c:606
 #, c-format
 msgid "Default (%s)"
 msgstr "За замовчуванням (%s)"
 
-#: ../spellcheck/src/gui.c:620
-#, c-format
-msgid "Toggle spell check while typing (current language: %s)"
+#: ../spellcheck/src/gui.c:617
+#, fuzzy, c-format
+msgid "Toggle spell check (current language: %s)"
 msgstr "Перевіряти правопис наживо (мова: %s)"
 
-#: ../spellcheck/src/gui.c:698
+#: ../spellcheck/src/gui.c:695
 msgid "Spelling Suggestions"
 msgstr "Виправити на"
 
@@ -7519,15 +7276,15 @@ msgstr "(Пусто)"
 msgid "Could not execute configured external command '%s' (%s)."
 msgstr "Не вдалось виконати задану зовнішню команду \"%s\" (%s)."
 
-#: ../treebrowser/src/treebrowser.c:1089
+#: ../treebrowser/src/treebrowser.c:1093
 msgid "NewDirectory"
 msgstr "Новий каталог"
 
-#: ../treebrowser/src/treebrowser.c:1091
+#: ../treebrowser/src/treebrowser.c:1095
 msgid "NewFile"
 msgstr "Новий файл"
 
-#: ../treebrowser/src/treebrowser.c:1096
+#: ../treebrowser/src/treebrowser.c:1100
 #, c-format
 msgid ""
 "Target file '%s' exists.\n"
@@ -7536,115 +7293,115 @@ msgstr ""
 "Файл \"%s\" вже існує.\n"
 "Ви дійсно хочете замінити його пустим файлом?"
 
-#: ../treebrowser/src/treebrowser.c:1142
+#: ../treebrowser/src/treebrowser.c:1146
 #, c-format
 msgid "Do you really want to delete '%s' ?"
 msgstr "Ви дійсно хочете видалити \"%s\"?"
 
-#: ../treebrowser/src/treebrowser.c:1255 ../treebrowser/src/treebrowser.c:1257
+#: ../treebrowser/src/treebrowser.c:1259 ../treebrowser/src/treebrowser.c:1261
 msgid "Go _Up"
 msgstr "Каталог рівнем вище"
 
-#: ../treebrowser/src/treebrowser.c:1263 ../treebrowser/src/treebrowser.c:1265
+#: ../treebrowser/src/treebrowser.c:1267 ../treebrowser/src/treebrowser.c:1269
 msgid "Set _Path From Document"
 msgstr "_Каталог документа"
 
-#: ../treebrowser/src/treebrowser.c:1271 ../treebrowser/src/treebrowser.c:1273
+#: ../treebrowser/src/treebrowser.c:1275 ../treebrowser/src/treebrowser.c:1277
 msgid "_Open Externally"
 msgstr "_Відкрити у зовнішній програмі"
 
-#: ../treebrowser/src/treebrowser.c:1279
+#: ../treebrowser/src/treebrowser.c:1283
 msgid "Open _Terminal"
 msgstr "Відкрити у _терміналі"
 
-#: ../treebrowser/src/treebrowser.c:1284 ../treebrowser/src/treebrowser.c:1286
+#: ../treebrowser/src/treebrowser.c:1288 ../treebrowser/src/treebrowser.c:1290
 msgid "Set as _Root"
 msgstr "Відкрити _каталог"
 
-#: ../treebrowser/src/treebrowser.c:1293 ../treebrowser/src/treebrowser.c:1295
+#: ../treebrowser/src/treebrowser.c:1297 ../treebrowser/src/treebrowser.c:1299
 msgid "Refres_h"
 msgstr "_Оновити"
 
-#: ../treebrowser/src/treebrowser.c:1301 ../treebrowser/src/treebrowser.c:1303
+#: ../treebrowser/src/treebrowser.c:1305 ../treebrowser/src/treebrowser.c:1307
 msgid "_Find in Files"
 msgstr "Знайти у файлах..."
 
-#: ../treebrowser/src/treebrowser.c:1313 ../treebrowser/src/treebrowser.c:1315
+#: ../treebrowser/src/treebrowser.c:1317 ../treebrowser/src/treebrowser.c:1319
 msgid "N_ew Folder"
 msgstr "Створити _каталог..."
 
-#: ../treebrowser/src/treebrowser.c:1321 ../treebrowser/src/treebrowser.c:1323
+#: ../treebrowser/src/treebrowser.c:1325 ../treebrowser/src/treebrowser.c:1327
 msgid "_New File"
 msgstr "Створити _файл..."
 
-#: ../treebrowser/src/treebrowser.c:1329 ../treebrowser/src/treebrowser.c:1331
+#: ../treebrowser/src/treebrowser.c:1333 ../treebrowser/src/treebrowser.c:1335
 msgid "Rena_me"
 msgstr "Пере_йменувати..."
 
-#: ../treebrowser/src/treebrowser.c:1350 ../treebrowser/src/treebrowser.c:1352
+#: ../treebrowser/src/treebrowser.c:1354 ../treebrowser/src/treebrowser.c:1356
 #, c-format
 msgid "Close: %s"
 msgstr "Закрити: %s"
 
-#: ../treebrowser/src/treebrowser.c:1359 ../treebrowser/src/treebrowser.c:1361
+#: ../treebrowser/src/treebrowser.c:1363 ../treebrowser/src/treebrowser.c:1365
 #, c-format
 msgid "Clo_se Child Documents "
 msgstr "Закрити всі документи з каталогу "
 
-#: ../treebrowser/src/treebrowser.c:1368 ../treebrowser/src/treebrowser.c:1370
+#: ../treebrowser/src/treebrowser.c:1372 ../treebrowser/src/treebrowser.c:1374
 msgid "_Copy Full Path to Clipboard"
 msgstr "_Копіювати шлях"
 
-#: ../treebrowser/src/treebrowser.c:1381 ../treebrowser/src/treebrowser.c:1383
+#: ../treebrowser/src/treebrowser.c:1385 ../treebrowser/src/treebrowser.c:1387
 msgid "E_xpand All"
 msgstr "_Розгорнути все"
 
-#: ../treebrowser/src/treebrowser.c:1389 ../treebrowser/src/treebrowser.c:1391
+#: ../treebrowser/src/treebrowser.c:1393 ../treebrowser/src/treebrowser.c:1395
 msgid "Coll_apse All"
 msgstr "_Згорнути все"
 
-#: ../treebrowser/src/treebrowser.c:1399
+#: ../treebrowser/src/treebrowser.c:1403
 msgid "Show Boo_kmarks"
 msgstr "За_кладки"
 
-#: ../treebrowser/src/treebrowser.c:1404
+#: ../treebrowser/src/treebrowser.c:1408
 msgid "Sho_w Hidden Files"
 msgstr "При_ховані файли"
 
-#: ../treebrowser/src/treebrowser.c:1409
+#: ../treebrowser/src/treebrowser.c:1413
 msgid "Show Tool_bars"
 msgstr "Панель _інструментів"
 
-#: ../treebrowser/src/treebrowser.c:1747
+#: ../treebrowser/src/treebrowser.c:1751
 #, c-format
 msgid "Target file '%s' exists, do you really want to replace it?"
 msgstr "Файл \"%s\" вже існує, ви дійсно хочете його замінити?"
 
-#: ../treebrowser/src/treebrowser.c:1883
+#: ../treebrowser/src/treebrowser.c:1887
 msgid "Go up"
 msgstr "Каталог рівнем вище"
 
-#: ../treebrowser/src/treebrowser.c:1893 ../treebrowser/src/treebrowser.c:2360
+#: ../treebrowser/src/treebrowser.c:1897 ../treebrowser/src/treebrowser.c:2365
 msgid "Refresh"
 msgstr "Оновити"
 
-#: ../treebrowser/src/treebrowser.c:1903
+#: ../treebrowser/src/treebrowser.c:1907
 msgid "Home"
 msgstr "Домашній каталог"
 
-#: ../treebrowser/src/treebrowser.c:1913
+#: ../treebrowser/src/treebrowser.c:1917
 msgid "Set path from document"
 msgstr "Каталог документа"
 
-#: ../treebrowser/src/treebrowser.c:1923
+#: ../treebrowser/src/treebrowser.c:1927
 msgid "Track path"
 msgstr "Показати файл документа"
 
-#: ../treebrowser/src/treebrowser.c:1933
+#: ../treebrowser/src/treebrowser.c:1937
 msgid "Hide bars"
 msgstr "Приховати панель інструментів"
 
-#: ../treebrowser/src/treebrowser.c:1943
+#: ../treebrowser/src/treebrowser.c:1947
 msgid ""
 "Filter (*.c;*.h;*.cpp), and if you want temporary filter using the '!' "
 "reverse try for example this '!;*.c;*.h;*.cpp'"
@@ -7652,20 +7409,20 @@ msgstr ""
 "Фільтр імен файлів (список, розділений \";\"), або інверсний фільтр (список "
 "починається з \"!;\"). Наприклад, \"*.c;*.h;*.cpp\", або \"!;*.obj;temp*\""
 
-#: ../treebrowser/src/treebrowser.c:1948
+#: ../treebrowser/src/treebrowser.c:1952
 msgid "Addressbar for example '/projects/my-project'"
 msgstr "Шлях до каталогу"
 
-#: ../treebrowser/src/treebrowser.c:1973
+#: ../treebrowser/src/treebrowser.c:1977
 msgid "Tree Browser"
 msgstr "Провідник каталогів"
 
-#: ../treebrowser/src/treebrowser.c:2114
+#: ../treebrowser/src/treebrowser.c:2118
 msgid "External open command"
 msgstr "Зовнішня команда:"
 
-#: ../treebrowser/src/treebrowser.c:2124
-#, c-format
+#: ../treebrowser/src/treebrowser.c:2129
+#, no-c-format
 msgid ""
 "The command to execute when using \"Open with\". You can use %f and %d "
 "wildcards.\n"
@@ -7677,60 +7434,60 @@ msgstr ""
 "використання маркерів %f (повний шлях до файлу) та %d (повний шлях до "
 "каталогу вибраного файлу)."
 
-#: ../treebrowser/src/treebrowser.c:2143
+#: ../treebrowser/src/treebrowser.c:2148
 msgid "The terminal to use with the command \"Open Terminal\""
 msgstr "Програма терміналу"
 
-#: ../treebrowser/src/treebrowser.c:2149
+#: ../treebrowser/src/treebrowser.c:2154
 msgid "Toolbar"
 msgstr "Панель інструментів:"
 
-#: ../treebrowser/src/treebrowser.c:2151
+#: ../treebrowser/src/treebrowser.c:2156
 msgid "Hidden"
 msgstr "Не показувати"
 
-#: ../treebrowser/src/treebrowser.c:2152
+#: ../treebrowser/src/treebrowser.c:2157
 msgid "Top"
 msgstr "Зверху"
 
-#: ../treebrowser/src/treebrowser.c:2153
+#: ../treebrowser/src/treebrowser.c:2158
 msgid "Bottom"
 msgstr "Знизу"
 
-#: ../treebrowser/src/treebrowser.c:2158
+#: ../treebrowser/src/treebrowser.c:2163
 msgid "If position is changed, the option require plugin restart."
 msgstr ""
 "Перезапустіть плаґін, щоб зміни позиції панелі інструментів набули чинності."
 
-#: ../treebrowser/src/treebrowser.c:2162
+#: ../treebrowser/src/treebrowser.c:2167
 msgid "Show icons"
 msgstr "Піктограми файлів:"
 
-#: ../treebrowser/src/treebrowser.c:2164
+#: ../treebrowser/src/treebrowser.c:2169
 msgid "None"
 msgstr "Не показувати"
 
-#: ../treebrowser/src/treebrowser.c:2165
+#: ../treebrowser/src/treebrowser.c:2170
 msgid "Base"
 msgstr "Основні"
 
-#: ../treebrowser/src/treebrowser.c:2166
+#: ../treebrowser/src/treebrowser.c:2171
 msgid "Content-type"
 msgstr "Тип файлу"
 
-#: ../treebrowser/src/treebrowser.c:2172
+#: ../treebrowser/src/treebrowser.c:2177
 msgid "Show hidden files"
 msgstr "Показувати приховані файли"
 
-#: ../treebrowser/src/treebrowser.c:2181
+#: ../treebrowser/src/treebrowser.c:2186
 msgid "On Windows, this just hide files that are prefixed with '.' (dot)"
 msgstr "У Windows це впливає лише на dot-файли (ім'я починається з крапки)."
 
-#: ../treebrowser/src/treebrowser.c:2183
+#: ../treebrowser/src/treebrowser.c:2188
 msgid "Hide object files"
 msgstr "Не показувати об'єктні файли"
 
-#: ../treebrowser/src/treebrowser.c:2192
+#: ../treebrowser/src/treebrowser.c:2197
 msgid ""
 "Don't show generated object files in the file browser, this includes *.o, *."
 "obj. *.so, *.dll, *.a, *.lib"
@@ -7738,59 +7495,59 @@ msgstr ""
 "Не показувати згенеровані об'єктні файли (*.o, *.obj, *.so, *.dll, *.a, *."
 "lib)."
 
-#: ../treebrowser/src/treebrowser.c:2194
+#: ../treebrowser/src/treebrowser.c:2199
 msgid "Reverse filter"
 msgstr "Дозволити інверсний формат фільтру імен файлів"
 
-#: ../treebrowser/src/treebrowser.c:2203
+#: ../treebrowser/src/treebrowser.c:2208
 msgid "Follow current document"
 msgstr "Показувати шлях до поточного документа"
 
-#: ../treebrowser/src/treebrowser.c:2212
+#: ../treebrowser/src/treebrowser.c:2217
 msgid "Single click, open document and focus it"
 msgstr "Відкривати документ одним натисканням кнопки миші"
 
-#: ../treebrowser/src/treebrowser.c:2221
+#: ../treebrowser/src/treebrowser.c:2226
 msgid "Double click open directory"
 msgstr "Подвійне клацання відкриває разом усі файли з каталогу"
 
-#: ../treebrowser/src/treebrowser.c:2230
+#: ../treebrowser/src/treebrowser.c:2235
 msgid "On delete file, close it if is opened"
 msgstr "Закривати файл при видаленні (якщо відкритий)"
 
-#: ../treebrowser/src/treebrowser.c:2239
+#: ../treebrowser/src/treebrowser.c:2244
 msgid "Focus editor on file open"
 msgstr "Переходити на вкладку відкритого файлу"
 
-#: ../treebrowser/src/treebrowser.c:2248
+#: ../treebrowser/src/treebrowser.c:2253
 msgid "Show tree lines"
 msgstr "Показувати лінії рівнів дерева каталогів"
 
-#: ../treebrowser/src/treebrowser.c:2257
+#: ../treebrowser/src/treebrowser.c:2262
 msgid "Show bookmarks"
 msgstr "Показувати закладки"
 
-#: ../treebrowser/src/treebrowser.c:2266
+#: ../treebrowser/src/treebrowser.c:2271
 msgid "Open new files"
 msgstr "Відкривати створені файли"
 
-#: ../treebrowser/src/treebrowser.c:2350
+#: ../treebrowser/src/treebrowser.c:2355
 msgid "Focus File List"
 msgstr "Перейти до списку файлів"
 
-#: ../treebrowser/src/treebrowser.c:2352
+#: ../treebrowser/src/treebrowser.c:2357
 msgid "Focus Path Entry"
 msgstr "Ввести шлях"
 
-#: ../treebrowser/src/treebrowser.c:2354
+#: ../treebrowser/src/treebrowser.c:2359
 msgid "Rename Object"
 msgstr "Перейменувати"
 
-#: ../treebrowser/src/treebrowser.c:2358
+#: ../treebrowser/src/treebrowser.c:2363
 msgid "New Folder"
 msgstr "Створити каталог"
 
-#: ../treebrowser/src/treebrowser.c:2362
+#: ../treebrowser/src/treebrowser.c:2367
 msgid "Track Current"
 msgstr "Перейти на файл документа"
 
@@ -8469,14 +8226,6 @@ msgstr "Немає каталогів"
 msgid "No workbench opened."
 msgstr "Верстак відсутній"
 
-#: ../workbench/src/sidebar.c:875
-#, c-format
-msgid "%s: %u Project"
-msgid_plural "%s: %u Projects"
-msgstr[0] "%s: %u проект"
-msgstr[1] "%s: %u проекти"
-msgstr[2] "%s: %u проектів"
-
 #: ../workbench/src/sidebar.c:886
 msgid ""
 "Add a project using the context menu\n"
@@ -8592,3 +8341,209 @@ msgid "Autocompletes XML/HTML tags using snippets."
 msgstr ""
 "Автозавершення тегів XML/HTML з можливістю вставки фрагментів коду "
 "(сніпетів)."
+
+#~ msgid "_Monitor repository for changes"
+#~ msgstr "_Стежити за змінами у репозиторію"
+
+#~ msgid ""
+#~ "Whether to automatically update the diff in order to maintain it up to "
+#~ "date when the underlying Git repository changes.  This should generally "
+#~ "be enabled for optimal user experience."
+#~ msgstr ""
+#~ "Автоматично оновлювати показані відмінності у разі нових змін у "
+#~ "репозиторію Git. Для оптимальної роботи, залиште цю опцію увімкненою."
+
+#~ msgid "_Added lines:"
+#~ msgstr "_Додані рядки:"
+
+#~ msgid "_Changed lines:"
+#~ msgstr "_Змінені рядки:"
+
+#~ msgid "_Removed lines:"
+#~ msgstr "_Видалені рядки:"
+
+#~ msgid "Colors"
+#~ msgstr "Колір"
+
+#~ msgid ""
+#~ "The amount to zoom the overview sidebar. This should probably negative if "
+#~ "you want the sidebar zoomed out."
+#~ msgstr ""
+#~ "Масштабування панелі огляду. Для зменшеного виду встановіть від’ємне "
+#~ "значення."
+
+#~ msgid "Zoom Level:"
+#~ msgstr "Масштаб:"
+
+#~ msgid "The width of the overview sidebar."
+#~ msgstr "Ширина панелі огляду (пікселі)."
+
+#~ msgid "Width:"
+#~ msgstr "Ширина:"
+
+#~ msgid ""
+#~ "The number of lines to scroll at a time when scrolling the overview "
+#~ "sidebar."
+#~ msgstr ""
+#~ "Скільки рядків документа прокручувати під час прокрутки панелі огляду."
+
+#~ msgid "Scroll Lines:"
+#~ msgstr "Прокручувати рядків:"
+
+#~ msgid "Position on left"
+#~ msgstr "Зліва"
+
+#~ msgid ""
+#~ "Position the overview bar on the left rather than the right (requires "
+#~ "Geany 1.25 or greater)."
+#~ msgstr ""
+#~ "Розмістити панель огляду ліворуч, а не праворуч (потребує Geany версії "
+#~ "1.25 або вище)."
+
+#~ msgid "Hide tooltip"
+#~ msgstr "Приховати підказку"
+
+#~ msgid ""
+#~ "Hide the tooltip that is displayed when mousing over the overview that "
+#~ "shows line, column and position information."
+#~ msgstr ""
+#~ "Приховати підказку, яка з'являється при наведенні вказівника миші на "
+#~ "огляд. Підказка містить інформацію про рядок, стовпець та позицію у "
+#~ "документі."
+
+#~ msgid "Hide editor scrollbar"
+#~ msgstr "Приховати смугу прокрутки"
+
+#~ msgid ""
+#~ "Whether to hide Geany's regular editor scrollbar while the overview bar "
+#~ "is visible."
+#~ msgstr ""
+#~ "Приховувати звичайну смугу прокрутки редактора Geany, поки видно панель "
+#~ "огляду."
+
+#~ msgid "Disable overlay"
+#~ msgstr "Не показувати рамку перегляду"
+
+#~ msgid ""
+#~ "Turn off drawing overlay, which shows the region of the main editor view "
+#~ "that is currently in view, ontop of the overview bar."
+#~ msgstr ""
+#~ "Вимкнути додання рамки поверх панелі огляду щоби позначити поточну "
+#~ "область перегляду."
+
+#~ msgid ""
+#~ "The color and opacity of the overlay drawn ontop of the overlay sidebar."
+#~ msgstr "Колір і прозорість рамки поточної області перегляду."
+
+#~ msgid "Color:"
+#~ msgstr "Колір:"
+
+#~ msgid ""
+#~ "The color and opacity of the border drawn around the revealed area in the "
+#~ "overview sidebar. Set to the same as Overlay Color to disable."
+#~ msgstr ""
+#~ "Колір і прозорість контуру навколо поточної області перегляду на бічній "
+#~ "панелі огляду. Щоби вимкнути, встановіть той самий колір, що й для рамки "
+#~ "перегляду."
+
+#~ msgid "Outline Color:"
+#~ msgstr "Колір контуру:"
+
+#~ msgid "Draw over visible area"
+#~ msgstr "Затіняти видиму область"
+
+#~ msgid ""
+#~ "When checked it will draw the overlay ontop of the area that is visible "
+#~ "in the main editor view, when unchecked, it will do the opposite and draw "
+#~ "the overlay everywhere but the visible area, \"revealing\" the visible "
+#~ "part."
+#~ msgstr ""
+#~ "Затіняти поточну область перегляду. Інакше, накладена рамка буде "
+#~ "затінювати панель скрізь, крім видимої області, позначаючи таким чином "
+#~ "видиму область."
+
+#~ msgid "Overlay"
+#~ msgstr "Затінення"
+
+#~ msgid "_Translation Helper"
+#~ msgstr "Помічник перекладача"
+
+#~ msgid "_Previous String"
+#~ msgstr "_Попередній сегмент"
+
+#~ msgid "_Next String"
+#~ msgstr "_Наступний сегмент"
+
+#~ msgid "Pre_vious Untranslated"
+#~ msgstr "Попередній неперекладений"
+
+#~ msgid "Next _Untranslated"
+#~ msgstr "Наступний _неперекладений"
+
+#~ msgid "Previous Fu_zzy"
+#~ msgstr "Попередній fu_zzy"
+
+#~ msgid "Next _Fuzzy"
+#~ msgstr "Наступний _fuzzy"
+
+#~ msgid "Previous Untranslated or Fuzz_y"
+#~ msgstr "Попередній неперекладений або fuzz_y"
+
+#~ msgid "Next Untranslated _or Fuzzy"
+#~ msgstr "Наступний неперекладений _або fuzzy"
+
+#~ msgid "_Toggle Fuzziness"
+#~ msgstr "_Позначити / Скасувати як fuzzy"
+
+#~ msgid "Paste _Message as Translation"
+#~ msgstr "Вставити _оригінал як переклад"
+
+#~ msgid "Paste the original untranslated string to the translation"
+#~ msgstr "Вставити неперекладений текст в текст перекладу сегмента"
+
+#~ msgid "_Reflow Translation"
+#~ msgstr "_Форматувати переклад"
+
+#~ msgid "_Show stats"
+#~ msgstr "_Статистика"
+
+#~ msgid ""
+#~ "Whether to update the translation headers (author, revision date, ...) "
+#~ "upon file save"
+#~ msgstr ""
+#~ "Оновлювати заголовки (автор, дата редакції та інше) при збереженні файлу "
+#~ "переклада."
+
+#~ msgid "Update _Headers Upon Save"
+#~ msgstr "_Оновлювати заголовки"
+
+#~ msgid "Translation statistics"
+#~ msgstr "Статистика перекладу"
+
+#~ msgid "Choose a color for translated strings"
+#~ msgstr "Колір для перекладених рядків"
+
+#~ msgid "Choose a color for fuzzily translated strings"
+#~ msgstr "Колір для fuzzy рядків"
+
+#~ msgid "Choose a color for untranslated strings"
+#~ msgstr "Колір для неперекладених рядків"
+
+#~ msgid "Translated:"
+#~ msgstr "Перекладено:"
+
+#~ msgid "Untranslated:"
+#~ msgstr "Не перекладено:"
+
+#~ msgid "Toggle Check While Typing"
+#~ msgstr "Перевіряти під час набору тексту"
+
+#~ msgid "Check spelling while typing"
+#~ msgstr "Перевіряти правопис наживо (під час набору тексту)"
+
+#, c-format
+#~ msgid "%s: %u Project"
+#~ msgid_plural "%s: %u Projects"
+#~ msgstr[0] "%s: %u проект"
+#~ msgstr[1] "%s: %u проекти"
+#~ msgstr[2] "%s: %u проектів"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -6,8 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Geany-Plugins 1.30\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-29 19:41+0200\n"
+"Report-Msgid-Bugs-To: https://github.com/geany/geany/issues\n"
+"POT-Creation-Date: 2022-06-28 07:39+0200\n"
 "PO-Revision-Date: 2009-10-30 08:44+0800\n"
 "Last-Translator: Xhacker Liu <liu.dongyuan@gmail.com>\n"
 "Language-Team: zh_CN <>\n"
@@ -22,28 +22,28 @@ msgstr ""
 msgid "(Empty Line)"
 msgstr "（空行）"
 
-#: ../addons/src/ao_bookmarklist.c:315
+#: ../addons/src/ao_bookmarklist.c:331
 #, fuzzy
 msgid "_Remove Bookmark"
 msgstr "书签"
 
 #. Translators: Number is meant at this point.
-#: ../addons/src/ao_bookmarklist.c:342
+#: ../addons/src/ao_bookmarklist.c:358
 msgid "No."
 msgstr "No."
 
-#: ../addons/src/ao_bookmarklist.c:350 ../devhelp/src/dhp-object.c:494
+#: ../addons/src/ao_bookmarklist.c:366 ../devhelp/src/dhp-object.c:494
 #: ../devhelp/devhelp/dh-window.c:1142
 msgid "Contents"
 msgstr "内容"
 
-#: ../addons/src/ao_bookmarklist.c:383 ../treebrowser/src/treebrowser.c:666
+#: ../addons/src/ao_bookmarklist.c:399 ../treebrowser/src/treebrowser.c:666
 #: ../webhelper/src/gwh-plugin.c:328
 msgid "Bookmarks"
 msgstr "书签"
 
 #. complete update
-#: ../addons/src/ao_tasks.c:373 ../geanyvc/src/geanyvc.c:2679
+#: ../addons/src/ao_tasks.c:373 ../geanyvc/src/geanyvc.c:2730
 msgid "_Update"
 msgstr "更新(_U)"
 
@@ -171,10 +171,10 @@ msgstr "检查当前文件的拼写。"
 #: ../addons/src/addons.c:364 ../autoclose/src/autoclose.c:920
 #: ../codenav/src/codenavigation.c:281 ../latex/src/latex.c:208
 #: ../latex/src/latex.c:293 ../geanyprj/src/geanyprj.c:176
-#: ../geanyvc/src/geanyvc.c:2079 ../geniuspaste/src/geniuspaste.c:336
+#: ../geanyvc/src/geanyvc.c:2130 ../geniuspaste/src/geniuspaste.c:336
 #: ../lineoperations/src/lo_prefs.c:58 ../sendmail/src/sendmail.c:128
 #: ../sendmail/src/sendmail.c:293 ../spellcheck/src/scplugin.c:124
-#: ../treebrowser/src/treebrowser.c:2102
+#: ../treebrowser/src/treebrowser.c:2106
 #: ../updatechecker/src/updatechecker.c:262
 msgid "Plugin configuration directory could not be created."
 msgstr "无法创建插件配置文件目录。"
@@ -738,7 +738,7 @@ msgstr ""
 msgid "Error loading file"
 msgstr ""
 
-#. setting asyncronous mode
+#. setting asynchronous mode
 #. setting null-stop array printing
 #. enable pretty printing
 #: ../debugger/src/dbm_gdb.c:789 ../debugger/src/dbm_gdb.c:792
@@ -1150,7 +1150,7 @@ msgid "A developers' help browser for GNOME"
 msgstr ""
 
 #. Create the current file Submenu
-#: ../devhelp/devhelp/dh-window.c:759 ../geanyvc/src/geanyvc.c:2660
+#: ../devhelp/devhelp/dh-window.c:759 ../geanyvc/src/geanyvc.c:2711
 msgid "_File"
 msgstr "文件(_F)"
 
@@ -1185,12 +1185,12 @@ msgstr ""
 msgid "_Print…"
 msgstr ""
 
-#: ../devhelp/devhelp/dh-window.c:782 ../devhelp/devhelp/eggfindbar.c:342
+#: ../devhelp/devhelp/dh-window.c:782
 #, fuzzy
 msgid "Find Next"
 msgstr "添加文件"
 
-#: ../devhelp/devhelp/dh-window.c:784 ../devhelp/devhelp/eggfindbar.c:329
+#: ../devhelp/devhelp/dh-window.c:784
 #, fuzzy
 msgid "Find Previous"
 msgstr "在项目中查找"
@@ -1388,7 +1388,7 @@ msgid ""
 "contributing to this plugin?"
 msgstr ""
 
-#: ../geanydoc/src/geanydoc.c:159 ../geanyvc/src/geanyvc.c:442
+#: ../geanydoc/src/geanydoc.c:159 ../geanyvc/src/geanyvc.c:448
 msgid "Could not parse the output of command"
 msgstr "无法解析命令的输出"
 
@@ -3131,7 +3131,7 @@ msgstr ""
 "在模块“%s”的函数 %s() 中出现错误：\n"
 "没有给命令“%s”传递足够的参数。\n"
 
-#: ../geanylua/glspi_sci.c:637 ../geanylua/glspi_app.c:406
+#: ../geanylua/glspi_sci.c:729 ../geanylua/glspi_app.c:406
 #, c-format
 msgid ""
 "Error in module \"%s\" at function %s():\n"
@@ -3140,7 +3140,7 @@ msgstr ""
 "在模块“%s”的函数 %s() 中出现错误：\n"
 "参数 #1 未知的命令“%s”。\n"
 
-#: ../geanylua/glspi_sci.c:781
+#: ../geanylua/glspi_sci.c:924
 #, c-format
 msgid ""
 "Error in module \"%s\" at function %s():\n"
@@ -3151,7 +3151,7 @@ msgstr ""
 " 参数 #%3$d 中表不合法：\n"
 " 元素 #%5$d 未知的标识“%4$s”\n"
 
-#: ../geanylua/glspi_sci.c:785
+#: ../geanylua/glspi_sci.c:928
 msgid "<too large to display>"
 msgstr "<过大，无法显示>"
 
@@ -3931,7 +3931,7 @@ msgid "New _Below"
 msgstr ""
 
 #: ../geanymacro/src/geanymacro.c:1824 ../geanymacro/src/geanymacro.c:2120
-#: ../treebrowser/src/treebrowser.c:1338 ../treebrowser/src/treebrowser.c:1340
+#: ../treebrowser/src/treebrowser.c:1342 ../treebrowser/src/treebrowser.c:1344
 #, fuzzy
 msgid "_Delete"
 msgstr "删除项目"
@@ -4310,8 +4310,8 @@ msgstr ""
 msgid "a key with fingerprint"
 msgstr ""
 
-#: ../geanypg/src/verify_aux.c:66 ../spellcheck/src/gui.c:610
-#: ../spellcheck/src/gui.c:621
+#: ../geanypg/src/verify_aux.c:66 ../spellcheck/src/gui.c:607
+#: ../spellcheck/src/gui.c:618
 msgid "unknown"
 msgstr "未知"
 
@@ -4612,50 +4612,50 @@ msgid ""
 "contributing to this plugin?"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:501
+#: ../geanyvc/src/geanyvc.c:507
 #, c-format
 msgid "geanyvc: s_spawn_sync error: %s"
 msgstr "geanyvc：s_spawn_sync 错误：%s"
 
-#: ../geanyvc/src/geanyvc.c:587
+#: ../geanyvc/src/geanyvc.c:593
 #, c-format
 msgid "File %s: action %s executed via %s."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:646 ../geanyvc/src/geanyvc.c:657
-#, c-format
-msgid "geanyvc: vcdiff_file_activated: Unable to rename '%s' to '%s'"
+#: ../geanyvc/src/geanyvc.c:633 ../geanyvc/src/geanyvc.c:643
+#, fuzzy, c-format
+msgid "geanyvc: diff_external: Unable to rename '%s' to '%s'"
 msgstr "geanyvc：vcdiff_file_activated：无法重命名“%s”为“%s”"
 
-#: ../geanyvc/src/geanyvc.c:683 ../geanyvc/src/geanyvc.c:733
+#: ../geanyvc/src/geanyvc.c:698 ../geanyvc/src/geanyvc.c:784
 msgid "No changes were made."
 msgstr "没有作出任何修改。"
 
-#: ../geanyvc/src/geanyvc.c:760
+#: ../geanyvc/src/geanyvc.c:811
 #, fuzzy
 msgid "No history available"
 msgstr "没有可用的历史"
 
-#: ../geanyvc/src/geanyvc.c:953 ../geanyvc/src/geanyvc.c:961
+#: ../geanyvc/src/geanyvc.c:1004 ../geanyvc/src/geanyvc.c:1012
 #, c-format
 msgid "Do you really want to revert: %s?"
 msgstr "您真的想恢复：%s？"
 
-#: ../geanyvc/src/geanyvc.c:969
+#: ../geanyvc/src/geanyvc.c:1020
 #, c-format
 msgid "Do you really want to add: %s?"
 msgstr "您真的想添加：%s？"
 
-#: ../geanyvc/src/geanyvc.c:976
+#: ../geanyvc/src/geanyvc.c:1027
 #, c-format
 msgid "Do you really want to remove: %s?"
 msgstr "您真的想移除：%s？"
 
-#: ../geanyvc/src/geanyvc.c:999
+#: ../geanyvc/src/geanyvc.c:1050
 msgid "Do you really want to update?"
 msgstr "您真的想更新吗？"
 
-#: ../geanyvc/src/geanyvc.c:1126
+#: ../geanyvc/src/geanyvc.c:1177
 msgid ""
 "The resulting differences cannot be displayed because the changes are too "
 "big to display here and would slow down the UI significantly.\n"
@@ -4664,74 +4664,74 @@ msgid ""
 "Geany directly by using the GeanyVC menu (Base Directory -> Diff)."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1280
+#: ../geanyvc/src/geanyvc.c:1331
 msgid "Commit Y/N"
 msgstr "提交 Y/N"
 
-#: ../geanyvc/src/geanyvc.c:1290
+#: ../geanyvc/src/geanyvc.c:1341
 msgid "Status"
 msgstr "状态"
 
-#: ../geanyvc/src/geanyvc.c:1297
+#: ../geanyvc/src/geanyvc.c:1348
 msgid "Path"
 msgstr "路径"
 
-#: ../geanyvc/src/geanyvc.c:1414
+#: ../geanyvc/src/geanyvc.c:1465
 msgid "Choose a previous commit message"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1476
+#: ../geanyvc/src/geanyvc.c:1527
 #, c-format
 msgid "Line: %d Column: %d"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1523
+#: ../geanyvc/src/geanyvc.c:1574
 msgid "Commit"
 msgstr "提交"
 
-#: ../geanyvc/src/geanyvc.c:1564
+#: ../geanyvc/src/geanyvc.c:1615
 msgid "_De-/select all files"
 msgstr "全不选/全选所有文件(_D)"
 
-#: ../geanyvc/src/geanyvc.c:1608
+#: ../geanyvc/src/geanyvc.c:1659
 msgid "<b>Commit message:</b>"
 msgstr "<b>提交信息：</b>"
 
-#: ../geanyvc/src/geanyvc.c:1632
+#: ../geanyvc/src/geanyvc.c:1683
 #, fuzzy
 msgid "C_ommit"
 msgstr "提交"
 
-#: ../geanyvc/src/geanyvc.c:1740
+#: ../geanyvc/src/geanyvc.c:1791
 msgid "Nothing to commit."
 msgstr "没有可以提交的。"
 
-#: ../geanyvc/src/geanyvc.c:1788
+#: ../geanyvc/src/geanyvc.c:1839
 #, fuzzy, c-format
 msgid ""
 "Error initializing GeanyVC spell checking: %s. Check your configuration."
 msgstr "初始化拼写检查时出现错误：%s"
 
-#: ../geanyvc/src/geanyvc.c:1823
+#: ../geanyvc/src/geanyvc.c:1874
 #, c-format
 msgid "Commit failed (status: %d, error: %s)."
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:1824
+#: ../geanyvc/src/geanyvc.c:1875
 #, fuzzy
 msgid "Commit failed; see status in the Message window."
 msgstr "在消息窗口中显示可用的任务"
 
-#: ../geanyvc/src/geanyvc.c:1829
+#: ../geanyvc/src/geanyvc.c:1880
 #, fuzzy
 msgid "Changes committed."
 msgstr "没有可以提交的。"
 
-#: ../geanyvc/src/geanyvc.c:2151
+#: ../geanyvc/src/geanyvc.c:2202
 msgid "Set Changed-flag for document tabs created by the plugin"
 msgstr "为插件创建的文档页设置已更改标记"
 
-#: ../geanyvc/src/geanyvc.c:2154
+#: ../geanyvc/src/geanyvc.c:2205
 msgid ""
 "If this option is activated, every new by the VC-plugin created document tab "
 "will be marked as changed. Even this option is useful in some cases, it "
@@ -4740,259 +4740,259 @@ msgstr ""
 "如果开启这个选项，每个 VC 插件创建的文档页将被标记为已更改。某些情况下这个选"
 "项有用，但它也许也会带来许多烦人的“您要保存吗”对话框。"
 
-#: ../geanyvc/src/geanyvc.c:2162
+#: ../geanyvc/src/geanyvc.c:2213
 msgid "Confirm adding new files to a VCS"
 msgstr "确认添加新文件到VCS"
 
-#: ../geanyvc/src/geanyvc.c:2165
+#: ../geanyvc/src/geanyvc.c:2216
 msgid "Shows a confirmation dialog on adding a new (created) file to VCS."
 msgstr "添加新文件到VCS时显示一个确认对话框。"
 
-#: ../geanyvc/src/geanyvc.c:2171
+#: ../geanyvc/src/geanyvc.c:2222
 msgid "Maximize commit dialog"
 msgstr "最大化提交对话框"
 
-#: ../geanyvc/src/geanyvc.c:2172
+#: ../geanyvc/src/geanyvc.c:2223
 msgid "Show commit dialog maximize."
 msgstr "最大化显示提交对话框。"
 
-#: ../geanyvc/src/geanyvc.c:2178
+#: ../geanyvc/src/geanyvc.c:2229
 msgid "Use external diff viewer"
 msgstr "使用外部差异查看器"
 
-#: ../geanyvc/src/geanyvc.c:2180
+#: ../geanyvc/src/geanyvc.c:2231
 msgid "Use external diff viewer for file diff."
 msgstr "使用外部差异查看器查看文件差异。"
 
-#: ../geanyvc/src/geanyvc.c:2186
+#: ../geanyvc/src/geanyvc.c:2237
 msgid "Show VC entries at editor menu"
 msgstr "在编辑器菜单中显示VC条目"
 
-#: ../geanyvc/src/geanyvc.c:2188
+#: ../geanyvc/src/geanyvc.c:2239
 msgid "Show entries for VC functions inside editor menu"
 msgstr "在编辑器菜单中显示VC条目。"
 
-#: ../geanyvc/src/geanyvc.c:2193
+#: ../geanyvc/src/geanyvc.c:2244
 msgid "Attach menu to menubar"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2195
+#: ../geanyvc/src/geanyvc.c:2246
 msgid ""
 "Whether menu for this plugin are getting placed either inside tools menu or "
 "directly inside Geany's menubar. Will take in account after next start of "
 "GeanyVC"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2203
+#: ../geanyvc/src/geanyvc.c:2254
 msgid "Enable CVS"
 msgstr "启用 CVS"
 
-#: ../geanyvc/src/geanyvc.c:2208
+#: ../geanyvc/src/geanyvc.c:2259
 msgid "Enable GIT"
 msgstr "启用 GIT"
 
-#: ../geanyvc/src/geanyvc.c:2213
+#: ../geanyvc/src/geanyvc.c:2264
 msgid "Enable Fossil"
 msgstr "启用 Fossil"
 
-#: ../geanyvc/src/geanyvc.c:2218
+#: ../geanyvc/src/geanyvc.c:2269
 msgid "Enable SVN"
 msgstr "启用 SVN"
 
-#: ../geanyvc/src/geanyvc.c:2223
+#: ../geanyvc/src/geanyvc.c:2274
 msgid "Enable SVK"
 msgstr "启用 SVK"
 
-#: ../geanyvc/src/geanyvc.c:2228
+#: ../geanyvc/src/geanyvc.c:2279
 msgid "Enable Bazaar"
 msgstr "启用 Bazaar"
 
-#: ../geanyvc/src/geanyvc.c:2233
+#: ../geanyvc/src/geanyvc.c:2284
 msgid "Enable Mercurial"
 msgstr "启用 Mercurial"
 
-#: ../geanyvc/src/geanyvc.c:2239
+#: ../geanyvc/src/geanyvc.c:2290
 msgid "Spellcheck language"
 msgstr "拼写检查语言"
 
 #. Diff of current file
 #. Diff of the current dir
 #. Complete diff of base directory
-#: ../geanyvc/src/geanyvc.c:2368 ../geanyvc/src/geanyvc.c:2463
-#: ../geanyvc/src/geanyvc.c:2503
+#: ../geanyvc/src/geanyvc.c:2419 ../geanyvc/src/geanyvc.c:2514
+#: ../geanyvc/src/geanyvc.c:2554
 msgid "_Diff"
 msgstr "差异(_D)"
 
-#: ../geanyvc/src/geanyvc.c:2371
+#: ../geanyvc/src/geanyvc.c:2422
 msgid "Make a diff from the current active file"
 msgstr "从当前活动的文件生成差异"
 
 #. Revert current file
 #. Revert current dir
 #. Revert everything
-#: ../geanyvc/src/geanyvc.c:2376 ../geanyvc/src/geanyvc.c:2472
-#: ../geanyvc/src/geanyvc.c:2511
+#: ../geanyvc/src/geanyvc.c:2427 ../geanyvc/src/geanyvc.c:2523
+#: ../geanyvc/src/geanyvc.c:2562
 msgid "_Revert"
 msgstr "恢复(_R)"
 
-#: ../geanyvc/src/geanyvc.c:2379
+#: ../geanyvc/src/geanyvc.c:2430
 msgid "Restore pristine working copy file (undo local edits)."
 msgstr "还原原始的工作复制文件（撤销本地编辑）。"
 
 #. Blame for current file
-#: ../geanyvc/src/geanyvc.c:2388
+#: ../geanyvc/src/geanyvc.c:2439
 msgid "_Blame"
 msgstr ""
 
-#: ../geanyvc/src/geanyvc.c:2391
+#: ../geanyvc/src/geanyvc.c:2442
 msgid "Shows the changes made at one file per revision and author."
 msgstr "显示文件每个作者和每次修订的更改。"
 
 #. History/log of current file
 #. History/log of the current dir
 #. Complete History/Log of base directory
-#: ../geanyvc/src/geanyvc.c:2398 ../geanyvc/src/geanyvc.c:2482
-#: ../geanyvc/src/geanyvc.c:2523
+#: ../geanyvc/src/geanyvc.c:2449 ../geanyvc/src/geanyvc.c:2533
+#: ../geanyvc/src/geanyvc.c:2574
 msgid "_History (log)"
 msgstr "历史（日志）(_H)"
 
-#: ../geanyvc/src/geanyvc.c:2401
+#: ../geanyvc/src/geanyvc.c:2452
 msgid "Shows the log of the current file"
 msgstr "显示当前文件日志"
 
 #. base version of the current file
-#: ../geanyvc/src/geanyvc.c:2406
+#: ../geanyvc/src/geanyvc.c:2457
 msgid "_Original"
 msgstr "原始(_O)"
 
-#: ../geanyvc/src/geanyvc.c:2409
+#: ../geanyvc/src/geanyvc.c:2460
 #, fuzzy
 msgid "Shows the original of the current file"
 msgstr "显示当前文件的最初版本"
 
 #. add current file
-#: ../geanyvc/src/geanyvc.c:2417
+#: ../geanyvc/src/geanyvc.c:2468
 msgid "_Add to Version Control"
 msgstr "添加到版本控制(_A)"
 
-#: ../geanyvc/src/geanyvc.c:2419
+#: ../geanyvc/src/geanyvc.c:2470
 msgid "Add file to repository."
 msgstr "添加文件到库。"
 
 #. remove current file
-#: ../geanyvc/src/geanyvc.c:2425
+#: ../geanyvc/src/geanyvc.c:2476
 msgid "_Remove from Version Control"
 msgstr "从版本控制中移除(_R)"
 
-#: ../geanyvc/src/geanyvc.c:2427
+#: ../geanyvc/src/geanyvc.c:2478
 msgid "Remove file from repository."
 msgstr "从库中移除文件。"
 
-#: ../geanyvc/src/geanyvc.c:2460
+#: ../geanyvc/src/geanyvc.c:2511
 msgid "_Directory"
 msgstr "目录(_D)"
 
-#: ../geanyvc/src/geanyvc.c:2466
+#: ../geanyvc/src/geanyvc.c:2517
 msgid "Make a diff from the directory of the current active file"
 msgstr "从文件夹生成与当前活动文件之间的差异"
 
-#: ../geanyvc/src/geanyvc.c:2475
+#: ../geanyvc/src/geanyvc.c:2526
 msgid "Restore original files in the current folder (undo local edits)."
 msgstr "还原当前文件夹中的原始文件（撤销本地编辑）。"
 
-#: ../geanyvc/src/geanyvc.c:2485
+#: ../geanyvc/src/geanyvc.c:2536
 msgid "Shows the log of the current directory"
 msgstr "显示当前目录日志"
 
-#: ../geanyvc/src/geanyvc.c:2499
+#: ../geanyvc/src/geanyvc.c:2550
 msgid "_Base Directory"
 msgstr "根目录(_B)"
 
-#: ../geanyvc/src/geanyvc.c:2505
+#: ../geanyvc/src/geanyvc.c:2556
 msgid "Make a diff from the top VC directory"
 msgstr "从顶层VC目录生成差异"
 
-#: ../geanyvc/src/geanyvc.c:2513
+#: ../geanyvc/src/geanyvc.c:2564
 msgid "Revert any local edits."
 msgstr "恢复所有本地编辑。"
 
-#: ../geanyvc/src/geanyvc.c:2526
+#: ../geanyvc/src/geanyvc.c:2577
 msgid "Shows the log of the top VC directory"
 msgstr "显示顶层VC目录差异"
 
-#: ../geanyvc/src/geanyvc.c:2543
+#: ../geanyvc/src/geanyvc.c:2594
 msgid "_VC file Actions"
 msgstr "_VC 文件操作"
 
-#: ../geanyvc/src/geanyvc.c:2552
+#: ../geanyvc/src/geanyvc.c:2603
 msgid "VC _Commit..."
 msgstr "VC 提交...(_C)"
 
-#: ../geanyvc/src/geanyvc.c:2596
+#: ../geanyvc/src/geanyvc.c:2647
 msgid "Show diff of file"
 msgstr "显示文件差异"
 
-#: ../geanyvc/src/geanyvc.c:2598
+#: ../geanyvc/src/geanyvc.c:2649
 msgid "Show diff of directory"
 msgstr "显示目录差异"
 
-#: ../geanyvc/src/geanyvc.c:2600
+#: ../geanyvc/src/geanyvc.c:2651
 msgid "Show diff of basedir"
 msgstr "显示根目录差异"
 
-#: ../geanyvc/src/geanyvc.c:2603
+#: ../geanyvc/src/geanyvc.c:2654
 msgid "Commit changes"
 msgstr "提交更改"
 
-#: ../geanyvc/src/geanyvc.c:2605
+#: ../geanyvc/src/geanyvc.c:2656
 msgid "Show status"
 msgstr "显示状态"
 
-#: ../geanyvc/src/geanyvc.c:2607
+#: ../geanyvc/src/geanyvc.c:2658
 msgid "Revert single file"
 msgstr "恢复单个文件"
 
-#: ../geanyvc/src/geanyvc.c:2609
+#: ../geanyvc/src/geanyvc.c:2660
 msgid "Revert directory"
 msgstr "恢复目录"
 
-#: ../geanyvc/src/geanyvc.c:2611
+#: ../geanyvc/src/geanyvc.c:2662
 msgid "Revert base directory"
 msgstr "恢复根目录"
 
-#: ../geanyvc/src/geanyvc.c:2613
+#: ../geanyvc/src/geanyvc.c:2664
 msgid "Update file"
 msgstr "更新文件"
 
-#: ../geanyvc/src/geanyvc.c:2643
+#: ../geanyvc/src/geanyvc.c:2694
 msgid "_VC"
 msgstr "_VC"
 
-#: ../geanyvc/src/geanyvc.c:2650
+#: ../geanyvc/src/geanyvc.c:2701
 #, fuzzy
 msgid "_Version Control"
 msgstr "添加到版本控制(_A)"
 
 #. Status of basedir
-#: ../geanyvc/src/geanyvc.c:2672
+#: ../geanyvc/src/geanyvc.c:2723
 msgid "_Status"
 msgstr "状态(_S)"
 
-#: ../geanyvc/src/geanyvc.c:2674
+#: ../geanyvc/src/geanyvc.c:2725
 msgid "Show status."
 msgstr "显示状态。"
 
-#: ../geanyvc/src/geanyvc.c:2681
+#: ../geanyvc/src/geanyvc.c:2732
 #, fuzzy
 msgid "Update from remote repository."
 msgstr "从远程库更新。"
 
 #. Commit all changes
-#: ../geanyvc/src/geanyvc.c:2686
+#: ../geanyvc/src/geanyvc.c:2737
 msgid "_Commit..."
 msgstr "提交...(_C)"
 
-#: ../geanyvc/src/geanyvc.c:2688
+#: ../geanyvc/src/geanyvc.c:2739
 msgid "Commit changes."
 msgstr "提交更改。"
 
@@ -5106,34 +5106,6 @@ msgstr ""
 
 #: ../geniuspaste/src/geniuspaste.c:959
 msgid "_Paste it!"
-msgstr ""
-
-#: ../git-changebar/data/prefs.ui.h:1
-msgid "_Monitor repository for changes"
-msgstr ""
-
-#: ../git-changebar/data/prefs.ui.h:2
-msgid ""
-"Whether to automatically update the diff in order to maintain it up to date "
-"when the underlying Git repository changes.  This should generally be "
-"enabled for optimal user experience."
-msgstr ""
-
-#: ../git-changebar/data/prefs.ui.h:3
-msgid "_Added lines:"
-msgstr ""
-
-#: ../git-changebar/data/prefs.ui.h:4
-msgid "_Changed lines:"
-msgstr ""
-
-#: ../git-changebar/data/prefs.ui.h:5
-#, fuzzy
-msgid "_Removed lines:"
-msgstr "移除文件"
-
-#: ../git-changebar/data/prefs.ui.h:6
-msgid "Colors"
 msgstr ""
 
 #: ../git-changebar/src/gcb-plugin.c:62
@@ -5325,8 +5297,8 @@ msgstr ""
 #: ../lipsum/src/lipsum.c:184 ../sendmail/src/sendmail.c:396
 #, c-format
 msgid ""
-"Your configuration directory has been successfully moved from \"%s\" to \"%s"
-"\"."
+"Your configuration directory has been successfully moved from \"%s\" to "
+"\"%s\"."
 msgstr ""
 
 #: ../lipsum/src/lipsum.c:199
@@ -5503,7 +5475,7 @@ msgstr "显示当前文件日志"
 msgid "Unable to read value for '%s' key: %s"
 msgstr ""
 
-#: ../multiterm/src/tab-label.vala:62 ../treebrowser/src/treebrowser.c:2132
+#: ../multiterm/src/tab-label.vala:62 ../treebrowser/src/treebrowser.c:2137
 #, fuzzy
 msgid "Terminal"
 msgstr "已终止"
@@ -5544,116 +5516,6 @@ msgstr ""
 msgid "Show Overview"
 msgstr "在终端中运行"
 
-#: ../overview/data/prefs.ui.h:1
-msgid ""
-"The amount to zoom the overview sidebar. This should probably negative if "
-"you want the sidebar zoomed out."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:2
-msgid "Zoom Level:"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:3
-msgid "The width of the overview sidebar."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:4
-msgid "Width:"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:5
-msgid ""
-"The number of lines to scroll at a time when scrolling the overview sidebar."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:6
-msgid "Scroll Lines:"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:7
-#, fuzzy
-msgid "Position on left"
-msgstr "Edition"
-
-#: ../overview/data/prefs.ui.h:8
-msgid ""
-"Position the overview bar on the left rather than the right (requires Geany "
-"1.25 or greater)."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:9
-#, fuzzy
-msgid "Hide tooltip"
-msgstr "显示工具提示。"
-
-#: ../overview/data/prefs.ui.h:10
-msgid ""
-"Hide the tooltip that is displayed when mousing over the overview that shows "
-"line, column and position information."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:11
-msgid "Hide editor scrollbar"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:12
-msgid ""
-"Whether to hide Geany's regular editor scrollbar while the overview bar is "
-"visible."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:13
-msgid "Disable overlay"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:14
-msgid ""
-"Turn off drawing overlay, which shows the region of the main editor view "
-"that is currently in view, ontop of the overview bar."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:15 ../scope/data/scope.glade.h:130
-#: ../scope/data/scope_gtk3.glade.h:130
-#, fuzzy
-msgid "Options"
-msgstr "选项(_O)"
-
-#: ../overview/data/prefs.ui.h:16
-msgid ""
-"The color and opacity of the overlay drawn ontop of the overlay sidebar."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:17
-msgid "Color:"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:18
-msgid ""
-"The color and opacity of the border drawn around the revealed area in the "
-"overview sidebar. Set to the same as Overlay Color to disable."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:19
-#, fuzzy
-msgid "Outline Color:"
-msgstr "选择颜色"
-
-#: ../overview/data/prefs.ui.h:20
-msgid "Draw over visible area"
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:21
-msgid ""
-"When checked it will draw the overlay ontop of the area that is visible in "
-"the main editor view, when unchecked, it will do the opposite and draw the "
-"overlay everywhere but the visible area, \"revealing\" the visible part."
-msgstr ""
-
-#: ../overview/data/prefs.ui.h:22
-msgid "Overlay"
-msgstr ""
-
 #: ../pairtaghighlighter/src/pair_tag_highlighter.c:43
 msgid "Pair Tag Highlighter"
 msgstr ""
@@ -5678,149 +5540,6 @@ msgstr ""
 #, fuzzy
 msgid "Select To Matching Tag"
 msgstr "选择字体"
-
-#: ../pohelper/data/menus.ui.h:1
-msgid "_Translation Helper"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:2
-msgid "_Previous String"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:3 ../pohelper/src/gph-plugin.c:1590
-#, fuzzy
-msgid "Go to previous string"
-msgstr "返回上一个对话框。"
-
-#: ../pohelper/data/menus.ui.h:4
-msgid "_Next String"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:5 ../pohelper/src/gph-plugin.c:1593
-#, fuzzy
-msgid "Go to next string"
-msgstr "单步进入下一行。"
-
-#: ../pohelper/data/menus.ui.h:6
-msgid "Pre_vious Untranslated"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:7 ../pohelper/src/gph-plugin.c:1596
-msgid "Go to previous untranslated string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:8
-msgid "Next _Untranslated"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:9 ../pohelper/src/gph-plugin.c:1599
-msgid "Go to next untranslated string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:10
-msgid "Previous Fu_zzy"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:11 ../pohelper/src/gph-plugin.c:1602
-msgid "Go to previous fuzzily translated string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:12
-msgid "Next _Fuzzy"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:13 ../pohelper/src/gph-plugin.c:1605
-msgid "Go to next fuzzily translated string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:14
-msgid "Previous Untranslated or Fuzz_y"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:15 ../pohelper/src/gph-plugin.c:1608
-msgid "Go to previous untranslated or fuzzy string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:16
-msgid "Next Untranslated _or Fuzzy"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:17 ../pohelper/src/gph-plugin.c:1612
-msgid "Go to next untranslated or fuzzy string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:18 ../pohelper/src/gph-plugin.c:1623
-#, fuzzy
-msgid "Toggle current translation fuzziness"
-msgstr "文件交互"
-
-#: ../pohelper/data/menus.ui.h:19
-msgid "_Toggle Fuzziness"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:20
-msgid "Paste _Message as Translation"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:21
-msgid "Paste the original untranslated string to the translation"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:22 ../pohelper/src/gph-plugin.c:1620
-msgid "Reflow the current translation string"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:23
-msgid "_Reflow Translation"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:24 ../pohelper/src/gph-plugin.c:1626
-#, fuzzy
-msgid "Show statistics of the current document"
-msgstr "检查当前文件的拼写。"
-
-#: ../pohelper/data/menus.ui.h:25
-#, fuzzy
-msgid "_Show stats"
-msgstr "显示状态"
-
-#: ../pohelper/data/menus.ui.h:26
-msgid ""
-"Whether to update the translation headers (author, revision date, ...) upon "
-"file save"
-msgstr ""
-
-#: ../pohelper/data/menus.ui.h:27
-msgid "Update _Headers Upon Save"
-msgstr ""
-
-#: ../pohelper/data/stats.ui.h:1
-msgid "Translation statistics"
-msgstr ""
-
-#: ../pohelper/data/stats.ui.h:2
-msgid "Choose a color for translated strings"
-msgstr ""
-
-#: ../pohelper/data/stats.ui.h:3
-msgid "Choose a color for fuzzily translated strings"
-msgstr ""
-
-#: ../pohelper/data/stats.ui.h:4
-msgid "Choose a color for untranslated strings"
-msgstr ""
-
-#: ../pohelper/data/stats.ui.h:5
-msgid "Translated:"
-msgstr ""
-
-#: ../pohelper/data/stats.ui.h:6
-msgid "Fuzzy:"
-msgstr ""
-
-#: ../pohelper/data/stats.ui.h:7
-msgid "Untranslated:"
-msgstr ""
 
 #: ../pohelper/src/gph-plugin.c:40
 msgid "Translation Helper"
@@ -5850,9 +5569,57 @@ msgstr ""
 msgid "%u (%.3g%%)"
 msgstr ""
 
+#: ../pohelper/src/gph-plugin.c:1590
+#, fuzzy
+msgid "Go to previous string"
+msgstr "返回上一个对话框。"
+
+#: ../pohelper/src/gph-plugin.c:1593
+#, fuzzy
+msgid "Go to next string"
+msgstr "单步进入下一行。"
+
+#: ../pohelper/src/gph-plugin.c:1596
+msgid "Go to previous untranslated string"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1599
+msgid "Go to next untranslated string"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1602
+msgid "Go to previous fuzzily translated string"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1605
+msgid "Go to next fuzzily translated string"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1608
+msgid "Go to previous untranslated or fuzzy string"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1612
+msgid "Go to next untranslated or fuzzy string"
+msgstr ""
+
 #: ../pohelper/src/gph-plugin.c:1616
 msgid "Paste original untranslated string to translation"
 msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1620
+msgid "Reflow the current translation string"
+msgstr ""
+
+#: ../pohelper/src/gph-plugin.c:1623
+#, fuzzy
+msgid "Toggle current translation fuzziness"
+msgstr "文件交互"
+
+#: ../pohelper/src/gph-plugin.c:1626
+#, fuzzy
+msgid "Show statistics of the current document"
+msgstr "检查当前文件的拼写。"
 
 #: ../pohelper/src/gph-plugin.c:1833
 #, c-format
@@ -6128,7 +5895,7 @@ msgid "Add"
 msgstr "附加组件"
 
 #: ../projectorganizer/src/prjorg-sidebar.c:390
-#: ../treebrowser/src/treebrowser.c:2356
+#: ../treebrowser/src/treebrowser.c:2361
 #, fuzzy
 msgid "New File"
 msgstr "文件(_F)"
@@ -6803,6 +6570,11 @@ msgstr "显示工具提示。"
 msgid "<b>Others</b>"
 msgstr ""
 
+#: ../scope/data/scope.glade.h:130 ../scope/data/scope_gtk3.glade.h:130
+#, fuzzy
+msgid "Options"
+msgstr "选项(_O)"
+
 #: ../scope/data/scope.glade.h:131 ../scope/data/scope_gtk3.glade.h:131
 #, fuzzy
 msgid "_Import"
@@ -7411,12 +7183,14 @@ msgid "Checks the spelling of the current document."
 msgstr "检查当前文件的拼写。"
 
 #: ../spellcheck/src/scplugin.c:225
-msgid "Run Spell Check"
+#, fuzzy
+msgid "Run spell check once"
 msgstr "运行拼写检查"
 
-#: ../spellcheck/src/scplugin.c:228
-msgid "Toggle Check While Typing"
-msgstr "开关输入时的拼写检查"
+#: ../spellcheck/src/scplugin.c:228 ../spellcheck/src/scplugin.c:333
+#, fuzzy
+msgid "Toggle spell check"
+msgstr "拼写检查"
 
 #. initialise the dialog
 #: ../spellcheck/src/scplugin.c:239
@@ -7444,10 +7218,6 @@ msgstr "在消息窗口输出拼写错误的单词和建议"
 #: ../spellcheck/src/scplugin.c:325
 msgid "<b>Interface</b>"
 msgstr ""
-
-#: ../spellcheck/src/scplugin.c:333
-msgid "Check spelling while typing"
-msgstr "输入时进行拼写检查"
 
 #: ../spellcheck/src/scplugin.c:336
 #, fuzzy
@@ -7481,53 +7251,53 @@ msgstr "在这个目录中读取附加的字典文件，目前，只有 myspell 
 msgid "<b>Behavior</b>"
 msgstr ""
 
-#: ../spellcheck/src/gui.c:76
+#: ../spellcheck/src/gui.c:88
 msgid "Spell checking while typing is now enabled"
 msgstr "输入时的拼写检查已启用"
 
-#: ../spellcheck/src/gui.c:78
+#: ../spellcheck/src/gui.c:90
 msgid "Spell checking while typing is now disabled"
 msgstr "输入时的拼写检查已禁用"
 
-#: ../spellcheck/src/gui.c:326
+#: ../spellcheck/src/gui.c:323
 msgid "More..."
 msgstr "更多..."
 
-#: ../spellcheck/src/gui.c:347
+#: ../spellcheck/src/gui.c:344
 msgid "(No Suggestions)"
 msgstr "（无建议）"
 
-#: ../spellcheck/src/gui.c:360
+#: ../spellcheck/src/gui.c:357
 #, c-format
 msgid "Add \"%s\" to Dictionary"
 msgstr "添加“%s”到字典"
 
-#: ../spellcheck/src/gui.c:368
+#: ../spellcheck/src/gui.c:365
 msgid "Ignore All"
 msgstr "忽略全部"
 
-#: ../spellcheck/src/gui.c:441
+#: ../spellcheck/src/gui.c:438
 msgid ""
 "Search term is too long to provide\n"
 "spelling suggestions in the editor menu."
 msgstr ""
 
-#: ../spellcheck/src/gui.c:447
+#: ../spellcheck/src/gui.c:444
 #, fuzzy
 msgid "Perform Spell Check"
 msgstr "拼写检查"
 
-#: ../spellcheck/src/gui.c:609
+#: ../spellcheck/src/gui.c:606
 #, c-format
 msgid "Default (%s)"
 msgstr "默认（%s）"
 
-#: ../spellcheck/src/gui.c:620
-#, c-format
-msgid "Toggle spell check while typing (current language: %s)"
+#: ../spellcheck/src/gui.c:617
+#, fuzzy, c-format
+msgid "Toggle spell check (current language: %s)"
 msgstr "开关输入时的拼写检查（当前语言：%s）"
 
-#: ../spellcheck/src/gui.c:698
+#: ../spellcheck/src/gui.c:695
 msgid "Spelling Suggestions"
 msgstr "拼写建议"
 
@@ -7623,168 +7393,168 @@ msgstr "（空行）"
 msgid "Could not execute configured external command '%s' (%s)."
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1089
+#: ../treebrowser/src/treebrowser.c:1093
 #, fuzzy
 msgid "NewDirectory"
 msgstr "目录(_D)"
 
-#: ../treebrowser/src/treebrowser.c:1091
+#: ../treebrowser/src/treebrowser.c:1095
 #, fuzzy
 msgid "NewFile"
 msgstr "文件(_F)"
 
-#: ../treebrowser/src/treebrowser.c:1096
+#: ../treebrowser/src/treebrowser.c:1100
 #, c-format
 msgid ""
 "Target file '%s' exists.\n"
 "Do you really want to replace it with an empty file?"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1142
+#: ../treebrowser/src/treebrowser.c:1146
 #, fuzzy, c-format
 msgid "Do you really want to delete '%s' ?"
 msgstr "您真的想恢复：%s？"
 
-#: ../treebrowser/src/treebrowser.c:1255 ../treebrowser/src/treebrowser.c:1257
+#: ../treebrowser/src/treebrowser.c:1259 ../treebrowser/src/treebrowser.c:1261
 msgid "Go _Up"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1263 ../treebrowser/src/treebrowser.c:1265
+#: ../treebrowser/src/treebrowser.c:1267 ../treebrowser/src/treebrowser.c:1269
 #, fuzzy
 msgid "Set _Path From Document"
 msgstr "为您的新文档设置编码"
 
-#: ../treebrowser/src/treebrowser.c:1271 ../treebrowser/src/treebrowser.c:1273
+#: ../treebrowser/src/treebrowser.c:1275 ../treebrowser/src/treebrowser.c:1277
 #, fuzzy
 msgid "_Open Externally"
 msgstr "在终端中运行"
 
-#: ../treebrowser/src/treebrowser.c:1279
+#: ../treebrowser/src/treebrowser.c:1283
 #, fuzzy
 msgid "Open _Terminal"
 msgstr "在终端中运行"
 
-#: ../treebrowser/src/treebrowser.c:1284 ../treebrowser/src/treebrowser.c:1286
+#: ../treebrowser/src/treebrowser.c:1288 ../treebrowser/src/treebrowser.c:1290
 msgid "Set as _Root"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1293 ../treebrowser/src/treebrowser.c:1295
+#: ../treebrowser/src/treebrowser.c:1297 ../treebrowser/src/treebrowser.c:1299
 #, fuzzy
 msgid "Refres_h"
 msgstr "Series"
 
-#: ../treebrowser/src/treebrowser.c:1301 ../treebrowser/src/treebrowser.c:1303
+#: ../treebrowser/src/treebrowser.c:1305 ../treebrowser/src/treebrowser.c:1307
 #, fuzzy
 msgid "_Find in Files"
 msgstr "在项目中查找"
 
-#: ../treebrowser/src/treebrowser.c:1313 ../treebrowser/src/treebrowser.c:1315
+#: ../treebrowser/src/treebrowser.c:1317 ../treebrowser/src/treebrowser.c:1319
 #, fuzzy
 msgid "N_ew Folder"
 msgstr "选择颜色"
 
-#: ../treebrowser/src/treebrowser.c:1321 ../treebrowser/src/treebrowser.c:1323
+#: ../treebrowser/src/treebrowser.c:1325 ../treebrowser/src/treebrowser.c:1327
 #, fuzzy
 msgid "_New File"
 msgstr "文件(_F)"
 
-#: ../treebrowser/src/treebrowser.c:1329 ../treebrowser/src/treebrowser.c:1331
+#: ../treebrowser/src/treebrowser.c:1333 ../treebrowser/src/treebrowser.c:1335
 #, fuzzy
 msgid "Rena_me"
 msgstr "文件名："
 
-#: ../treebrowser/src/treebrowser.c:1350 ../treebrowser/src/treebrowser.c:1352
+#: ../treebrowser/src/treebrowser.c:1354 ../treebrowser/src/treebrowser.c:1356
 #, fuzzy, c-format
 msgid "Close: %s"
 msgstr "关闭全部(_L)"
 
-#: ../treebrowser/src/treebrowser.c:1359 ../treebrowser/src/treebrowser.c:1361
+#: ../treebrowser/src/treebrowser.c:1363 ../treebrowser/src/treebrowser.c:1365
 #, fuzzy, c-format
 msgid "Clo_se Child Documents "
 msgstr "关闭其他文件(_H)"
 
-#: ../treebrowser/src/treebrowser.c:1368 ../treebrowser/src/treebrowser.c:1370
+#: ../treebrowser/src/treebrowser.c:1372 ../treebrowser/src/treebrowser.c:1374
 msgid "_Copy Full Path to Clipboard"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1381 ../treebrowser/src/treebrowser.c:1383
+#: ../treebrowser/src/treebrowser.c:1385 ../treebrowser/src/treebrowser.c:1387
 msgid "E_xpand All"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1389 ../treebrowser/src/treebrowser.c:1391
+#: ../treebrowser/src/treebrowser.c:1393 ../treebrowser/src/treebrowser.c:1395
 #, fuzzy
 msgid "Coll_apse All"
 msgstr "关闭全部(_L)"
 
-#: ../treebrowser/src/treebrowser.c:1399
+#: ../treebrowser/src/treebrowser.c:1403
 #, fuzzy
 msgid "Show Boo_kmarks"
 msgstr "书签"
 
-#: ../treebrowser/src/treebrowser.c:1404
+#: ../treebrowser/src/treebrowser.c:1408
 #, fuzzy
 msgid "Sho_w Hidden Files"
 msgstr "显示文件差异"
 
-#: ../treebrowser/src/treebrowser.c:1409
+#: ../treebrowser/src/treebrowser.c:1413
 #, fuzzy
 msgid "Show Tool_bars"
 msgstr "显示状态"
 
-#: ../treebrowser/src/treebrowser.c:1747
+#: ../treebrowser/src/treebrowser.c:1751
 #, c-format
 msgid "Target file '%s' exists, do you really want to replace it?"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1883
+#: ../treebrowser/src/treebrowser.c:1887
 msgid "Go up"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1893 ../treebrowser/src/treebrowser.c:2360
+#: ../treebrowser/src/treebrowser.c:1897 ../treebrowser/src/treebrowser.c:2365
 #, fuzzy
 msgid "Refresh"
 msgstr "Series"
 
-#: ../treebrowser/src/treebrowser.c:1903
+#: ../treebrowser/src/treebrowser.c:1907
 #, fuzzy
 msgid "Home"
 msgstr "Volume"
 
-#: ../treebrowser/src/treebrowser.c:1913
+#: ../treebrowser/src/treebrowser.c:1917
 #, fuzzy
 msgid "Set path from document"
 msgstr "为您的新文档设置编码"
 
-#: ../treebrowser/src/treebrowser.c:1923
+#: ../treebrowser/src/treebrowser.c:1927
 #, fuzzy
 msgid "Track path"
 msgstr "根目录："
 
-#: ../treebrowser/src/treebrowser.c:1933
+#: ../treebrowser/src/treebrowser.c:1937
 #, fuzzy
 msgid "Hide bars"
 msgstr "隐藏侧栏(_I)"
 
-#: ../treebrowser/src/treebrowser.c:1943
+#: ../treebrowser/src/treebrowser.c:1947
 msgid ""
 "Filter (*.c;*.h;*.cpp), and if you want temporary filter using the '!' "
 "reverse try for example this '!;*.c;*.h;*.cpp'"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1948
+#: ../treebrowser/src/treebrowser.c:1952
 msgid "Addressbar for example '/projects/my-project'"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:1973
+#: ../treebrowser/src/treebrowser.c:1977
 msgid "Tree Browser"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2114
+#: ../treebrowser/src/treebrowser.c:2118
 msgid "External open command"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2124
-#, c-format
+#: ../treebrowser/src/treebrowser.c:2129
+#, no-c-format
 msgid ""
 "The command to execute when using \"Open with\". You can use %f and %d "
 "wildcards.\n"
@@ -7793,130 +7563,130 @@ msgid ""
 "filename"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2143
+#: ../treebrowser/src/treebrowser.c:2148
 msgid "The terminal to use with the command \"Open Terminal\""
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2149
+#: ../treebrowser/src/treebrowser.c:2154
 msgid "Toolbar"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2151
+#: ../treebrowser/src/treebrowser.c:2156
 msgid "Hidden"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2152
+#: ../treebrowser/src/treebrowser.c:2157
 msgid "Top"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2153
+#: ../treebrowser/src/treebrowser.c:2158
 msgid "Bottom"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2158
+#: ../treebrowser/src/treebrowser.c:2163
 msgid "If position is changed, the option require plugin restart."
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2162
+#: ../treebrowser/src/treebrowser.c:2167
 #, fuzzy
 msgid "Show icons"
 msgstr "显示图标。"
 
-#: ../treebrowser/src/treebrowser.c:2164
+#: ../treebrowser/src/treebrowser.c:2169
 msgid "None"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2165
+#: ../treebrowser/src/treebrowser.c:2170
 #, fuzzy
 msgid "Base"
 msgstr "暂停(_P)"
 
-#: ../treebrowser/src/treebrowser.c:2166
+#: ../treebrowser/src/treebrowser.c:2171
 #, fuzzy
 msgid "Content-type"
 msgstr "内容"
 
-#: ../treebrowser/src/treebrowser.c:2172
+#: ../treebrowser/src/treebrowser.c:2177
 #, fuzzy
 msgid "Show hidden files"
 msgstr "显示文件差异"
 
-#: ../treebrowser/src/treebrowser.c:2181
+#: ../treebrowser/src/treebrowser.c:2186
 msgid "On Windows, this just hide files that are prefixed with '.' (dot)"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2183
+#: ../treebrowser/src/treebrowser.c:2188
 #, fuzzy
 msgid "Hide object files"
 msgstr "选择文件"
 
-#: ../treebrowser/src/treebrowser.c:2192
+#: ../treebrowser/src/treebrowser.c:2197
 msgid ""
 "Don't show generated object files in the file browser, this includes *.o, *."
 "obj. *.so, *.dll, *.a, *.lib"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2194
+#: ../treebrowser/src/treebrowser.c:2199
 #, fuzzy
 msgid "Reverse filter"
 msgstr "恢复单个文件"
 
-#: ../treebrowser/src/treebrowser.c:2203
+#: ../treebrowser/src/treebrowser.c:2208
 msgid "Follow current document"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2212
+#: ../treebrowser/src/treebrowser.c:2217
 msgid "Single click, open document and focus it"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2221
+#: ../treebrowser/src/treebrowser.c:2226
 #, fuzzy
 msgid "Double click open directory"
 msgstr "显示目录差异"
 
-#: ../treebrowser/src/treebrowser.c:2230
+#: ../treebrowser/src/treebrowser.c:2235
 msgid "On delete file, close it if is opened"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2239
+#: ../treebrowser/src/treebrowser.c:2244
 msgid "Focus editor on file open"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2248
+#: ../treebrowser/src/treebrowser.c:2253
 #, fuzzy
 msgid "Show tree lines"
 msgstr "显示工具提示。"
 
-#: ../treebrowser/src/treebrowser.c:2257
+#: ../treebrowser/src/treebrowser.c:2262
 #, fuzzy
 msgid "Show bookmarks"
 msgstr "书签"
 
-#: ../treebrowser/src/treebrowser.c:2266
+#: ../treebrowser/src/treebrowser.c:2271
 #, fuzzy
 msgid "Open new files"
 msgstr "打开文件"
 
-#: ../treebrowser/src/treebrowser.c:2350
+#: ../treebrowser/src/treebrowser.c:2355
 #, fuzzy
 msgid "Focus File List"
 msgstr "焦点书签列表"
 
-#: ../treebrowser/src/treebrowser.c:2352
+#: ../treebrowser/src/treebrowser.c:2357
 msgid "Focus Path Entry"
 msgstr ""
 
-#: ../treebrowser/src/treebrowser.c:2354
+#: ../treebrowser/src/treebrowser.c:2359
 #, fuzzy
 msgid "Rename Object"
 msgstr "文件名："
 
-#: ../treebrowser/src/treebrowser.c:2358
+#: ../treebrowser/src/treebrowser.c:2363
 #, fuzzy
 msgid "New Folder"
 msgstr "选择颜色"
 
-#: ../treebrowser/src/treebrowser.c:2362
+#: ../treebrowser/src/treebrowser.c:2367
 #, fuzzy
 msgid "Track Current"
 msgstr "根目录："
@@ -8620,12 +8390,6 @@ msgstr "目录(_D)"
 msgid "No workbench opened."
 msgstr ""
 
-#: ../workbench/src/sidebar.c:875
-#, fuzzy, c-format
-msgid "%s: %u Project"
-msgid_plural "%s: %u Projects"
-msgstr[0] "项目"
-
 #: ../workbench/src/sidebar.c:886
 msgid ""
 "Add a project using the context menu\n"
@@ -8731,6 +8495,37 @@ msgstr ""
 #: ../xmlsnippets/src/plugin.c:45
 msgid "Autocompletes XML/HTML tags using snippets."
 msgstr ""
+
+#, fuzzy
+#~ msgid "_Removed lines:"
+#~ msgstr "移除文件"
+
+#, fuzzy
+#~ msgid "Position on left"
+#~ msgstr "Edition"
+
+#, fuzzy
+#~ msgid "Hide tooltip"
+#~ msgstr "显示工具提示。"
+
+#, fuzzy
+#~ msgid "Outline Color:"
+#~ msgstr "选择颜色"
+
+#, fuzzy
+#~ msgid "_Show stats"
+#~ msgstr "显示状态"
+
+#~ msgid "Toggle Check While Typing"
+#~ msgstr "开关输入时的拼写检查"
+
+#~ msgid "Check spelling while typing"
+#~ msgstr "输入时进行拼写检查"
+
+#, fuzzy, c-format
+#~ msgid "%s: %u Project"
+#~ msgid_plural "%s: %u Projects"
+#~ msgstr[0] "项目"
 
 #, fuzzy
 #~ msgid "GeanyLaTeX"

--- a/treebrowser/src/treebrowser.c
+++ b/treebrowser/src/treebrowser.c
@@ -2125,6 +2125,7 @@ plugin_configure(GtkDialog *dialog)
 	gtk_misc_set_alignment(GTK_MISC(label), 0, 0.5);
 #endif
 	gtk_widget_set_tooltip_text(configure_widgets.OPEN_EXTERNAL_CMD,
+		/* xgettext:no-c-format, %d/%f are displayed as-is */
 		_("The command to execute when using \"Open with\". You can use %f and %d wildcards.\n"
 		  "%f will be replaced with the filename including full path\n"
 		  "%d will be replaced with the path name of the selected file without the filename"));


### PR DESCRIPTION
Standard gettext should be used over glib's glue these days.
AM_GLIB_GNU_GETTEXT and glib-gettextize are deprecated. This helps
possible meson build (no concrete plans yet) as well as working with
intltool is harder over there. gettext, on the other hand, is supported
out of the box in meson.

Beware, autopoint is a new dependency when building from git,
should not affect tarballs. Also, it's already required by Geany core.

Additionally, autogen.sh follows Geany's autogen.sh more closely,
allowing for out-of-tree builds.
