### PR TITLE
projectorganizer: Increase the file number for automatic indexing to 1000

### DIFF
--- a/projectorganizer/README
+++ b/projectorganizer/README
@@ -95,7 +95,7 @@ files and VCS or hidden directories.
 
 Finally, you can specify whether all the project files should be indexed or not.
 The default settings is Auto which means that if the total number
-of project (and external directory) files is less than 300, indexing is performed.
+of project (and external directory) files is less than 1000, indexing is performed.
 This is a rather conservative number, at least for an SSD disk - Project Organizer 
 was tested with tens of thousands project files and even though the initial scanning 
 may take some time (for the linux kernel with 35000 files and 2300000 symbols it takes

--- a/projectorganizer/src/prjorg-project.c
+++ b/projectorganizer/src/prjorg-project.c
@@ -324,7 +324,7 @@ void prjorg_project_rescan(void)
 	foreach_slist(elem, prj_org->roots)
 		filenum += prjorg_project_rescan_root(elem->data);
 
-	if (prj_org->generate_tag_prefs == PrjOrgTagYes || (prj_org->generate_tag_prefs == PrjOrgTagAuto && filenum < 300))
+	if (prj_org->generate_tag_prefs == PrjOrgTagYes || (prj_org->generate_tag_prefs == PrjOrgTagAuto && filenum < 1000))
 		g_slist_foreach(prj_org->roots, (GFunc)regenerate_tags, NULL);
 }
 
@@ -700,7 +700,7 @@ GtkWidget *prjorg_project_add_properties_tab(GtkWidget *notebook)
 	label = gtk_label_new(_("Index all project files:"));
 	gtk_misc_set_alignment(GTK_MISC(label), 0, 0);
 	e->generate_tag_prefs = gtk_combo_box_text_new();
-	gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(e->generate_tag_prefs), _("Auto (index if less than 300 files)"));
+	gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(e->generate_tag_prefs), _("Auto (index if less than 1000 files)"));
 	gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(e->generate_tag_prefs), _("Yes"));
 	gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(e->generate_tag_prefs), _("No"));
 	gtk_combo_box_set_active(GTK_COMBO_BOX(e->generate_tag_prefs), prj_org->generate_tag_prefs);


### PR DESCRIPTION
Most people use SSDs these days so this shouldn't be a problem.