### PR TITLE
geanygendoc: Remove all sanity checks testing if tag is tm_tag_file_t

### DIFF
--- a/geanygendoc/src/ggd.c
+++ b/geanygendoc/src/ggd.c
@@ -529,7 +529,7 @@ ggd_insert_comment (GeanyDocument  *doc,
     tag_array = doc->tm_file->tags_array;
     tag = ggd_tag_find_from_line (tag_array, line + 1 /* it is a SCI line */);
   }
-  if (! tag || (tag->type & tm_tag_file_t)) {
+  if (! tag) {
     msgwin_status_add (_("No valid tag at line %d."), line);
   } else {
     if (get_config (doc, doc_type, &filetype, &doctype)) {


### PR DESCRIPTION
tm_tag_file_t has never been used by Geany so the check is unnecessary.
In the latest version of Geany this tag was renamed to tm_tag_local_var_t
and used for local variables which breaks compilation.

Those things that appear as big diffs on github are just unindents after the removed `if` check.