### PR TITLE
Scope: Define GETTEXT_PACKAGE macro for recent cppcheck versions

### DIFF
--- a/scope/src/Makefile.am
+++ b/scope/src/Makefile.am
@@ -60,6 +60,8 @@ scope_la_CFLAGS = $(AM_CFLAGS) $(VTE_CFLAGS) \
 	-Wno-shadow \
 	-I$(top_srcdir)/utils/src
 
+AM_CPPCHECKFLAGS = -DGETTEXT_PACKAGE="geany-plugins"
+
 include $(top_srcdir)/build/cppcheck.mk
 
 if UNITTESTS


### PR DESCRIPTION
Without this, cppcheck will throw errors like
```
store/scptreestore.c:1990:37: warning: syntax error [syntaxError]
  g_param_spec_boolean("sublevels", P_("Sublevels"),
```

This is probably caused by the P_() macro if GETTEXT_PACKAGE is not set.

Admittedly, this is the easy way to fix or better workaround it. But I guess this is OK. Otherwise, make a better PR :).

The new cppcheck error breaks the night builds on Debian Unstable (https://www.geany.org/download/nightly-builds/).