### PR TITLE
Remove self as maintainer for treebrowser plugin

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -286,11 +286,11 @@ W: http://plugins.geany.org/tableconvert.html
 S: Maintained
 
 treebrowser
-P: Adam Dingle <adam@medovina.org>
-g: @medovina
-M: Adam Dingle <adam@medovina.org>
+P:
+g:
+M:
 W: http://plugins.geany.org/treebrowser.html
-S: Maintained
+S: Orphaned
 
 updatechecker
 P: Frank Lanitz <frank@frank.uvena.de>


### PR DESCRIPTION
I no longer use Geany, so I cannot maintain the treebrowser plugin.  Best of luck to anyone who wishes to continue its development.