### PR TITLE
vimode: Don't build the viw binary on Windows

### DIFF
--- a/vimode/src/Makefile.am
+++ b/vimode/src/Makefile.am
@@ -3,8 +3,6 @@ plugin = vimode
 
 geanyplugins_LTLIBRARIES = vimode.la
 
-noinst_PROGRAMS = viw
-
 vi_srcs = \
 	vi.h \
 	vi.c \
@@ -42,19 +40,23 @@ vi_srcs = \
 vimode_la_SOURCES = \
 	backends/backend-geany.c \
 	$(vi_srcs)
-
-viw_SOURCES = \
-	backends/backend-viw.c \
-	$(vi_srcs)
     
 vimode_la_CPPFLAGS = $(AM_CPPFLAGS) \
 	-DG_LOG_DOMAIN=\"Vimode\"
 vimode_la_CFLAGS = $(AM_CFLAGS)
 vimode_la_LIBADD = $(COMMONLIBS)
 
+if !MINGW
+noinst_PROGRAMS = viw
+
+viw_SOURCES = \
+	backends/backend-viw.c \
+	$(vi_srcs)
+
 viw_CPPFLAGS = $(AM_CPPFLAGS) \
 	-DG_LOG_DOMAIN=\"Vimode\"
 viw_CFLAGS = $(AM_CFLAGS)
 viw_LDADD = $(COMMONLIBS)
+endif
 
 include $(top_srcdir)/build/cppcheck.mk


### PR DESCRIPTION
With the latest version of msys, the viw binary fails to link (most probably it should be built as a C++ binary instead of the current plain C binary).

Since this binary is used just for testing purposes, there's no need to build it on Windows so this patch skips the build there to avoid this problem.

Fixes #1255 (hopefully)