### PR TITLE
Add --library=gtk to cppcheck

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,8 @@
 ACLOCAL_AMFLAGS = -I build/cache -I build -I build/bundled -I geanypy/m4 --install
 AM_DISTCHECK_CONFIGURE_FLAGS = --with-geany-libdir='$${libdir}'
 
+EXTRA_DIST = build/cppcheck-geany-plugins.cfg
+
 SUBDIRS = po
 
 if ENABLE_UTILSLIB

--- a/build/cppcheck-geany-plugins.cfg
+++ b/build/cppcheck-geany-plugins.cfg
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<def format="2">
+  <define name="G_DEFINE_TYPE(TN, t_n, T_P)" value=""/>
+  <define name="G_DEFINE_BOXED_TYPE(TypeName,type_name,copy_func,free_func)" value=""/>
+</def>

--- a/build/cppcheck.mk
+++ b/build/cppcheck.mk
@@ -4,6 +4,7 @@ if HAVE_CPPCHECK
 check-cppcheck: $(srcdir)
 	$(CPPCHECK) \
 		-q --template gcc --error-exitcode=2 \
+		--library=$(top_srcdir)/build/cppcheck-geany-plugins.cfg \
 		-I$(GEANY_INCLUDEDIR)/geany \
 		$(AM_CPPCHECKFLAGS) $(CPPCHECKFLAGS) \
 		$(srcdir)

--- a/codenav/src/goto_file.c
+++ b/codenav/src/goto_file.c
@@ -151,7 +151,7 @@ directory_check(GtkEntry* entry, GtkEntryCompletion* completion)
     static GtkTreeModel *old_model = NULL;
    	GtkTreeModel* completion_list;
     static gchar *curr_dir = NULL;
-    gchar *new_dir, *new_dir_path; 
+    gchar *new_dir, *new_dir_path = NULL; 
     const gchar *text;
     
     text = gtk_entry_get_text(entry);
@@ -174,8 +174,10 @@ directory_check(GtkEntry* entry, GtkEntryCompletion* completion)
     new_dir = g_strndup (text, dir_sep+1);
     /* I've already inserted new model completion for sub-dir elements? */
     if ( g_strcmp0 (new_dir, curr_dir) == 0 )
+    {
+        g_free(new_dir);
         return;
-
+    }
     if ( curr_dir != NULL )
         g_free(curr_dir);
 
@@ -188,7 +190,7 @@ directory_check(GtkEntry* entry, GtkEntryCompletion* completion)
     log_debug("New completion list!");
 
     if ( g_path_is_absolute(new_dir) )
-        new_dir_path = new_dir;
+        new_dir_path = g_strdup(new_dir);
     else
         new_dir_path = g_build_filename(directory_ref, new_dir, NULL);
 
@@ -196,6 +198,8 @@ directory_check(GtkEntry* entry, GtkEntryCompletion* completion)
     completion_list = build_file_list(new_dir_path, new_dir);
   	gtk_entry_completion_set_model (completion, completion_list);
     g_object_unref(completion_list);
+
+    g_free(new_dir_path);
 }
 
 

--- a/debugger/src/dbm_gdb.c
+++ b/debugger/src/dbm_gdb.c
@@ -761,6 +761,7 @@ static gboolean run(const gchar* file, const gchar* commandline, GList* env, GLi
 		{
 			colorize_message((gchar*)iter->data);
 		}
+		g_free(unescaped);
 	}
 	g_list_foreach(lines, (GFunc)g_free, NULL);
 	g_list_free(lines);

--- a/debugger/src/debug.c
+++ b/debugger/src/debug.c
@@ -1101,6 +1101,8 @@ void debug_init(void)
 	gtk_text_buffer_create_tag(buffer, "yellow", "foreground", "#FFFF00", NULL);
 	gtk_text_buffer_create_tag(buffer, "brown", "foreground", "#BB8915", NULL);
 	gtk_text_buffer_create_tag(buffer, "rose", "foreground", "#BA92B7", NULL);
