### PR TITLE
GeanyLua: Allow building with Lua 5.1-5.5 and LuaJIT

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ concurrency:
 
 env:
   CFLAGS: -g -O2 -Werror=pointer-arith -Werror=implicit-function-declaration
-  CONFIGURE_FLAGS: --disable-silent-rules
+  CONFIGURE_FLAGS: --disable-silent-rules --with-lua-pkg=lua5.4
   CPPCHECKFLAGS: --check-level=exhaustive
   CCACHE_DIR: ${{ github.workspace }}/.ccache
   CCACHE_COMPRESS: true
@@ -119,7 +119,7 @@ jobs:
             # geanygendoc
             libctpl-dev
             # geanylua
-            liblua5.1-0-dev
+            liblua5.4-dev
             # geanypg
             libgpgme-dev
             # geanyvc

--- a/.github/workflows/windows-msys2-build.yml
+++ b/.github/workflows/windows-msys2-build.yml
@@ -33,7 +33,7 @@ jobs:
             mingw-w64-x86_64-gtkspell3
             mingw-w64-x86_64-libgit2
             mingw-w64-x86_64-libsoup3
-            mingw-w64-x86_64-lua51
+            mingw-w64-x86_64-lua54
             patch
             rsync
             unzip
@@ -66,7 +66,7 @@ jobs:
           export lt_cv_deplibs_check_method=${lt_cv_deplibs_check_method='pass_all'}
           mkdir -p _build
           cd _build
-          ../configure --prefix=${DESTINATON}/build/geany --with-geany-libdir=${DESTINATON}/build/geany/lib --disable-silent-rules
+          ../configure --prefix=${DESTINATON}/build/geany --with-geany-libdir=${DESTINATON}/build/geany/lib --disable-silent-rules --with-lua-pkg=lua54
           make -j
           make DESTDIR=${DESTINATON}/build/geany-plugins install
           rm -rf ${DESTINATON}/release/geany-plugins-orig

--- a/build/geanylua.m4
+++ b/build/geanylua.m4
@@ -4,20 +4,18 @@ AC_DEFUN([GP_CHECK_GEANYLUA],
 
     AC_ARG_WITH([lua-pkg],
         AS_HELP_STRING([--with-lua-pkg=ARG],
-            [name of Lua pkg-config script [[default=lua5.1]]]),
+            [name of Lua pkg-config script [[default=lua]]]),
         [LUA_PKG_NAME=${withval%.pc}],
-        [LUA_PKG_NAME=lua5.1
+        [LUA_PKG_NAME=lua])
 
-        for L in lua5.1 lua51 lua-5.1 lua; do
-            PKG_CHECK_EXISTS([$L],
-                [LUA_PKG_NAME=$L]; break,[])
-        done])
+    AS_CASE([$LUA_PKG_NAME],
+        [luajit], [LUA_VERSION_MIN=2.0; LUA_VERSION_LIMIT=3.0],
+        [*],      [LUA_VERSION_MIN=5.1; LUA_VERSION_LIMIT=5.5]
+    )
 
-    LUA_VERSION=5.1
-    LUA_VERSION_BOUNDARY=5.2
     GP_CHECK_PLUGIN_DEPS([GeanyLua], [LUA],
-                         [${LUA_PKG_NAME} >= ${LUA_VERSION}
-                          ${LUA_PKG_NAME} < ${LUA_VERSION_BOUNDARY}])
+                         [${LUA_PKG_NAME} >= ${LUA_VERSION_MIN}
+                          ${LUA_PKG_NAME} < ${LUA_VERSION_LIMIT}])
     GP_CHECK_PLUGIN_DEPS([GeanyLua], [GMODULE], [gmodule-2.0])
     GP_COMMIT_PLUGIN_STATUS([GeanyLua])
 

