### PR TITLE
Addons: Fix Wordwrap wrong keybinding use

### DIFF
--- a/addons/src/addons.c
+++ b/addons/src/addons.c
@@ -46,18 +46,6 @@ GeanyPlugin		*geany_plugin = NULL;
 GeanyData		*geany_data = NULL;
 
 
-/* Keybinding(s) */
-enum
-{
-	KB_FOCUS_BOOKMARK_LIST,
-	KB_FOCUS_TASKS,
-	KB_UPDATE_TASKS,
-	KB_XMLTAGGING,
-	KB_COPYFILEPATH,
-	KB_COUNT
-};
-
-
 typedef struct
 {
 	/* general settings */
@@ -137,7 +125,7 @@ static gboolean ao_editor_notify_cb(GObject *object, GeanyEditor *editor,
 							 SCNotification *nt, gpointer data)
 {
 	ao_bookmark_list_update_marker(ao_info->bookmarklist, editor, nt);
-	
+
 	ao_mark_editor_notify(ao_info->markword, editor, nt);
 
 	ao_color_tip_editor_notify(ao_info->colortip, editor, nt);

--- a/addons/src/addons.h
+++ b/addons/src/addons.h
@@ -25,6 +25,17 @@
 #ifndef ADDONS_H
 #define ADDONS_H 1
 
+/* Keybinding(s) */
+enum
+{
+	KB_FOCUS_BOOKMARK_LIST,
+	KB_FOCUS_TASKS,
+	KB_UPDATE_TASKS,
+	KB_XMLTAGGING,
+	KB_COPYFILEPATH,
+	KB_COUNT
+};
+
 
 extern GeanyPlugin		*geany_plugin;
 extern GeanyData		*geany_data;

--- a/addons/src/ao_wrapwords.c
+++ b/addons/src/ao_wrapwords.c
@@ -64,7 +64,7 @@ void enclose_text_action (guint key_id)
 	if (sci_get_selected_text_length (sci_obj) < 2)
 		return;
 
-	key_id -= 4;
+	key_id -= KB_COUNT;
 	selection_end = sci_get_selection_end (sci_obj);
 
 	sci_start_undo_action (sci_obj);


### PR DESCRIPTION
Instead of hardcoding the count of previously defined keybindings in the Addons plugin, use the already available enum counter.

While testing #1182, I noticed that there is a mismatch between the pressed keybinding with the configured replacement. The Wordwrap plugin had the keybinding count of all keybindings of the Addons plugin hardcoded and of course it changed since then but the hardcoded magic number was not updated.

Instead of hardcoding, use the enum counter constant.