### PR TITLE
webhelper: Port to webkit2gtk

### DIFF
--- a/build/webhelper.m4
+++ b/build/webhelper.m4
@@ -19,7 +19,7 @@ AC_DEFUN([GP_CHECK_WEBHELPER],
         fi
     fi
 
-    GP_CHECK_GTK3([webkit_package=webkitgtk-3.0],
+    GP_CHECK_GTK3([webkit_package=webkit2gtk-4.0],
                   [webkit_package=webkit-1.0])
     GP_CHECK_PLUGIN_DEPS([WebHelper], [WEBHELPER],
                          [$GP_GTK_PACKAGE >= ${GTK_VERSION}

--- a/build/webhelper.m4
+++ b/build/webhelper.m4
@@ -19,14 +19,13 @@ AC_DEFUN([GP_CHECK_WEBHELPER],
         fi
     fi
 
-    GP_CHECK_GTK3([webkit_package=webkit2gtk-4.0],
-                  [webkit_package=webkit-1.0])
+    GP_CHECK_PLUGIN_GTK3_ONLY([webhelper])
     GP_CHECK_PLUGIN_DEPS([WebHelper], [WEBHELPER],
                          [$GP_GTK_PACKAGE >= ${GTK_VERSION}
                           glib-2.0 >= ${GLIB_VERSION}
                           gio-2.0 >= ${GIO_VERSION}
                           gdk-pixbuf-2.0 >= ${GDK_PIXBUF_VERSION}
-                          $webkit_package >= ${WEBKIT_VERSION}
+                          webkit2gtk-4.0 >= ${WEBKIT_VERSION}
                           gthread-2.0])
 
 

--- a/webhelper/src/Makefile.am
+++ b/webhelper/src/Makefile.am
@@ -34,7 +34,8 @@ webhelper_la_CPPFLAGS = $(AM_CPPFLAGS) \
 webhelper_la_CFLAGS   = $(AM_CFLAGS) \
                         $(WEBHELPER_CFLAGS)
 webhelper_la_LIBADD   = $(COMMONLIBS) \
-                        $(WEBHELPER_LIBS)
+                        $(WEBHELPER_LIBS) \
+                        -lm
 
 # These are generated in $(srcdir) because they are part of the distribution,
 # and should anyway only be regenerated if the .tpl changes, which is a

--- a/webhelper/src/gwh-browser.c
+++ b/webhelper/src/gwh-browser.c
@@ -400,7 +400,7 @@ on_web_view_context_menu (WebKitWebView       *view,
   WebKitContextMenuItem    *item;
   WebKitContextMenu        *submenu;
   GSimpleAction            *action;
-  GVariant                 *action_state;
+  gboolean                  zoom_text_only;
 
   webkit_context_menu_append (context_menu,
                               webkit_context_menu_item_new_separator ());
@@ -442,21 +442,15 @@ on_web_view_context_menu (WebKitWebView       *view,
   /* full content zoom */
   webkit_context_menu_append (submenu,
                               webkit_context_menu_item_new_separator ());
-  action_state = g_variant_new_boolean (
-    !webkit_settings_get_zoom_text_only (webkit_web_view_get_settings (view)));
-
-  action = g_simple_action_new_stateful (
-    "full-content-zoom",
-    NULL,
-    action_state
-  );
+  zoom_text_only = webkit_settings_get_zoom_text_only (webkit_web_view_get_settings (view));
+  action = g_simple_action_new_stateful ("full-content-zoom", NULL,
+                                         g_variant_new_boolean (!zoom_text_only));
+  g_signal_connect (action, "activate",
+                    G_CALLBACK (on_item_full_content_zoom_activate), self);
   item = webkit_context_menu_item_new_from_gaction (G_ACTION (action),
                                                     _("Full-_content zoom"),
                                                     NULL);
-  g_simple_action_set_enabled (action, TRUE);
   webkit_context_menu_append (submenu, item);
-  g_signal_connect (action, "activate",
-                    G_CALLBACK (on_item_full_content_zoom_activate), self);
   g_object_unref (action);
 
   g_signal_emit (self, signals[POPULATE_POPUP], 0, context_menu);

--- a/webhelper/src/gwh-browser.c
+++ b/webhelper/src/gwh-browser.c
@@ -417,6 +417,7 @@ on_web_view_context_menu (WebKitWebView       *view,
   item = webkit_context_menu_item_new_from_gaction (G_ACTION (action),
                                                     _("Zoom _In"), NULL);
   webkit_context_menu_append (submenu, item);
+  g_object_unref (action);
 
   /* zoom out */
   action = g_simple_action_new ("zoom-out", NULL);
@@ -425,6 +426,7 @@ on_web_view_context_menu (WebKitWebView       *view,
   item = webkit_context_menu_item_new_from_gaction (G_ACTION (action),
                                                     _("Zoom _Out"), NULL);
   webkit_context_menu_append (submenu, item);
+  g_object_unref (action);
 
   /* zoom 1:1 */
   webkit_context_menu_append (submenu,
@@ -435,6 +437,7 @@ on_web_view_context_menu (WebKitWebView       *view,
   item = webkit_context_menu_item_new_from_gaction (G_ACTION (action),
                                                     _("_Reset Zoom"), NULL);
   webkit_context_menu_append (submenu, item);
+  g_object_unref (action);
 
   /* full content zoom */
   webkit_context_menu_append (submenu,
@@ -454,6 +457,7 @@ on_web_view_context_menu (WebKitWebView       *view,
   webkit_context_menu_append (submenu, item);
   g_signal_connect (action, "activate",
                     G_CALLBACK (on_item_full_content_zoom_activate), self);
+  g_object_unref (action);
 
   g_signal_emit (self, signals[POPULATE_POPUP], 0, context_menu);
 

--- a/webhelper/src/gwh-browser.c
+++ b/webhelper/src/gwh-browser.c
@@ -238,9 +238,6 @@ on_settings_wm_windows_type_notify (GObject    *object,
 
 /* web inspector events handling */
 
-#define INSPECTOR_DETACHED(self) \
-  (webkit_web_inspector_is_attached ((self)->priv->inspector))
-
 #define INSPECTOR_VISIBLE(self) \
   (webkit_web_inspector_get_web_view ((self)->priv->inspector) != NULL)
 
@@ -560,16 +557,15 @@ on_web_view_context_menu (WebKitWebView       *view,
   webkit_context_menu_append (context_menu,
                               webkit_context_menu_item_new_separator ());
   action = g_simple_action_new ("flip-panes", NULL);
-  g_signal_connect_swapped (action, "activate",
-                            G_CALLBACK (on_item_flip_orientation_activate),
-                            view);
+  g_signal_connect (action, "activate",
+                    G_CALLBACK (on_item_flip_orientation_activate),
+                    self);
   item = webkit_context_menu_item_new_from_gaction (G_ACTION (action),
                                                     _("_Flip panes orientation"),
                                                     NULL);
   webkit_context_menu_append (context_menu, item);
-  if (! INSPECTOR_VISIBLE (self) || INSPECTOR_DETACHED (self)) {
-    g_simple_action_set_enabled (action, FALSE);
-  }
+  g_simple_action_set_enabled (action, (INSPECTOR_VISIBLE (self) &&
+                                        webkit_web_inspector_is_attached (self->priv->inspector)));
 
   g_signal_emit (self, signals[POPULATE_POPUP], 0, context_menu);
 

--- a/webhelper/src/gwh-browser.c
+++ b/webhelper/src/gwh-browser.c
@@ -938,6 +938,19 @@ url_completion_match_func (GtkEntryCompletion  *comp,
   return match;
 }
 
+static GtkToolItem *
+tool_button_new (const gchar *mnemonic,
+                 const gchar *icon_name,
+                 const gchar *tooltip)
+{
+  return g_object_new (GTK_TYPE_TOOL_BUTTON,
+                       "use-underline", TRUE,
+                       "label", mnemonic,
+                       "icon-name", icon_name,
+                       "tooltip-text", tooltip,
+                       NULL);
+}
+
 static GtkWidget *
 create_toolbar (GwhBrowser *self)
 {
@@ -950,20 +963,20 @@ create_toolbar (GwhBrowser *self)
                           "toolbar-style", GTK_TOOLBAR_ICONS,
                           NULL);
   
-  self->priv->item_prev = gtk_tool_button_new_from_stock (GTK_STOCK_GO_BACK);
-  gtk_tool_item_set_tooltip_text (self->priv->item_prev, _("Back"));
+  self->priv->item_prev = tool_button_new (_("_Back"), "go-previous",
+                                           _("Go back"));
   gtk_toolbar_insert (GTK_TOOLBAR (toolbar), self->priv->item_prev, -1);
   gtk_widget_show (GTK_WIDGET (self->priv->item_prev));
-  self->priv->item_next = gtk_tool_button_new_from_stock (GTK_STOCK_GO_FORWARD);
-  gtk_tool_item_set_tooltip_text (self->priv->item_next, _("Forward"));
+  self->priv->item_next = tool_button_new (_("_Forward"), "go-next",
+                                           _("Go forward"));
   gtk_toolbar_insert (GTK_TOOLBAR (toolbar), self->priv->item_next, -1);
   gtk_widget_show (GTK_WIDGET (self->priv->item_next));
-  self->priv->item_cancel = gtk_tool_button_new_from_stock (GTK_STOCK_CANCEL);
-  gtk_tool_item_set_tooltip_text (self->priv->item_cancel, _("Cancel loading"));
+  self->priv->item_cancel = tool_button_new (_("_Cancel"), "process-stop",
+                                             _("Cancel loading"));
   gtk_toolbar_insert (GTK_TOOLBAR (toolbar), self->priv->item_cancel, -1);
   /* don't show cancel */
-  self->priv->item_reload = gtk_tool_button_new_from_stock (GTK_STOCK_REFRESH);
-  gtk_tool_item_set_tooltip_text (self->priv->item_reload, _("Reload current page"));
+  self->priv->item_reload = tool_button_new (_("_Refresh"), "view-refresh",
+                                             _("Reload current page"));
   gtk_toolbar_insert (GTK_TOOLBAR (toolbar), self->priv->item_reload, -1);
   gtk_widget_show (GTK_WIDGET (self->priv->item_reload));
   
@@ -987,9 +1000,12 @@ create_toolbar (GwhBrowser *self)
   gtk_entry_completion_set_match_func (comp, url_completion_match_func, NULL, NULL);
   gtk_entry_set_completion (GTK_ENTRY (self->priv->url_entry), comp);
   
-  self->priv->item_inspector = gtk_toggle_tool_button_new_from_stock (GTK_STOCK_INFO);
-  gtk_tool_button_set_label (GTK_TOOL_BUTTON (self->priv->item_inspector), _("Web inspector"));
-  gtk_tool_item_set_tooltip_text (self->priv->item_inspector, _("Toggle web inspector"));
+  self->priv->item_inspector = g_object_new (GTK_TYPE_TOGGLE_TOOL_BUTTON,
+                                             "use-underline", TRUE,
+                                             "label", _("Web _Inspector"),
+                                             "tooltip-text", _("Toggle web inspector"),
+                                             "icon-name", "dialog-information",
+                                             NULL);
   gtk_toolbar_insert (GTK_TOOLBAR (toolbar), self->priv->item_inspector, -1);
   gtk_widget_show (GTK_WIDGET (self->priv->item_inspector));
   

--- a/webhelper/src/gwh-browser.c
+++ b/webhelper/src/gwh-browser.c
@@ -654,7 +654,7 @@ on_web_view_context_menu (WebKitWebView       *view,
 {
   WebKitContextMenuItem    *item;
   WebKitContextMenu        *submenu;
-  GAction                  *action;
+  GSimpleAction            *action;
   GVariant                 *action_state;
 
   webkit_context_menu_append (context_menu,
@@ -669,16 +669,16 @@ on_web_view_context_menu (WebKitWebView       *view,
   action = g_simple_action_new ("zoom-in", NULL);
   g_signal_connect_swapped (action, "activate",
                             G_CALLBACK (web_view_zoom_in), view);
-  item = webkit_context_menu_item_new_from_gaction (action, _("Zoom _In"),
-                                                    NULL);
+  item = webkit_context_menu_item_new_from_gaction (G_ACTION (action),
+                                                    _("Zoom _In"), NULL);
   webkit_context_menu_append (submenu, item);
 
   /* zoom out */
   action = g_simple_action_new ("zoom-out", NULL);
   g_signal_connect_swapped (action, "activate",
                             G_CALLBACK (web_view_zoom_out), view);
-  item = webkit_context_menu_item_new_from_gaction (action, _("Zoom _Out"),
-                                                    NULL);
+  item = webkit_context_menu_item_new_from_gaction (G_ACTION (action),
+                                                    _("Zoom _Out"), NULL);
   webkit_context_menu_append (submenu, item);
 
   /* zoom 1:1 */
@@ -687,8 +687,8 @@ on_web_view_context_menu (WebKitWebView       *view,
   action = g_simple_action_new ("zoom-reset", NULL);
   g_signal_connect_swapped (action, "activate",
                             G_CALLBACK (on_item_zoom_100_activate), view);
-  item = webkit_context_menu_item_new_from_gaction (action, _("_Reset Zoom"),
-                                                    NULL);
+  item = webkit_context_menu_item_new_from_gaction (G_ACTION (action),
+                                                    _("_Reset Zoom"), NULL);
   webkit_context_menu_append (submenu, item);
 
   /* full content zoom */
@@ -702,7 +702,7 @@ on_web_view_context_menu (WebKitWebView       *view,
     NULL,
     action_state
   );
-  item = webkit_context_menu_item_new_from_gaction (action,
+  item = webkit_context_menu_item_new_from_gaction (G_ACTION (action),
                                                     _("Full-_content zoom"),
                                                     NULL);
   g_simple_action_set_enabled (action, TRUE);
@@ -717,8 +717,9 @@ on_web_view_context_menu (WebKitWebView       *view,
   g_signal_connect_swapped (action, "activate",
                             G_CALLBACK (on_item_flip_orientation_activate),
                             view);
-  item = webkit_context_menu_item_new_from_gaction (
-    action, _("_Flip panes orientation"), NULL);
+  item = webkit_context_menu_item_new_from_gaction (G_ACTION (action),
+                                                    _("_Flip panes orientation"),
+                                                    NULL);
   webkit_context_menu_append (context_menu, item);
   if (! INSPECTOR_VISIBLE (self) || INSPECTOR_DETACHED (self)) {
     g_simple_action_set_enabled (action, FALSE);

--- a/webhelper/src/gwh-browser.c
+++ b/webhelper/src/gwh-browser.c
@@ -1124,6 +1124,7 @@ gwh_browser_init (GwhBrowser *self)
 {
   GtkWidget          *scrolled;
   WebKitSettings     *wkws;
+  WebKitWebContext   *wkcontext;
   gboolean            inspector_detached;
   
   self->priv = G_TYPE_INSTANCE_GET_PRIVATE (self, GWH_TYPE_BROWSER,
@@ -1134,6 +1135,9 @@ gwh_browser_init (GwhBrowser *self)
   self->priv->web_view = webkit_web_view_new ();
   wkws = webkit_web_view_get_settings (WEBKIT_WEB_VIEW (self->priv->web_view));
   g_object_set (wkws, "enable-developer-extras", TRUE, NULL);
+
+  wkcontext = webkit_web_view_get_context (WEBKIT_WEB_VIEW (self->priv->web_view));
+  webkit_web_context_set_favicon_database_directory (wkcontext, NULL);
   
   self->priv->settings = gwh_settings_get_default ();
   g_object_get (self->priv->settings,

--- a/webhelper/src/gwh-browser.c
+++ b/webhelper/src/gwh-browser.c
@@ -440,7 +440,7 @@ on_web_view_context_menu (WebKitWebView       *view,
   webkit_context_menu_append (submenu,
                               webkit_context_menu_item_new_separator ());
   action_state = g_variant_new_boolean (
-    webkit_settings_get_zoom_text_only (webkit_web_view_get_settings (view)));
+    !webkit_settings_get_zoom_text_only (webkit_web_view_get_settings (view)));
 
   action = g_simple_action_new_stateful (
     "full-content-zoom",

--- a/webhelper/src/gwh-browser.c
+++ b/webhelper/src/gwh-browser.c
@@ -708,7 +708,7 @@ on_web_view_context_menu (WebKitWebView       *view,
   g_simple_action_set_enabled (action, TRUE);
   webkit_context_menu_append (submenu, item);
   g_signal_connect (action, "activate",
-                    on_item_full_content_zoom_activate, self);
+                    G_CALLBACK (on_item_full_content_zoom_activate), self);
 
   /* flip panes orientation */
   webkit_context_menu_append (context_menu,

--- a/webhelper/src/gwh-browser.c
+++ b/webhelper/src/gwh-browser.c
@@ -140,7 +140,7 @@ static void       inspector_set_detached      (GwhBrowser *self,
 
 static void
 set_location_icon (GwhBrowser  *self,
-                   const cairo_surface_t *icon_surface)
+                   cairo_surface_t *icon_surface)
 {
   gboolean success = FALSE;
 
@@ -576,7 +576,7 @@ on_web_view_favicon_notify (GObject    *object,
                             GParamSpec *pspec,
                             GwhBrowser *self)
 {
-  const cairo_surface_t *icon_surface;
+  cairo_surface_t *icon_surface;
   
   icon_surface = webkit_web_view_get_favicon (WEBKIT_WEB_VIEW (self->priv->web_view));
   set_location_icon (self, icon_surface);

--- a/webhelper/src/gwh-browser.c
+++ b/webhelper/src/gwh-browser.c
@@ -1114,18 +1114,24 @@ get_statusbar_context_id (GtkStatusbar *statusbar)
 }
 
 static void
-on_web_view_hovering_over_link (WebKitWebView *view,
-                                gchar         *title,
-                                gchar         *uri,
-                                GwhBrowser    *self)
+on_web_view_mouse_target_changed (WebKitWebView       *view,
+                                  WebKitHitTestResult *hit_test_result,
+                                  guint                modifiers,
+                                  GwhBrowser          *self)
 {
   GtkStatusbar *statusbar = GTK_STATUSBAR (self->priv->statusbar);
-  
+  const gchar *uri;
+
   if (self->priv->hovered_link) {
     gtk_statusbar_pop (statusbar, get_statusbar_context_id (statusbar));
     g_free (self->priv->hovered_link);
     self->priv->hovered_link = NULL;
   }
+
+  if (!webkit_hit_test_result_context_is_link (hit_test_result))
+    return;
+
+  uri = webkit_hit_test_result_get_link_uri (hit_test_result);
   if (uri && *uri) {
     self->priv->hovered_link = g_strdup (uri);
     gtk_statusbar_push (statusbar, get_statusbar_context_id (statusbar),
@@ -1252,8 +1258,8 @@ gwh_browser_init (GwhBrowser *self)
                     G_CALLBACK (on_web_view_context_menu), self);
   g_signal_connect (G_OBJECT (self->priv->web_view), "scroll-event",
                     G_CALLBACK (on_web_view_scroll_event), self);
-  g_signal_connect (G_OBJECT (self->priv->web_view), "hovering-over-link",
-                    G_CALLBACK (on_web_view_hovering_over_link), self);
+  g_signal_connect (G_OBJECT (self->priv->web_view), "mouse-target-changed",
+                    G_CALLBACK (on_web_view_mouse_target_changed), self);
   g_signal_connect (G_OBJECT (self->priv->web_view), "leave-notify-event",
                     G_CALLBACK (on_web_view_leave_notify_event), self);
   g_signal_connect (G_OBJECT (self->priv->web_view), "enter-notify-event",

--- a/webhelper/src/gwh-browser.c
+++ b/webhelper/src/gwh-browser.c
@@ -340,9 +340,9 @@ on_web_view_favicon_notify (GObject    *object,
 }
 
 static void
-on_web_view_progress_notify (GObject    *object,
-                             GParamSpec *pspec,
-                             GwhBrowser *self)
+on_web_view_estimated_load_progress_notify (GObject    *object,
+                                            GParamSpec *pspec,
+                                            GwhBrowser *self)
 {
   gdouble value;
   
@@ -882,8 +882,8 @@ gwh_browser_init (GwhBrowser *self)
   g_signal_connect (self->priv->inspector, "closed",
                     G_CALLBACK (on_inspector_closed), self);
   
-  g_signal_connect (G_OBJECT (self->priv->web_view), "notify::progress",
-                    G_CALLBACK (on_web_view_progress_notify), self);
+  g_signal_connect (G_OBJECT (self->priv->web_view), "notify::estimated-load-progress",
+                    G_CALLBACK (on_web_view_estimated_load_progress_notify), self);
   g_signal_connect (G_OBJECT (self->priv->web_view), "notify::uri",
                     G_CALLBACK (on_web_view_uri_notify), self);
   g_signal_connect (G_OBJECT (self->priv->web_view), "load-changed",

--- a/webhelper/src/gwh-browser.c
+++ b/webhelper/src/gwh-browser.c
@@ -90,10 +90,6 @@ G_DEFINE_TYPE_WITH_CODE (GwhBrowser, gwh_browser, GTK_TYPE_VBOX,
                          G_IMPLEMENT_INTERFACE (GTK_TYPE_ORIENTABLE, NULL))
 
 
-static void       inspector_set_detached      (GwhBrowser *self,
-                                               gboolean    detached);
-
-
 static void
 set_location_icon (GwhBrowser  *self,
                    cairo_surface_t *icon_surface)
@@ -208,17 +204,6 @@ on_settings_inspector_window_geometry_notify (GObject    *object,
 }
 
 static void
-on_settings_inspector_detached_notify (GObject    *object,
-                                       GParamSpec *pspec,
-                                       GwhBrowser *self)
-{
-  gboolean detached;
-  
-  g_object_get (object, pspec->name, &detached, NULL);
-  inspector_set_detached (self, detached);
-}
-
-static void
 on_settings_wm_windows_skip_taskbar_notify (GObject    *object,
                                             GParamSpec *pspec,
                                             GwhBrowser *self)
@@ -254,10 +239,10 @@ on_settings_wm_windows_type_notify (GObject    *object,
 /* web inspector events handling */
 
 #define INSPECTOR_DETACHED(self) \
-  (gtk_bin_get_child (GTK_BIN ((self)->priv->inspector_window)) != NULL)
+  (webkit_web_inspector_is_attached ((self)->priv->inspector))
 
 #define INSPECTOR_VISIBLE(self) \
-  (gtk_widget_get_visible ((self)->priv->inspector_view))
+  (webkit_web_inspector_get_web_view ((self)->priv->inspector) != NULL)
 
 static void
 inspector_set_visible (GwhBrowser *self,
@@ -272,117 +257,22 @@ inspector_set_visible (GwhBrowser *self,
   }
 }
 
-static void
-inspector_hide_window (GwhBrowser *self)
-{
-  if (gtk_widget_get_visible (self->priv->inspector_window)) {
-    gtk_window_get_position (GTK_WINDOW (self->priv->inspector_window),
-                             &self->priv->inspector_window_x,
-                             &self->priv->inspector_window_y);
-    gtk_widget_hide (self->priv->inspector_window);
-  }
-}
-
-static void
-inspector_show_window (GwhBrowser *self)
-{
-  if (! gtk_widget_get_visible (self->priv->inspector_window)) {
-    gtk_widget_show (self->priv->inspector_window);
-    gtk_window_move (GTK_WINDOW (self->priv->inspector_window),
-                     self->priv->inspector_window_x,
-                     self->priv->inspector_window_y);
-  }
-}
-
-static void
-inspector_set_detached (GwhBrowser *self,
-                        gboolean    detached)
-{
-  if (detached != INSPECTOR_DETACHED (self)) {
-    if (detached) {
-      gtk_widget_reparent (self->priv->inspector_view,
-                           self->priv->inspector_window);
-      if (INSPECTOR_VISIBLE (self)) {
-        inspector_show_window (self);
-      }
-    } else {
-      gtk_widget_reparent (self->priv->inspector_view, self->priv->paned);
-      inspector_hide_window (self);
-    }
-    g_object_set (self->priv->settings, "inspector-detached", detached, NULL);
-  }
-}
-
-static WebKitWebView *
-on_inspector_inspect_web_view (WebKitWebInspector *inspector,
-                               WebKitWebView      *view,
-                               GwhBrowser         *self)
-{
-  if (self->priv->inspector_web_view) {
-    gtk_widget_destroy (self->priv->inspector_web_view);
-  }
-  
-  self->priv->inspector_web_view = webkit_web_view_new ();
-  gtk_widget_show (self->priv->inspector_web_view);
-  gtk_container_add (GTK_CONTAINER (self->priv->inspector_view),
-                     self->priv->inspector_web_view);
-  
-  return WEBKIT_WEB_VIEW (self->priv->inspector_web_view);
-}
-
 static gboolean
-on_inspector_show_window (WebKitWebInspector *inspector,
-                          GwhBrowser         *self)
+on_inspector_closed (WebKitWebInspector *inspector,
+                     GwhBrowser         *self)
 {
-  gtk_widget_show (self->priv->inspector_view);
-  if (INSPECTOR_DETACHED (self)) {
-    inspector_show_window (self);
-  }
-  gtk_toggle_tool_button_set_active (GTK_TOGGLE_TOOL_BUTTON (self->priv->item_inspector),
-                                     TRUE);
-  
-  return TRUE;
-}
-
-static gboolean
-on_inspector_close_window (WebKitWebInspector *inspector,
-                           GwhBrowser         *self)
-{
-  gtk_widget_hide (self->priv->inspector_view);
-  inspector_hide_window (self);
   gtk_toggle_tool_button_set_active (GTK_TOGGLE_TOOL_BUTTON (self->priv->item_inspector),
                                      FALSE);
-  gtk_widget_grab_focus (gtk_widget_get_toplevel (self->priv->web_view));
-  
-  return TRUE;
+  return FALSE;
 }
 
 static gboolean
-on_inspector_detach_window (WebKitWebInspector *inspector,
-                            GwhBrowser         *self)
+on_inspector_opened (WebKitWebInspector *inspector,
+                          GwhBrowser         *self)
 {
-  inspector_set_detached (self, TRUE);
-  
-  return TRUE;
-}
-
-static gboolean
-on_inspector_attach_window (WebKitWebInspector *inspector,
-                            GwhBrowser         *self)
-{
-  inspector_set_detached (self, FALSE);
-  
-  return TRUE;
-}
-
-static gboolean
-on_inspector_window_delete_event (GtkWidget  *window,
-                                  GdkEvent   *event,
-                                  GwhBrowser *self)
-{
-  webkit_web_inspector_close (self->priv->inspector);
-  
-  return TRUE;
+  gtk_toggle_tool_button_set_active (GTK_TOGGLE_TOOL_BUTTON (self->priv->item_inspector),
+                                     TRUE);
+  return FALSE;
 }
 
 /* web view events hanlding */
@@ -1039,33 +929,6 @@ create_toolbar (GwhBrowser *self)
   return toolbar;
 }
 
-static GtkWidget *
-create_inspector_window (GwhBrowser *self)
-{
-  gboolean skips_taskbar;
-  gboolean window_type;
-  
-  g_object_get (self->priv->settings,
-                "wm-secondary-windows-skip-taskbar", &skips_taskbar,
-                "wm-secondary-windows-type", &window_type,
-                NULL);
-  self->priv->inspector_window_x = self->priv->inspector_window_y = 0;
-  self->priv->inspector_window = g_object_new (GTK_TYPE_WINDOW,
-                                               "type", GTK_WINDOW_TOPLEVEL,
-                                               "skip-taskbar-hint", skips_taskbar,
-                                               "type-hint", window_type,
-                                               "title", _("Web inspector"),
-                                               NULL);
-  g_signal_connect (self->priv->inspector_window, "delete-event",
-                    G_CALLBACK (on_inspector_window_delete_event), self);
-  g_signal_connect (self->priv->settings, "notify::wm-secondary-windows-skip-taskbar",
-                    G_CALLBACK (on_settings_wm_windows_skip_taskbar_notify), self);
-  g_signal_connect (self->priv->settings, "notify::wm-secondary-windows-type",
-                    G_CALLBACK (on_settings_wm_windows_type_notify), self);
-  
-  return self->priv->inspector_window;
-}
-
 static guint
 get_statusbar_context_id (GtkStatusbar *statusbar)
 {
@@ -1179,7 +1042,6 @@ gwh_browser_init (GwhBrowser *self)
                                   GTK_POLICY_AUTOMATIC, GTK_POLICY_AUTOMATIC);
   self->priv->inspector_web_view = NULL;
   
-  self->priv->inspector_window = create_inspector_window (self);
   gtk_container_add (GTK_CONTAINER (inspector_detached
                                     ? self->priv->inspector_window
                                     : self->priv->paned),
@@ -1198,16 +1060,10 @@ gwh_browser_init (GwhBrowser *self)
                     G_CALLBACK (on_orientation_notify), self);
   
   self->priv->inspector = webkit_web_view_get_inspector (WEBKIT_WEB_VIEW (self->priv->web_view));
-  g_signal_connect (self->priv->inspector, "inspect-web-view",
-                    G_CALLBACK (on_inspector_inspect_web_view), self);
-  g_signal_connect (self->priv->inspector, "show-window",
-                    G_CALLBACK (on_inspector_show_window), self);
-  g_signal_connect (self->priv->inspector, "close-window",
-                    G_CALLBACK (on_inspector_close_window), self);
-  g_signal_connect (self->priv->inspector, "detach-window",
-                    G_CALLBACK (on_inspector_detach_window), self);
-  g_signal_connect (self->priv->inspector, "attach-window",
-                    G_CALLBACK (on_inspector_attach_window), self);
+  g_signal_connect (self->priv->inspector, "bring-to-front",
+                    G_CALLBACK (on_inspector_opened), self);
+  g_signal_connect (self->priv->inspector, "closed",
+                    G_CALLBACK (on_inspector_closed), self);
   
   g_signal_connect (G_OBJECT (self->priv->web_view), "notify::progress",
                     G_CALLBACK (on_web_view_progress_notify), self);
@@ -1245,8 +1101,6 @@ gwh_browser_init (GwhBrowser *self)
                     G_CALLBACK (on_settings_browser_bookmarks_notify), self);
   g_signal_connect (self->priv->settings, "notify::browser-orientation",
                     G_CALLBACK (on_settings_browser_orientation_notify), self);
-  g_signal_connect (self->priv->settings, "notify::inspector-detached",
-                    G_CALLBACK (on_settings_inspector_detached_notify), self);
   g_signal_connect (self->priv->settings, "notify::inspector-window-geometry",
                     G_CALLBACK (on_settings_inspector_window_geometry_notify), self);
 }

--- a/webhelper/src/gwh-browser.h
+++ b/webhelper/src/gwh-browser.h
@@ -56,8 +56,8 @@ struct _GwhBrowserClass
 {
   GtkVBoxClass parent_class;
   
-  void        (*populate_popup)       (GwhBrowser *browser,
-                                       GtkMenu    *menu);
+  void        (*populate_popup)       (GwhBrowser        *browser,
+                                       WebKitContextMenu *menu);
 };
 
 

--- a/webhelper/src/gwh-browser.h
+++ b/webhelper/src/gwh-browser.h
@@ -22,7 +22,7 @@
 
 #include <glib.h>
 #include <gtk/gtk.h>
-#include <webkit/webkit.h>
+#include <webkit2/webkit2.h>
 
 G_BEGIN_DECLS
 

--- a/webhelper/src/gwh-browser.h
+++ b/webhelper/src/gwh-browser.h
@@ -77,11 +77,6 @@ WebKitWebView  *gwh_browser_get_web_view                  (GwhBrowser *self);
 G_GNUC_INTERNAL
 void            gwh_browser_reload                        (GwhBrowser *self);
 G_GNUC_INTERNAL
-void            gwh_browser_set_inspector_transient_for   (GwhBrowser *self,
-                                                           GtkWindow  *window);
-G_GNUC_INTERNAL
-GtkWindow      *gwh_browser_get_inspector_transient_for   (GwhBrowser *self);
-G_GNUC_INTERNAL
 void            gwh_browser_toggle_inspector              (GwhBrowser *self);
 G_GNUC_INTERNAL
 gchar         **gwh_browser_get_bookmarks                 (GwhBrowser *self);

--- a/webhelper/src/gwh-plugin.c
+++ b/webhelper/src/gwh-plugin.c
@@ -250,7 +250,8 @@ on_item_auto_reload_toggled (GAction  *action,
                 "browser-auto-reload", &browser_auto_reload, NULL);
   g_object_set (G_OBJECT (G_settings), "browser-auto-reload",
                 !browser_auto_reload, NULL);
-  g_simple_action_set_state (action, g_variant_new_boolean (browser_auto_reload));
+  g_simple_action_set_state (G_SIMPLE_ACTION (action),
+                             g_variant_new_boolean (browser_auto_reload));
 }
 
 static void
@@ -258,7 +259,7 @@ on_browser_populate_popup (GwhBrowser        *browser,
                            WebKitContextMenu *menu,
                            gpointer           dummy)
 {
-  GAction               *action;
+  GSimpleAction         *action;
   gboolean               auto_reload = FALSE;
   GVariant              *action_state;
   WebKitContextMenuItem *item;
@@ -269,13 +270,11 @@ on_browser_populate_popup (GwhBrowser        *browser,
   g_object_get (G_OBJECT (G_settings), "browser-auto-reload", &auto_reload,
                 NULL);
   action_state = g_variant_new_boolean (auto_reload);
-  action = g_simple_action_new_stateful (
-    "browser-auto-reload",
-    NULL,
-    action_state
-  );
-  item = webkit_context_menu_item_new_from_gaction (
-    action, _("Reload upon document saving"), NULL);
+  action = g_simple_action_new_stateful ("browser-auto-reload",
+                                         NULL, action_state);
+  item = webkit_context_menu_item_new_from_gaction (G_ACTION (action),
+                                                    _("Reload upon document saving"),
+                                                    NULL);
   webkit_context_menu_append (menu, item);
   g_signal_connect (action, "activate",
                     on_item_auto_reload_toggled, NULL);

--- a/webhelper/src/gwh-plugin.c
+++ b/webhelper/src/gwh-plugin.c
@@ -256,7 +256,6 @@ on_browser_populate_popup (GwhBrowser        *browser,
 {
   GSimpleAction         *action;
   gboolean               auto_reload = FALSE;
-  GVariant              *action_state;
   WebKitContextMenuItem *item;
 
   webkit_context_menu_append (menu,
@@ -264,15 +263,14 @@ on_browser_populate_popup (GwhBrowser        *browser,
 
   g_object_get (G_OBJECT (G_settings), "browser-auto-reload", &auto_reload,
                 NULL);
-  action_state = g_variant_new_boolean (auto_reload);
-  action = g_simple_action_new_stateful ("browser-auto-reload",
-                                         NULL, action_state);
+  action = g_simple_action_new_stateful ("browser-auto-reload", NULL,
+                                         g_variant_new_boolean (auto_reload));
+  g_signal_connect (action, "activate",
+                    G_CALLBACK (on_item_auto_reload_toggled), NULL);
   item = webkit_context_menu_item_new_from_gaction (G_ACTION (action),
                                                     _("Reload upon document saving"),
                                                     NULL);
   webkit_context_menu_append (menu, item);
-  g_signal_connect (action, "activate",
-                    G_CALLBACK (on_item_auto_reload_toggled), NULL);
   g_object_unref (action);
 }
 

--- a/webhelper/src/gwh-plugin.c
+++ b/webhelper/src/gwh-plugin.c
@@ -246,7 +246,7 @@ on_item_auto_reload_toggled (GAction  *action,
   g_object_set (G_OBJECT (G_settings), "browser-auto-reload",
                 !browser_auto_reload, NULL);
   g_simple_action_set_state (G_SIMPLE_ACTION (action),
-                             g_variant_new_boolean (browser_auto_reload));
+                             g_variant_new_boolean (!browser_auto_reload));
 }
 
 static void

--- a/webhelper/src/gwh-plugin.c
+++ b/webhelper/src/gwh-plugin.c
@@ -273,6 +273,7 @@ on_browser_populate_popup (GwhBrowser        *browser,
   webkit_context_menu_append (menu, item);
   g_signal_connect (action, "activate",
                     G_CALLBACK (on_item_auto_reload_toggled), NULL);
+  g_object_unref (action);
 }
 
 static void

--- a/webhelper/src/gwh-plugin.c
+++ b/webhelper/src/gwh-plugin.c
@@ -105,7 +105,6 @@ static void
 on_separate_window_destroy (GtkWidget  *widget,
                             gpointer    data)
 {
-  gwh_browser_set_inspector_transient_for (GWH_BROWSER (G_browser), NULL);
   gtk_container_remove (GTK_CONTAINER (G_container.widget), G_browser);
 }
 
@@ -156,8 +155,6 @@ create_separate_window (void)
     gtk_window_set_icon_list (GTK_WINDOW (window), icons);
     g_list_free (icons);
   }
-  gwh_browser_set_inspector_transient_for (GWH_BROWSER (G_browser),
-                                           GTK_WINDOW (window));
   
   return window;
 }
@@ -183,8 +180,6 @@ attach_browser (void)
     }
     gtk_notebook_append_page (GTK_NOTEBOOK (G_container.widget),
                               G_browser, gtk_label_new (_("Web preview")));
-    gwh_browser_set_inspector_transient_for (GWH_BROWSER (G_browser),
-                                             GTK_WINDOW (geany_data->main_widgets->window));
   }
 }
 
@@ -358,12 +353,6 @@ load_config (void)
     "browser-separate-window-geometry",
     _("Browser separate window geometry"),
     _("Last geometry of the separated browser's window"),
-    "400x300",
-    G_PARAM_READWRITE));
-  gwh_settings_install_property (G_settings, g_param_spec_string (
-    "inspector-window-geometry",
-    _("Inspector window geometry"),
-    _("Last geometry of the inspector window"),
     "400x300",
     G_PARAM_READWRITE));
   gwh_settings_install_property (G_settings, g_param_spec_boolean (

--- a/webhelper/src/gwh-plugin.c
+++ b/webhelper/src/gwh-plugin.c
@@ -277,7 +277,7 @@ on_browser_populate_popup (GwhBrowser        *browser,
                                                     NULL);
   webkit_context_menu_append (menu, item);
   g_signal_connect (action, "activate",
-                    on_item_auto_reload_toggled, NULL);
+                    G_CALLBACK (on_item_auto_reload_toggled), NULL);
 }
 
 static void

--- a/webhelper/src/gwh-settings.c
+++ b/webhelper/src/gwh-settings.c
@@ -800,7 +800,7 @@ gwh_settings_widget_new_full (GwhSettings            *self,
       GtkWidget *box;
       gchar     *label;
       
-      box = gtk_hbox_new (FALSE, 6);
+      box = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 6);
       label = g_strdup_printf (_("%s:"), g_param_spec_get_nick (pspec));
       gtk_box_pack_start (GTK_BOX (box), gtk_label_new (label), FALSE, TRUE, 0);
       g_free (label);

--- a/webhelper/src/gwh-settings.c
+++ b/webhelper/src/gwh-settings.c
@@ -29,13 +29,6 @@
 #include <gtk/gtk.h>
 
 
-#if ! GTK_CHECK_VERSION (3, 0, 0)
-/* make gtk_adjustment_new() return a real GtkAdjustment, not a GtkObject */
-# define gtk_adjustment_new(v, l, u, si, pi, ps) \
-  (GtkAdjustment *) (gtk_adjustment_new ((v), (l), (u), (si), (pi), (ps)))
-#endif
-
-
 struct _GwhSettingsPrivate
 {
   GPtrArray *prop_array;


### PR DESCRIPTION
Based off work from @hyperair that was merged at some point in #677, but reverted since then (see there). This adds a couple bits on top to fix some issues, and I believe the "meh no GTK2" whining of mine is lost to time and the fact there's no supported webkit for GTK2 anymore anyway.

BEWARE: this has been given little testing in the 2020s, I just rebased, merged a couple branches to the point there diffed empty, and did some very basic testing (it builds, it runs, and *seems* to work).  Take it, leave it, improve it, comment on it, etc.  I'll be there try not to forget looking at this for any comment though :wink: 

NOTE: it's not at 100% feature-parity with the old version, mostly because of API changes regarding the inspector (II[RU]C, docking settings are not as controllable anymore), yet the inspector itself has seen countless improvements of course.  But again, maybe things have changed since 2018.

See also #1217.