--- a/build/geanylua.m4
+++ b/build/geanylua.m4
@@ -10,7 +10,7 @@ AC_DEFUN([GP_CHECK_GEANYLUA],
 
     AS_CASE([$LUA_PKG_NAME],
         [luajit], [LUA_VERSION_MIN=2.0; LUA_VERSION_LIMIT=3.0],
-        [*],      [LUA_VERSION_MIN=5.1; LUA_VERSION_LIMIT=5.5]
+        [*],      [LUA_VERSION_MIN=5.1; LUA_VERSION_LIMIT=5.6]
     )
 
     GP_CHECK_PLUGIN_DEPS([GeanyLua], [LUA],

--- a/geanylua/Makefile.am
+++ b/geanylua/Makefile.am
@@ -24,6 +24,8 @@ libgeanylua_la_SOURCES = \
 	glspi_keycmd.h \
 	glspi_sci.h \
 	glspi_ver.h \
+	glspi_compat.c \
+	glspi_compat.h \
 	gsdlg.h
 
 geanylua_la_CFLAGS = \

--- a/geanylua/examples/edit/calculator.lua
+++ b/geanylua/examples/edit/calculator.lua
@@ -4,6 +4,9 @@
   some fairly complex calculations, e.g.  sqrt(pi^2*sin(rad(45)))
 --]]
 
+-- Lua 5.1 compatibility shim
+local load = loadstring or load
+
 
 -- Copy math functions to global namespace
 for k,v in pairs(math) do _G[k] = math[k] end
@@ -34,7 +37,7 @@ end
 
 
 -- Create a function call around the selected expression
-func=assert(loadstring("return "..geany.selection()))
+func=assert(load("return "..geany.selection()))
 
 
 -- Did we get our function ?

--- a/geanylua/examples/edit/lua-replace.lua
+++ b/geanylua/examples/edit/lua-replace.lua
@@ -2,9 +2,13 @@
   Replace text using Lua pattern syntax
 --]]
 
+-- Lua 5.1 compatibility shim
+local load = loadstring or load
+
+
 function esc(s)
   s=s and s:gsub('"', '\\"') or ""
-  assert(loadstring('rv="'..s..'"'))()
+  assert(load('rv="'..s..'"'))()
   return rv
 end
 

--- a/geanylua/glspi.h
+++ b/geanylua/glspi.h
@@ -16,6 +16,8 @@
 #include <string.h>
 #include <ctype.h>
 
+#include "glspi_compat.h"
+
 #include <geanyplugin.h>
 #define main_widgets	geany->main_widgets
 

--- a/geanylua/glspi_app.c
+++ b/geanylua/glspi_app.c
@@ -549,5 +549,5 @@ static const struct luaL_Reg glspi_app_funcs[] = {
 
 void glspi_init_app_funcs(lua_State *L, const gchar*script_dir) {
 	glspi_script_dir = script_dir;
-	luaL_register(L, NULL,glspi_app_funcs);
+	luaL_setfuncs(L, glspi_app_funcs, 0);
 }

--- a/geanylua/glspi_app.c
+++ b/geanylua/glspi_app.c
@@ -20,13 +20,30 @@
 
 static gint glspi_pluginver(lua_State* L)
 {
+	const char *lua_ver = LUA_RELEASE;
+
+	lua_getglobal(L, "jit");
+	if (lua_istable(L, -1)) {
+		lua_getfield(L, -1, "version");
+		if (lua_isstring(L, -1)) {
+			lua_ver = lua_tostring(L, -1);
+		}
+		lua_pop(L, 1);
+	}
+	lua_pop(L, 1);
+
 	lua_pushfstring(L, _(
 "%s %s: %s\n"
 "Copyright (c) 2007-2010 "PLUGIN_AUTHOR", et al.\n"
-"Compiled on "__DATE__" at "__TIME__" for Geany API version %d\n"
+"Using %s\n"
+"Compiled on " __DATE__ " at " __TIME__ " for Geany API version %d\n"
 "Released under version 2 of the GNU General Public License.\n"
-	),
-			PLUGIN_NAME, PLUGIN_VER, PLUGIN_DESC, MY_GEANY_API_VER);
+		),
+		PLUGIN_NAME, PLUGIN_VER, PLUGIN_DESC,
+		lua_ver,
+		MY_GEANY_API_VER
+	);
+
 	return 1;
 }
 

