### PR TITLE
GeanyLua: Fix with-lua-pkg configure flag, Add option to use LuaJIT

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,21 @@ Geany Plugins 1.39 (not release date yet)
 
     t.b.p.s.
 
+    GeanyLua
+    * 
+    * 
+    * Add LuaJIT build support (PR #1231, #1233)
+
+      The build default will continue to be Lua 5.1 until the next release,
+      after which the default will switch to LuaJIT.  To force a specific
+      Lua package, configure with the `with-lua-pkg` flag:
+
+          ./configure --with-lua-pkg=luajit
+          ./configure --with-lua-pkg=lua51
+
+    * 
+    * 
+    * 
 
 Geany Plugins 1.38 (2021-10-09)
 

--- a/build/geanylua.m4
+++ b/build/geanylua.m4
@@ -4,17 +4,23 @@ AC_DEFUN([GP_CHECK_GEANYLUA],
 
     AC_ARG_WITH([lua-pkg],
         AC_HELP_STRING([--with-lua-pkg=ARG],
-            [name of Lua pkg-config script [[default=lua5.1]]]),
+            [name of Lua pkg-config script [[default=luajit]]]),
         [LUA_PKG_NAME=${withval%.pc}],
-        [LUA_PKG_NAME=lua5.1
+        [LUA_PKG_NAME=luajit
 
-        for L in lua5.1 lua51 lua-5.1 lua; do
+        for L in luajit lua5.1 lua51 lua-5.1 lua; do
             PKG_CHECK_EXISTS([$L],
                 [LUA_PKG_NAME=$L]; break,[])
         done])
 
-    LUA_VERSION=5.1
-    LUA_VERSION_BOUNDARY=5.2
+    if [[ "x$LUA_PKG_NAME" = "xluajit" ]] ; then
+        LUA_VERSION=2.0
+        LUA_VERSION_BOUNDARY=3.0
+    else
+        LUA_VERSION=5.1
+        LUA_VERSION_BOUNDARY=5.2
+    fi
+
     GP_CHECK_PLUGIN_DEPS([GeanyLua], [LUA],
                          [${LUA_PKG_NAME} >= ${LUA_VERSION}
                           ${LUA_PKG_NAME} < ${LUA_VERSION_BOUNDARY}])

--- a/build/geanylua.m4
+++ b/build/geanylua.m4
@@ -8,7 +8,7 @@ AC_DEFUN([GP_CHECK_GEANYLUA],
         [LUA_PKG_NAME=${withval%.pc}],
         [LUA_PKG_NAME=luajit
 
-        for L in luajit lua5.1 lua51 lua-5.1 lua; do
+        for L in "$LUA_PKG_NAME" luajit lua5.1 lua51 lua-5.1 lua; do
             PKG_CHECK_EXISTS([$L],
                 [LUA_PKG_NAME=$L]; break,[])
         done])

--- a/build/geanylua.m4
+++ b/build/geanylua.m4
@@ -4,11 +4,11 @@ AC_DEFUN([GP_CHECK_GEANYLUA],
 
     AC_ARG_WITH([lua-pkg],
         AC_HELP_STRING([--with-lua-pkg=ARG],
-            [name of Lua pkg-config script [[default=luajit]]]),
+            [name of Lua pkg-config script [[default=lua51]]]),
         [LUA_PKG_NAME=${withval%.pc}],
-        [LUA_PKG_NAME=luajit
+        [LUA_PKG_NAME=lua51
 
-        for L in "$LUA_PKG_NAME" luajit lua5.1 lua51 lua-5.1 lua; do
+        for L in "$LUA_PKG_NAME" lua5.1 lua51 lua-5.1 lua luajit; do
             PKG_CHECK_EXISTS([$L],
                 [LUA_PKG_NAME=$L]; break,[])
         done])


### PR DESCRIPTION
Modifies `build/geanylua.m4`:

* Fixes `configure --with-lua-pkg=...`.  The flag was previously ignored.
* Falls back on LuaJIT if Lua 5.1 is not available.

When both Lua 5.1 and LuaJIT are installed, LuaJIT can be forced with:
````
./configure --with-lua-pkg=luajit
````

Note: Building with LuaJIT requires #1231.

Resolves #1228.  Possibly also resolves #1133.