### PR TITLE
GeanyLua: Use luaL_Reg instead of luaL_reg

### DIFF
--- a/geanylua/glspi_app.c
+++ b/geanylua/glspi_app.c
@@ -615,7 +615,7 @@ static gint glspi_reloadconf(lua_State* L)
 
 
 
-static const struct luaL_reg glspi_app_funcs[] = {
+static const struct luaL_Reg glspi_app_funcs[] = {
 	{"pluginver",  glspi_pluginver},
 	{"appinfo",    glspi_appinfo},
 	{"xsel",       glspi_xsel},

--- a/geanylua/glspi_dlg.c
+++ b/geanylua/glspi_dlg.c
@@ -540,7 +540,7 @@ static gint glspi_pickfile(lua_State* L)
 
 
 
-static const struct luaL_reg glspi_dlg_funcs[] = {
+static const struct luaL_Reg glspi_dlg_funcs[] = {
 	{"choose",   glspi_choose},
 	{"confirm",  glspi_confirm},
 	{"input",    glspi_input},

--- a/geanylua/glspi_doc.c
+++ b/geanylua/glspi_doc.c
@@ -359,7 +359,7 @@ static gint glspi_setfiletype(lua_State* L)
 
 
 
-static const struct luaL_reg glspi_doc_funcs[] = {
+static const struct luaL_Reg glspi_doc_funcs[] = {
 	{"filename",  glspi_filename},
 	{"fileinfo",  glspi_fileinfo},
 	{"settype",   glspi_setfiletype},

--- a/geanylua/glspi_init.c
+++ b/geanylua/glspi_init.c
@@ -539,7 +539,7 @@ static gint glspi_rescan(lua_State* L) {
 	return 0;
 }
 
-static const struct luaL_reg glspi_mnu_funcs[] = {
+static const struct luaL_Reg glspi_mnu_funcs[] = {
 	{"rescan",    glspi_rescan},
 	{NULL,NULL}
 };

--- a/geanylua/glspi_kfile.c
+++ b/geanylua/glspi_kfile.c
@@ -370,7 +370,7 @@ static gint kfile_remove(lua_State* L)
 
 
 
-static const struct luaL_reg kfile_funcs[] = {
+static const struct luaL_Reg kfile_funcs[] = {
 	{"new",     kfile_new},
 	{"data",    kfile_data},
 	{"groups",  kfile_groups},

--- a/geanylua/glspi_run.c
+++ b/geanylua/glspi_run.c
@@ -279,7 +279,7 @@ static void glspi_state_done(lua_State *L)
 
 
 
-static const struct luaL_reg glspi_timer_funcs[] = {
+static const struct luaL_Reg glspi_timer_funcs[] = {
 	{"timeout",  glspi_timeout},
 	{"yield",    glspi_yield},
 	{"optimize", glspi_optimize},

--- a/geanylua/glspi_sci.c
+++ b/geanylua/glspi_sci.c
@@ -972,7 +972,7 @@ struct Sci_TextToFind {
 
 
 
-static const struct luaL_reg glspi_sci_funcs[] = {
+static const struct luaL_Reg glspi_sci_funcs[] = {
 	{"text",      glspi_text},
 	{"selection", glspi_selection},
 	{"select",    glspi_select},

--- a/geanylua/gsdlg_lua.c
+++ b/geanylua/gsdlg_lua.c
@@ -387,7 +387,7 @@ static gint gsdl_done(lua_State *L)
 
 
 
-static const struct luaL_reg gsdl_funcs[] = {
+static const struct luaL_Reg gsdl_funcs[] = {
 	{"new",      gsdl_new},
 	{"run",      gsdl_run},
 	{"label",    gsdl_label},	


### PR DESCRIPTION
The real name of the struct in Lua 5.1 is luaL_Reg.  Lua 5.1 contains a define for compatibility, but it is not present in LuaJIT or later 5.x releases.