--- a/geanylua/glspi_compat.c
+++ b/geanylua/glspi_compat.c
@@ -1,0 +1,55 @@
+/* Lua compatibility functions */
+
+#include <lua.h>
+#include <lualib.h>
+#include <lauxlib.h>
+
+
+/*
+ * Compatibility functions for Lua 5.1 and LuaJIT
+ */
+#if LUA_VERSION_NUM==501
+
+/* Adapted from Lua 5.2.0 */
+void luaL_setfuncs (lua_State *L, const luaL_Reg *l, int nup) {
+	luaL_checkstack(L, nup+1, "too many upvalues");
+	for (; l->name != NULL; l++) {  /* fill the table with given functions */
+		int i;
+		lua_pushstring(L, l->name);
+		for (i = 0; i < nup; i++)  /* copy upvalues to the top */
+			lua_pushvalue(L, -(nup+1));
+		lua_pushcclosure(L, l->func, nup);  /* closure with those upvalues */
+		lua_settable(L, -(nup + 3));
+	}
+	lua_pop(L, nup);  /* remove upvalues */
+}
+
+#endif /* LUAJIT_VERSION_NUM */
+
+
+/*
+ * Compatibility functions for Lua 5.1 only
+ */
+#if LUA_VERSION_NUM==501 && !defined LUAJIT_VERSION_NUM
+
+void luaL_traceback (lua_State *L, lua_State *L1, const char *msg,
+				int level)
+{
+	lua_getfield(L, LUA_GLOBALSINDEX, "debug");
+	if (!lua_istable(L, -1)) {
+		lua_pop(L, 1);
+		return;
+	}
+	lua_getfield(L, -1, "traceback");
+	if (!lua_isfunction(L, -1)) {
+		lua_pop(L, 2);
+		return;
+	}
+	lua_pushvalue(L, 1);
+	lua_pushinteger(L, 2);
+	lua_call(L, 2, 1);
+
+	return;
+}
+
+#endif /* LUA_VERSION_NUM */

--- a/geanylua/glspi_compat.h
+++ b/geanylua/glspi_compat.h
@@ -1,0 +1,28 @@
+/* Lua compatibility functions */
+
+#ifndef GLSPI_COMPAT
+#define GLSPI_COMPAT 1
+
+/*
+ * Compatibility functions for Lua 5.1 and LuaJIT
+ */
+#if LUA_VERSION_NUM==501
+
+#define lua_rawlen(L,i)               lua_objlen(L, (i))
+
+void luaL_setfuncs (lua_State *L, const luaL_Reg *l, int nup);
+
+#endif /* LUAJIT_VERSION_NUM */
+
+
+/*
+ * Compatibility functions for Lua 5.1 only
+ */
+#if LUA_VERSION_NUM==501 && !defined LUAJIT_VERSION_NUM
+
+void luaL_traceback (lua_State *L, lua_State *L1, const char *msg, int level);
+
+#endif /* LUA_VERSION_NUM */
+
+
+#endif /* GLSPI_COMPAT */

--- a/geanylua/glspi_dlg.c
+++ b/geanylua/glspi_dlg.c
@@ -128,7 +128,7 @@ static gint glspi_choose(lua_State* L)
 			arg1=lua_tostring(L, 1);
 	}
 
