### PR TITLE
vimode: implement "iw", "ow", "iW" and "oW" text objects

### DIFF
--- a/vimode/README
+++ b/vimode/README
@@ -448,10 +448,12 @@ a new command, please do not forget to update the table below.::
     v_a<          a<                 "a <>" from '<' to the matching '>'
     v_a>          a>                 same as a<
     v_aB          aB                 "a Block" from "[{" to "]}" (with brackets)
+    v_aW          aW                 "a WORD" (with white space)
     v_a[          a[                 "a []" from '[' to the matching ']'
     v_a]          a]                 same as a[
     v_a`          a`                 string in backticks
     v_ab          ab                 "a block" from "[(" to "])" (with braces)
+    v_aw          aw                 "a word" (with white space)
     v_a{          a{                 same as aB
     v_a}          a}                 same as aB
     v_iquote      i"                 double quoted string without the quotes
@@ -461,10 +463,12 @@ a new command, please do not forget to update the table below.::
     v_i<          i<                 "inner <>" from '<' to the matching '>'
     v_i>          i>                 same as i<
     v_iB          iB                 "inner Block" from "[{" and "]}"
+    v_iW          iW                 "inner WORD"
     v_i[          i[                 "inner []" from '[' to the matching ']'
     v_i]          i]                 same as i[
     v_i`          i`                 string in backticks without the backticks
     v_ib          ib                 "inner block" from "[(" to "])"
+    v_iw          iw                 "inner word"
     v_i{          i{                 same as iB
     v_i}          i}                 same as iB
 

--- a/vimode/src/cmd-runner.c
+++ b/vimode/src/cmd-runner.c
@@ -222,6 +222,8 @@ CmdDef operator_cmds[] = {
 	{cmd_select_less, GDK_KEY_a, GDK_KEY_greater, 0, 0, FALSE, FALSE}, \
 	{cmd_select_bracket, GDK_KEY_a, GDK_KEY_bracketleft, 0, 0, FALSE, FALSE}, \
 	{cmd_select_bracket, GDK_KEY_a, GDK_KEY_bracketright, 0, 0, FALSE, FALSE}, \
+	{cmd_select_word, GDK_KEY_a, GDK_KEY_w, 0, 0, FALSE, FALSE}, \
+	{cmd_select_word_space, GDK_KEY_a, GDK_KEY_W, 0, 0, FALSE, FALSE}, \
 	/* inner */ \
 	{cmd_select_quotedbl_inner, GDK_KEY_i, GDK_KEY_quotedbl, 0, 0, FALSE, FALSE}, \
 	{cmd_select_quoteleft_inner, GDK_KEY_i, GDK_KEY_quoteleft, 0, 0, FALSE, FALSE}, \
@@ -236,6 +238,8 @@ CmdDef operator_cmds[] = {
 	{cmd_select_less_inner, GDK_KEY_i, GDK_KEY_greater, 0, 0, FALSE, FALSE}, \
 	{cmd_select_bracket_inner, GDK_KEY_i, GDK_KEY_bracketleft, 0, 0, FALSE, FALSE}, \
 	{cmd_select_bracket_inner, GDK_KEY_i, GDK_KEY_bracketright, 0, 0, FALSE, FALSE}, \
+	{cmd_select_word_inner, GDK_KEY_i, GDK_KEY_w, 0, 0, FALSE, FALSE}, \
+	{cmd_select_word_space_inner, GDK_KEY_i, GDK_KEY_W, 0, 0, FALSE, FALSE}, \
 	/* END */
 
 

--- a/vimode/src/cmds/motion-word.h
+++ b/vimode/src/cmds/motion-word.h
@@ -31,4 +31,7 @@ void cmd_goto_previous_word_space(CmdContext *c, CmdParams *p);
 void cmd_goto_next_word_end_space(CmdContext *c, CmdParams *p);
 void cmd_goto_previous_word_end_space(CmdContext *c, CmdParams *p);
 
+void get_word_range(ScintillaObject *sci, gboolean word_space, gboolean inner,
+	gint pos, gint num, gint *sel_start, gint *sel_len);
+
 #endif

--- a/vimode/src/cmds/txtobjs.c
+++ b/vimode/src/cmds/txtobjs.c
@@ -17,6 +17,7 @@
  */
 
 #include "cmds/txtobjs.h"
+#include "cmds/motion-word.h"
 
 
 static gint find_upper_level_brace(ScintillaObject *sci, gint pos, gint open_brace, gint close_brace)
@@ -187,4 +188,47 @@ void cmd_select_less_inner(CmdContext *c, CmdParams *p)
 void cmd_select_bracket_inner(CmdContext *c, CmdParams *p)
 {
 	select_brace(c, p, '[', ']', TRUE);
+}
+
+
+static void select_word(CmdContext *c, CmdParams *p, gboolean word_space, gboolean inner)
+{
+	gint sel_start, sel_len;
+
+	get_word_range(p->sci, word_space, inner, p->pos, p->num, &sel_start, &sel_len);
+
+	if (VI_IS_VISUAL(vi_get_mode()))
+	{
+		c->sel_anchor = sel_start;
+		SET_POS(p->sci, sel_start + sel_len, TRUE);
+	}
+	else
+	{
+		p->sel_start = sel_start;
+		p->sel_len = sel_len;
+	}
+}
+
+
+void cmd_select_word(CmdContext *c, CmdParams *p)
+{
+	select_word(c, p, FALSE, FALSE);
+}
+
+
+void cmd_select_word_space(CmdContext *c, CmdParams *p)
+{
+	select_word(c, p, TRUE, FALSE);
+}
+
+
+void cmd_select_word_inner(CmdContext *c, CmdParams *p)
+{
+	select_word(c, p, FALSE, TRUE);
+}
+
+
+void cmd_select_word_space_inner(CmdContext *c, CmdParams *p)
+{
+	select_word(c, p, TRUE, TRUE);
 }

--- a/vimode/src/cmds/txtobjs.h
+++ b/vimode/src/cmds/txtobjs.h
@@ -29,6 +29,8 @@ void cmd_select_brace(CmdContext *c, CmdParams *p);
 void cmd_select_paren(CmdContext *c, CmdParams *p);
 void cmd_select_less(CmdContext *c, CmdParams *p);
 void cmd_select_bracket(CmdContext *c, CmdParams *p);
+void cmd_select_word(CmdContext *c, CmdParams *p);
+void cmd_select_word_space(CmdContext *c, CmdParams *p);
 
 void cmd_select_quotedbl_inner(CmdContext *c, CmdParams *p);
 void cmd_select_quoteleft_inner(CmdContext *c, CmdParams *p);
@@ -37,5 +39,7 @@ void cmd_select_brace_inner(CmdContext *c, CmdParams *p);
 void cmd_select_paren_inner(CmdContext *c, CmdParams *p);
 void cmd_select_less_inner(CmdContext *c, CmdParams *p);
 void cmd_select_bracket_inner(CmdContext *c, CmdParams *p);
+void cmd_select_word_inner(CmdContext *c, CmdParams *p);
+void cmd_select_word_space_inner(CmdContext *c, CmdParams *p);
 
 #endif


### PR DESCRIPTION
This enables a family of word-related text object commands such as:
"ciw", "diw", "viw" etc.

Fixes https://github.com/geany/geany-plugins/issues/1155.