### PR TITLE
ProjectOrganizer: Initialise "is_header" variable

### DIFF
--- a/projectorganizer/src/prjorg-utils.c
+++ b/projectorganizer/src/prjorg-utils.c
@@ -294,7 +294,7 @@ gchar *find_header_source(GeanyDocument *doc)
 {
 	GSList *header_patterns, *source_patterns;
 	gboolean known_type = TRUE;
-	gboolean is_header;
+	gboolean is_header = FALSE;
 	gchar *found_name = NULL;
 
 	if (!doc || !doc->file_name)


### PR DESCRIPTION
Older cppcheck versions (e.g. 1.90) complain about this while newer versions (e.g. 2.10) do not.

@techee is `FALSE` a proper default here?