-	n=lua_objlen(L,2);
+	n=lua_rawlen(L,2);
 	for (i=1;i<=n; i++) {
 		lua_rawgeti(L,2,i);
 		if (!lua_isstring(L, -1)) {
@@ -556,5 +556,5 @@ static const struct luaL_Reg glspi_dlg_funcs[] = {
 
 void glspi_init_dlg_funcs(lua_State *L, GsDlgRunHook hook) {
 	glspi_pause_timer = hook;
-	luaL_register(L, NULL,glspi_dlg_funcs);
+	luaL_setfuncs(L, glspi_dlg_funcs, 0);
 }

--- a/geanylua/glspi_doc.c
+++ b/geanylua/glspi_doc.c
@@ -380,5 +380,5 @@ static const struct luaL_Reg glspi_doc_funcs[] = {
 };
 
 void glspi_init_doc_funcs(lua_State *L) {
-	luaL_register(L, NULL,glspi_doc_funcs);
+	luaL_setfuncs(L, glspi_doc_funcs, 0);
 }

--- a/geanylua/glspi_init.c
+++ b/geanylua/glspi_init.c
@@ -546,5 +546,5 @@ static const struct luaL_Reg glspi_mnu_funcs[] = {
 
 
 void glspi_init_mnu_funcs(lua_State *L) {
-	luaL_register(L, NULL,glspi_mnu_funcs);
+	luaL_setfuncs(L, glspi_mnu_funcs, 0);
 }

--- a/geanylua/glspi_kfile.c
+++ b/geanylua/glspi_kfile.c
@@ -12,6 +12,8 @@
 #include <lualib.h>
 #include <lauxlib.h>
 
+#include "glspi_compat.h"
+
 #define LUA_MODULE_NAME "keyfile"
 #define MetaName "_g_key_file_metatable"
 

--- a/geanylua/glspi_kfile.c
+++ b/geanylua/glspi_kfile.c
@@ -395,8 +395,10 @@ static gint luaopen_keyfile(lua_State *L)
 	lua_pushstring(L,"__gc");
 	lua_pushcfunction(L,kfile_done);
 	lua_rawset(L,-3);
-	luaL_register(L, NULL, &kfile_funcs[1]);
-	luaL_register(L, LUA_MODULE_NAME, kfile_funcs);
+	luaL_setfuncs(L, &kfile_funcs[1], 0);
+	lua_newtable(L);
+	luaL_setfuncs(L, kfile_funcs, 0);
+	lua_setglobal(L, LUA_MODULE_NAME);
 	return 0;
 }
 

--- a/geanylua/glspi_sci.c
+++ b/geanylua/glspi_sci.c
@@ -905,7 +905,7 @@ static gint glspi_find(lua_State* L)
 	ttf.chrg.cpMin=lua_tonumber(L,2);
 	ttf.chrg.cpMax=lua_tonumber(L,3);
 
-	n=lua_objlen(L,4);
+	n=lua_rawlen(L,4);
 	for (i=1;i<=n; i++) {
 		lua_rawgeti(L,4,i);
 		if (lua_isstring(L, -1)) {
@@ -995,5 +995,5 @@ static const struct luaL_Reg glspi_sci_funcs[] = {
 };
 
 void glspi_init_sci_funcs(lua_State *L) {
-	luaL_register(L, NULL,glspi_sci_funcs);
+	luaL_setfuncs(L, glspi_sci_funcs, 0);
 }

--- a/geanylua/glspi_ver.h
+++ b/geanylua/glspi_ver.h
@@ -6,7 +6,7 @@
 
 #define PLUGIN_NAME _("Lua Script")
 
-#define PLUGIN_DESC _("Write and run Lua scripts for custom commands.\nThis plugin currently has no maintainer. Would you like to help by contributing to this plugin?")
+#define PLUGIN_DESC _("Write and run Lua scripts for custom commands.")
 
 #define PLUGIN_VER VERSION
 

--- a/geanylua/gsdlg_lua.c
+++ b/geanylua/gsdlg_lua.c
@@ -323,7 +323,7 @@ static gint gsdl_new(lua_State *L) {
 	if (argc>=2) {
 		if (!lua_istable(L,2)) { return FAIL_TABLE_ARG(2); }
 	}
-	n=lua_objlen(L,2);
+	n=lua_rawlen(L,2);
 	for (i=1;i<=n; i++) {
 		lua_rawgeti(L,2,i);
 		if (!lua_isstring(L, -1)) {
@@ -425,8 +425,10 @@ gint luaopen_dialog(lua_State *L)
 	lua_pushcfunction(L,gsdl_done);
 	lua_rawset(L,-3);
 
-	luaL_register(L, NULL, &gsdl_funcs[1]);
-	luaL_register(L, LUA_MODULE_NAME, gsdl_funcs);
+	luaL_setfuncs(L, &gsdl_funcs[1], 0);
+	lua_newtable(L);
+	luaL_setfuncs(L, gsdl_funcs, 0);
+	lua_setglobal(L, LUA_MODULE_NAME);
 	return 0;
 }
 

--- a/geanylua/gsdlg_lua.c
+++ b/geanylua/gsdlg_lua.c
@@ -35,6 +35,7 @@
 #include <lualib.h>
 #include <lauxlib.h>
 
+#include "glspi_compat.h"
 
 #define GSDLG_ALL_IN_ONE
 #include "gsdlg.h"


### PR DESCRIPTION
This PR adds build support for Lua 5.1-5.5 and LuaJIT.

The Lua version can be changed by setting `--with-lua-pkg`.  The default is `lua`.  There is no fallback.  If `lua` is not available, a valid package needs to be specified.  Valid values are whatever `pkg-config` recognizes, which may vary by distro.

To change Lua variant, reconfigure and rebuild.
```
./configure --with-lua-pkg=[lua]
make -C geanylua clean
make -C geanylua
```

Supercedes #1233, #1235.
Resolves #1228.  Resolves #1133.