### PR TITLE
geanylua: Migrate to Lua 5.3

### DIFF
--- a/build/geanylua.m4
+++ b/build/geanylua.m4
@@ -6,15 +6,15 @@ AC_DEFUN([GP_CHECK_GEANYLUA],
         AC_HELP_STRING([--with-lua-pkg=ARG],
             [name of Lua pkg-config script [[default=lua5.1]]]),
         [LUA_PKG_NAME=${withval%.pc}],
-        [LUA_PKG_NAME=lua5.1
+        [LUA_PKG_NAME=lua5.3
 
-        for L in lua5.1 lua51 lua-5.1 lua; do
+        for L in lua5.3 lua53 lua-5.3 lua; do
             PKG_CHECK_EXISTS([$L],
                 [LUA_PKG_NAME=$L]; break,[])
         done])
 
-    LUA_VERSION=5.1
-    LUA_VERSION_BOUNDARY=5.2
+    LUA_VERSION=5.3
+    LUA_VERSION_BOUNDARY=5.4
     GP_CHECK_PLUGIN_DEPS([GeanyLua], [LUA],
                          [${LUA_PKG_NAME} >= ${LUA_VERSION}
                           ${LUA_PKG_NAME} < ${LUA_VERSION_BOUNDARY}])

--- a/geanylua/glspi_app.c
+++ b/geanylua/glspi_app.c
@@ -615,7 +615,7 @@ static gint glspi_reloadconf(lua_State* L)
 
 
 
-static const struct luaL_reg glspi_app_funcs[] = {
+static const struct luaL_Reg glspi_app_funcs[] = {
 	{"pluginver",  glspi_pluginver},
 	{"appinfo",    glspi_appinfo},
 	{"xsel",       glspi_xsel},

--- a/geanylua/glspi_app.c
+++ b/geanylua/glspi_app.c
@@ -636,5 +636,5 @@ static const struct luaL_Reg glspi_app_funcs[] = {
 
 void glspi_init_app_funcs(lua_State *L, const gchar*script_dir) {
 	glspi_script_dir = script_dir;
-	luaL_register(L, NULL,glspi_app_funcs);
+	luaL_setfuncs(L, glspi_app_funcs, 0);
 }

--- a/geanylua/glspi_dlg.c
+++ b/geanylua/glspi_dlg.c
@@ -540,7 +540,7 @@ static gint glspi_pickfile(lua_State* L)
 
 
 
-static const struct luaL_reg glspi_dlg_funcs[] = {
+static const struct luaL_Reg glspi_dlg_funcs[] = {
 	{"choose",   glspi_choose},
 	{"confirm",  glspi_confirm},
 	{"input",    glspi_input},

--- a/geanylua/glspi_dlg.c
+++ b/geanylua/glspi_dlg.c
@@ -128,7 +128,7 @@ static gint glspi_choose(lua_State* L)
 			arg1=lua_tostring(L, 1);
 	}
 
-	n=lua_objlen(L,2);
+	n=lua_rawlen(L,2);
 	for (i=1;i<=n; i++) {
 		lua_rawgeti(L,2,i);
 		if (!lua_isstring(L, -1)) {

--- a/geanylua/glspi_dlg.c
+++ b/geanylua/glspi_dlg.c
@@ -554,5 +554,5 @@ static const struct luaL_Reg glspi_dlg_funcs[] = {
 
 void glspi_init_dlg_funcs(lua_State *L, GsDlgRunHook hook) {
 	glspi_pause_timer = hook;
-	luaL_register(L, NULL,glspi_dlg_funcs);
+	luaL_setfuncs(L, glspi_dlg_funcs, 0);
 }

--- a/geanylua/glspi_doc.c
+++ b/geanylua/glspi_doc.c
@@ -359,7 +359,7 @@ static gint glspi_setfiletype(lua_State* L)
 
 
 
-static const struct luaL_reg glspi_doc_funcs[] = {
+static const struct luaL_Reg glspi_doc_funcs[] = {
 	{"filename",  glspi_filename},
 	{"fileinfo",  glspi_fileinfo},
 	{"settype",   glspi_setfiletype},

--- a/geanylua/glspi_doc.c
+++ b/geanylua/glspi_doc.c
@@ -374,5 +374,5 @@ static const struct luaL_Reg glspi_doc_funcs[] = {
 };
 
 void glspi_init_doc_funcs(lua_State *L) {
-	luaL_register(L, NULL,glspi_doc_funcs);
+	luaL_setfuncs(L, glspi_doc_funcs, 0);
 }

--- a/geanylua/glspi_init.c
+++ b/geanylua/glspi_init.c
@@ -539,7 +539,7 @@ static gint glspi_rescan(lua_State* L) {
 	return 0;
 }
 
-static const struct luaL_reg glspi_mnu_funcs[] = {
+static const struct luaL_Reg glspi_mnu_funcs[] = {
 	{"rescan",    glspi_rescan},
 	{NULL,NULL}
 };

--- a/geanylua/glspi_init.c
+++ b/geanylua/glspi_init.c
@@ -546,5 +546,5 @@ static const struct luaL_Reg glspi_mnu_funcs[] = {
 
 
 void glspi_init_mnu_funcs(lua_State *L) {
-	luaL_register(L, NULL,glspi_mnu_funcs);
+	luaL_setfuncs(L, glspi_mnu_funcs, 0);
 }

--- a/geanylua/glspi_kfile.c
+++ b/geanylua/glspi_kfile.c
@@ -370,7 +370,7 @@ static gint kfile_remove(lua_State* L)
 
 
 
-static const struct luaL_reg kfile_funcs[] = {
+static const struct luaL_Reg kfile_funcs[] = {
 	{"new",     kfile_new},
 	{"data",    kfile_data},
 	{"groups",  kfile_groups},

--- a/geanylua/glspi_kfile.c
+++ b/geanylua/glspi_kfile.c
@@ -395,7 +395,7 @@ static gint luaopen_keyfile(lua_State *L)
 	lua_pushstring(L,"__gc");
 	lua_pushcfunction(L,kfile_done);
 	lua_rawset(L,-3);
-	luaL_register(L, NULL, &kfile_funcs[1]);
+	luaL_setfuncs(L, &kfile_funcs[1], 0);
 	luaL_register(L, LUA_MODULE_NAME, kfile_funcs);
 	return 0;
 }

--- a/geanylua/glspi_kfile.c
+++ b/geanylua/glspi_kfile.c
@@ -396,7 +396,9 @@ static gint luaopen_keyfile(lua_State *L)
 	lua_pushcfunction(L,kfile_done);
 	lua_rawset(L,-3);
 	luaL_setfuncs(L, &kfile_funcs[1], 0);
-	luaL_register(L, LUA_MODULE_NAME, kfile_funcs);
+	lua_newtable(L);
+	luaL_setfuncs(L, kfile_funcs, 0);
+	lua_setglobal(L, LUA_MODULE_NAME);
 	return 0;
 }
 

--- a/geanylua/glspi_run.c
+++ b/geanylua/glspi_run.c
@@ -279,7 +279,7 @@ static void glspi_state_done(lua_State *L)
 
 
 
-static const struct luaL_reg glspi_timer_funcs[] = {
+static const struct luaL_Reg glspi_timer_funcs[] = {
 	{"timeout",  glspi_timeout},
 	{"yield",    glspi_yield},
 	{"optimize", glspi_optimize},

--- a/geanylua/glspi_run.c
+++ b/geanylua/glspi_run.c
@@ -393,12 +393,14 @@ static void show_error(lua_State *L, const gchar *script_file)
 
 static gint glspi_init_module(lua_State *L, const gchar *script_file, gint caller, GKeyFile*proj, const gchar*script_dir)
 {
-	luaL_register(L, LUA_MODULE_NAME, glspi_timer_funcs);
+	lua_newtable(L);
+	luaL_setfuncs(L, glspi_timer_funcs, 0);
 	glspi_init_sci_funcs(L);
 	glspi_init_doc_funcs(L);
 	glspi_init_mnu_funcs(L);
 	glspi_init_dlg_funcs(L, glspi_pause_timer);
 	glspi_init_app_funcs(L,script_dir);
+	lua_setglobal(L, LUA_MODULE_NAME);
 	set_string_token(L,tokenWordChars,GEANY_WORDCHARS);
 	set_string_token(L,tokenBanner,DEFAULT_BANNER);
 	set_string_token(L,tokenDirSep, G_DIR_SEPARATOR_S);

--- a/geanylua/glspi_sci.c
+++ b/geanylua/glspi_sci.c
@@ -972,7 +972,7 @@ struct Sci_TextToFind {
 
 
 
-static const struct luaL_reg glspi_sci_funcs[] = {
+static const struct luaL_Reg glspi_sci_funcs[] = {
 	{"text",      glspi_text},
 	{"selection", glspi_selection},
 	{"select",    glspi_select},

--- a/geanylua/glspi_sci.c
+++ b/geanylua/glspi_sci.c
@@ -905,7 +905,7 @@ static gint glspi_find(lua_State* L)
 	ttf.chrg.cpMin=lua_tonumber(L,2);
 	ttf.chrg.cpMax=lua_tonumber(L,3);
 
-	n=lua_objlen(L,4);
+	n=lua_rawlen(L,4);
 	for (i=1;i<=n; i++) {
 		lua_rawgeti(L,4,i);
 		if (lua_isstring(L, -1)) {

--- a/geanylua/glspi_sci.c
+++ b/geanylua/glspi_sci.c
@@ -995,5 +995,5 @@ static const struct luaL_Reg glspi_sci_funcs[] = {
 };
 
 void glspi_init_sci_funcs(lua_State *L) {
-	luaL_register(L, NULL,glspi_sci_funcs);
+	luaL_setfuncs(L, glspi_sci_funcs, 0);
 }

--- a/geanylua/gsdlg_lua.c
+++ b/geanylua/gsdlg_lua.c
@@ -387,7 +387,7 @@ static gint gsdl_done(lua_State *L)
 
 
 
-static const struct luaL_reg gsdl_funcs[] = {
+static const struct luaL_Reg gsdl_funcs[] = {
 	{"new",      gsdl_new},
 	{"run",      gsdl_run},
 	{"label",    gsdl_label},	

--- a/geanylua/gsdlg_lua.c
+++ b/geanylua/gsdlg_lua.c
@@ -323,7 +323,7 @@ static gint gsdl_new(lua_State *L) {
 	if (argc>=2) {
 		if (!lua_istable(L,2)) { return FAIL_TABLE_ARG(2); }
 	}
-	n=lua_objlen(L,2);
+	n=lua_rawlen(L,2);
 	for (i=1;i<=n; i++) {
 		lua_rawgeti(L,2,i);
 		if (!lua_isstring(L, -1)) {

--- a/geanylua/gsdlg_lua.c
+++ b/geanylua/gsdlg_lua.c
@@ -426,7 +426,9 @@ gint luaopen_dialog(lua_State *L)
 	lua_rawset(L,-3);
 
 	luaL_setfuncs(L, &gsdl_funcs[1], 0);
-	luaL_register(L, LUA_MODULE_NAME, gsdl_funcs);
+	lua_newtable(L);
+	luaL_setfuncs(L, gsdl_funcs, 0);
+	lua_setglobal(L, LUA_MODULE_NAME);
 	return 0;
 }
 

--- a/geanylua/gsdlg_lua.c
+++ b/geanylua/gsdlg_lua.c
@@ -425,7 +425,7 @@ gint luaopen_dialog(lua_State *L)
 	lua_pushcfunction(L,gsdl_done);
 	lua_rawset(L,-3);
 
-	luaL_register(L, NULL, &gsdl_funcs[1]);
+	luaL_setfuncs(L, &gsdl_funcs[1], 0);
 	luaL_register(L, LUA_MODULE_NAME, gsdl_funcs);
 	return 0;
 }


### PR DESCRIPTION
This PR migrates geanylua to Lua 5.3 (my oldish distro doesn't provide lua 5.4 so I didn't test, maybe it works too). There were mostly just simple changes. From my limited testing, everything seems to work.

Posting as an (in my opinion better) alternative to #1233 