### PR TITLE
GeanyLua: Use luaL_register instead of luaL_openlib

### DIFF
--- a/geanylua/glspi_kfile.c
+++ b/geanylua/glspi_kfile.c
@@ -395,8 +395,8 @@ static gint luaopen_keyfile(lua_State *L)
 	lua_pushstring(L,"__gc");
 	lua_pushcfunction(L,kfile_done);
 	lua_rawset(L,-3);
-	luaL_openlib(L, NULL, &kfile_funcs[1], 0);
-	luaL_openlib(L, LUA_MODULE_NAME, kfile_funcs, 0);
+	luaL_register(L, NULL, &kfile_funcs[1]);
+	luaL_register(L, LUA_MODULE_NAME, kfile_funcs);
 	return 0;
 }
 

--- a/geanylua/glspi_run.c
+++ b/geanylua/glspi_run.c
@@ -393,7 +393,7 @@ static void show_error(lua_State *L, const gchar *script_file)
 
 static gint glspi_init_module(lua_State *L, const gchar *script_file, gint caller, GKeyFile*proj, const gchar*script_dir)
 {
-	luaL_openlib(L, LUA_MODULE_NAME, glspi_timer_funcs, 0);
+	luaL_register(L, LUA_MODULE_NAME, glspi_timer_funcs);
 	glspi_init_sci_funcs(L);
 	glspi_init_doc_funcs(L);
 	glspi_init_mnu_funcs(L);

--- a/geanylua/gsdlg_lua.c
+++ b/geanylua/gsdlg_lua.c
@@ -425,8 +425,8 @@ gint luaopen_dialog(lua_State *L)
 	lua_pushcfunction(L,gsdl_done);
 	lua_rawset(L,-3);
 
-	luaL_openlib(L, NULL, &gsdl_funcs[1], 0);
-	luaL_openlib(L, LUA_MODULE_NAME, gsdl_funcs, 0);
+	luaL_register(L, NULL, &gsdl_funcs[1]);
+	luaL_register(L, LUA_MODULE_NAME, gsdl_funcs);
 	return 0;
 }
 


### PR DESCRIPTION
With GCC 11.3:

warning: implicit declaration of function ‘luaL_openlib’; did you mean ‘luaI_openlib’? [-Wimplicit-function-declaration]

Lua 5.1 replaced luaL_openlib with luaL_register

https://www.lua.org/manual/5.1/manual.html#7.3