### PR TITLE
Addons: Delay updating of tasks list until document has been colorised

### DIFF
--- a/addons/src/addons.c
+++ b/addons/src/addons.c
@@ -137,7 +137,7 @@ static gboolean ao_editor_notify_cb(GObject *object, GeanyEditor *editor,
 static void ao_update_editor_menu_cb(GObject *obj, const gchar *word, gint pos,
 									 GeanyDocument *doc, gpointer data)
 {
-	g_return_if_fail(doc != NULL && doc->is_valid);
+	g_return_if_fail(DOC_VALID(doc));
 
 	ao_open_uri_update_menu(ao_info->openuri, doc, pos);
 }
@@ -145,7 +145,7 @@ static void ao_update_editor_menu_cb(GObject *obj, const gchar *word, gint pos,
 
 static void ao_document_activate_cb(GObject *obj, GeanyDocument *doc, gpointer data)
 {
-	g_return_if_fail(doc != NULL && doc->is_valid);
+	g_return_if_fail(DOC_VALID(doc));
 
 	ao_bookmark_list_update(ao_info->bookmarklist, doc);
 	ao_tasks_update_single(ao_info->tasks, doc);
@@ -154,7 +154,7 @@ static void ao_document_activate_cb(GObject *obj, GeanyDocument *doc, gpointer d
 
 static void ao_document_new_cb(GObject *obj, GeanyDocument *doc, gpointer data)
 {
-	g_return_if_fail(doc != NULL && doc->is_valid);
+	g_return_if_fail(DOC_VALID(doc));
 
 	ao_mark_document_new(ao_info->markword, doc);
 	ao_color_tip_document_new(ao_info->colortip, doc);
@@ -163,7 +163,7 @@ static void ao_document_new_cb(GObject *obj, GeanyDocument *doc, gpointer data)
 
 static void ao_document_open_cb(GObject *obj, GeanyDocument *doc, gpointer data)
 {
-	g_return_if_fail(doc != NULL && doc->is_valid);
+	g_return_if_fail(DOC_VALID(doc));
 
 	ao_tasks_update(ao_info->tasks, doc);
 	ao_mark_document_open(ao_info->markword, doc);
@@ -173,7 +173,7 @@ static void ao_document_open_cb(GObject *obj, GeanyDocument *doc, gpointer data)
 
 static void ao_document_close_cb(GObject *obj, GeanyDocument *doc, gpointer data)
 {
-	g_return_if_fail(doc != NULL && doc->is_valid);
+	g_return_if_fail(DOC_VALID(doc));
 
 	ao_tasks_remove(ao_info->tasks, doc);
 	ao_mark_document_close(ao_info->markword, doc);
@@ -183,7 +183,7 @@ static void ao_document_close_cb(GObject *obj, GeanyDocument *doc, gpointer data
 
 static void ao_document_save_cb(GObject *obj, GeanyDocument *doc, gpointer data)
 {
-	g_return_if_fail(doc != NULL && doc->is_valid);
+	g_return_if_fail(DOC_VALID(doc));
 
 	ao_tasks_update(ao_info->tasks, doc);
 }
@@ -191,7 +191,7 @@ static void ao_document_save_cb(GObject *obj, GeanyDocument *doc, gpointer data)
 
 static void ao_document_before_save_cb(GObject *obj, GeanyDocument *doc, gpointer data)
 {
-	g_return_if_fail(doc != NULL && doc->is_valid);
+	g_return_if_fail(DOC_VALID(doc));
 
 	ao_blanklines_on_document_before_save(obj, doc, data);
 }
@@ -199,7 +199,7 @@ static void ao_document_before_save_cb(GObject *obj, GeanyDocument *doc, gpointe
 
 static void ao_document_reload_cb(GObject *obj, GeanyDocument *doc, gpointer data)
 {
-	g_return_if_fail(doc != NULL && doc->is_valid);
+	g_return_if_fail(DOC_VALID(doc));
 
 	ao_tasks_update(ao_info->tasks, doc);
 }

--- a/addons/src/ao_tasks.c
+++ b/addons/src/ao_tasks.c
@@ -568,18 +568,22 @@ static void create_task(AoTasks *t, GeanyDocument *doc, gint line, const gchar *
 static gboolean update_tasks_for_doc_idle_cb(gpointer data)
 {
 	AoTasksUpdateTasksForDocArguments *arguments = data;
-	AoTasks *t = arguments->t;
-	GeanyDocument *doc = arguments->doc;
-	gboolean clear = arguments->clear;
+	AoTasksPrivate *priv;
+	GeanyDocument *doc;
 	gint lexer, lines, line, last_pos = 0, style;
 	gchar *line_buf, *display_name, *task_start, *closing_comment = NULL;
 	gchar **token;
-	AoTasksPrivate *priv = AO_TASKS_GET_PRIVATE(t);
+
+	if (! arguments)
+		return FALSE;
+
+	priv = AO_TASKS_GET_PRIVATE(arguments->t);
+	doc = arguments->doc;
 
 	if (doc->is_valid && priv->active && priv->enable_tasks)
 	{
-		if (clear)
-			ao_tasks_remove(t, doc);
+		if (arguments->clear)
+			ao_tasks_remove(arguments->t, doc);
 
 		display_name = document_get_basename_for_display(doc, -1);
 		lexer = sci_get_lexer(doc->editor->sci);
@@ -610,7 +614,7 @@ static gboolean update_tasks_for_doc_idle_cb(gpointer data)
 					(closing_comment = strstr(task_start, doc->file_type->comment_close)) != NULL)
 					*closing_comment = '\0';
 				/* create the task */
-				create_task(t, doc, line, *token, line_buf, task_start, display_name);
+				create_task(arguments->t, doc, line, *token, line_buf, task_start, display_name);
 				/* if we found a token, continue on next line */
 				break;
 			}

--- a/addons/src/ao_tasks.c
+++ b/addons/src/ao_tasks.c
@@ -576,7 +576,7 @@ static gboolean update_tasks_for_doc_idle_cb(gpointer data)
 	gchar **token;
 	AoTasksPrivate *priv = AO_TASKS_GET_PRIVATE(t);
 
-	if (doc->is_valid)
+	if (doc->is_valid && priv->active && priv->enable_tasks)
 	{
 		if (clear)
 			ao_tasks_remove(t, doc);
@@ -636,6 +636,9 @@ static void update_tasks_for_doc(AoTasks *t, GeanyDocument *doc, gboolean clear)
 	arguments->t = t;
 	arguments->doc = doc;
 	arguments->clear = clear;
+
+	if (!doc->is_valid)
+		return;
 
 	/* Check for task tokens in an idle callback to wait until Geany applied Scintilla highlighting
 	 * styles as we need them to be set before checking for tasks. */

--- a/addons/src/ao_tasks.c
+++ b/addons/src/ao_tasks.c
@@ -580,7 +580,7 @@ static gboolean update_tasks_for_doc_idle_cb(gpointer data)
 	priv = AO_TASKS_GET_PRIVATE(arguments->t);
 	doc = arguments->doc;
 
-	if (doc->is_valid && priv->active && priv->enable_tasks)
+	if (DOC_VALID(doc) && priv->active && priv->enable_tasks)
 	{
 		if (arguments->clear)
 			ao_tasks_remove(arguments->t, doc);
@@ -641,7 +641,7 @@ static void update_tasks_for_doc(AoTasks *t, GeanyDocument *doc, gboolean clear)
 	arguments->doc = doc;
 	arguments->clear = clear;
 
-	if (!doc->is_valid)
+	if (!DOC_VALID(doc))
 		return;
 
 	/* Check for task tokens in an idle callback to wait until Geany applied Scintilla highlighting


### PR DESCRIPTION
Closes #1254.

This is not completely perfect but will do the trick to delay the parsing of tasks in the current document until the main loop has triggered the also delayed colourising of the current document which is necessary for parsing the tasks.