### PR TITLE
scope: Use 0 instead of NULL for gboolean

### DIFF
--- a/scope/src/stack.c
+++ b/scope/src/stack.c
@@ -165,7 +165,7 @@ void on_stack_follow(GArray *nodes)
 gboolean stack_entry(void)
 {
 	GtkTreeIter iter;
-	gboolean entry = NULL;
+	gboolean entry = FALSE;
 
 	if (gtk_tree_selection_get_selected(selection, NULL, &iter))
 	{


### PR DESCRIPTION
Fixes warnings with clang 15+

scope/src/stack.c:168:11: error: incompatible pointer to integer conversion initializing 'gboolean' (aka 'int') with an expression of type 'void *' [-Wint-conversion]
        gboolean entry = NULL;
                 ^       ~~~~
1 error generated.

Signed-off-by: Khem Raj <raj.khem@gmail.com>