+
+	g_free(configfile);
 }
 
 /*

--- a/geanyvc/src/utils.c
+++ b/geanyvc/src/utils.c
@@ -43,7 +43,10 @@ normpath(const gchar * filename)
 		return g_strdup(".");
 	v = g_strsplit_set(filename, "/\\", -1);
 	if (!g_strv_length(v))
+	{
+		g_strfreev(v);
 		return g_strdup(".");
+	}
 
 	out = g_malloc0(sizeof(gchar *) * (g_strv_length(v) + 2));
 	pout = out;

--- a/geniuspaste/src/geniuspaste.c
+++ b/geniuspaste/src/geniuspaste.c
@@ -102,6 +102,10 @@ PLUGIN_SET_TRANSLATABLE_INFO(LOCALEDIR, GETTEXT_PACKAGE, PLUGIN_NAME,
                              PLUGIN_VERSION, "Enrico Trotta <enrico.trt@gmail.com>")
 
 
+static void show_msgbox(GtkMessageType type, GtkButtonsType buttons,
+                        const gchar *main_text,
+                        const gchar *secondary_markup, ...) G_GNUC_PRINTF (4, 5);
+
 static void pastebin_free(Pastebin *pastebin)
 {
     g_key_file_free(pastebin->config);
@@ -715,7 +719,6 @@ static void message_dialog_label_set_url_hook(GtkWidget *widget, gpointer data)
     }
 }
 
-G_GNUC_PRINTF (4, 5)
 static void show_msgbox(GtkMessageType type, GtkButtonsType buttons,
                         const gchar *main_text,
                         const gchar *secondary_markup, ...)

--- a/latex/src/latex.c
+++ b/latex/src/latex.c
@@ -599,7 +599,7 @@ static gboolean on_editor_notify(G_GNUC_UNUSED GObject *object, GeanyEditor *edi
 					{
 						gchar *buf, *construct;
 						/* TODO: Make possible to have longer than a 50 chars environment */
-						gchar env[50];
+						gchar env[50] = { 0 };
 						gint line = sci_get_line_from_position(sci, pos - (editor_get_eol_char_len (editor) + 1));
 						gint line_len = sci_get_line_length(sci, line);
 						gint i, start;

--- a/treebrowser/src/treebrowser.c
+++ b/treebrowser/src/treebrowser.c
@@ -362,23 +362,39 @@ check_hidden(const gchar *filename)
 	base_name = g_path_get_basename(filename);
 
 	if (EMPTY(base_name))
+	{
+		g_free(base_name);
 		return FALSE;
+	}
 
 	if (CONFIG_SHOW_HIDDEN_FILES)
+	{
+		g_free(base_name);
 		return FALSE;
+	}
 
 #ifdef G_OS_WIN32
 	if (win32_check_hidden(filename))
+	{
+		g_free(base_name);
 		return TRUE;
+	}
 #else
 	if (base_name[0] == '.')
+	{
+		g_free(base_name);
 		return TRUE;
+	}
 #endif
 
 	len = strlen(base_name);
 	if (base_name[len - 1] == '~')
+	{
+		g_free(base_name);
 		return TRUE;
+	}
 
+	g_free(base_name);
 	return FALSE;
 }
 

--- a/workbench/src/sidebar.c
+++ b/workbench/src/sidebar.c
@@ -447,6 +447,7 @@ static void sidebar_add_file (WB_PROJECT *prj, WB_PROJECT_DIR *root, const gchar
 	{
 		g_object_unref(icon);
 	}
+	g_free(name);
 }
 
 
@@ -550,11 +551,14 @@ static gboolean sidebar_get_filepath_iter (WB_PROJECT *prj, WB_PROJECT_DIR *root
 	part = g_strdup(&(filepath[len]));
 	if (strlen(part) == 0)
 	{
+		g_free(part);
 		return FALSE;
 	}
 	parts = g_strsplit(part, G_DIR_SEPARATOR_S, -1);
 	if (parts[0] == NULL)
 	{
+		g_free(part);
+		g_strfreev(parts);
 		return FALSE;
 	}
 

--- a/workbench/src/wb_project.c
+++ b/workbench/src/wb_project.c
@@ -1246,12 +1246,13 @@ gchar *wb_project_dir_get_info (WB_PROJECT_DIR *dir)
  **/
 gchar *wb_project_get_info (WB_PROJECT *prj)
 {
-	GString *temp = g_string_new(NULL);
+	GString *temp = NULL;
 	gchar *text;
 
 	if (prj == NULL)
 		return g_strdup("");
 
+	temp = g_string_new(NULL);
 	g_string_append_printf(temp, _("Project: %s\n"), wb_project_get_name(prj));
 	g_string_append_printf(temp, _("File: %s\n"), wb_project_get_filename(prj));
 	g_string_append_printf(temp, _("Number of Directories: %u\n"), g_slist_length(prj->directories));


### PR DESCRIPTION
Recent versions of cppcheck (2.9+) seem to require this configuration. The gtk.cfg configuration file is part of cppcheck itself.

Closes #1196.