### PR TITLE
Fix ci version parser

### DIFF
--- a/build/ci_mingw64_geany_plugins.sh
+++ b/build/ci_mingw64_geany_plugins.sh
@@ -123,7 +123,11 @@ log_environment() {
 	echo "Geany installer              : ${GEANY_INSTALLER_EXECUTABLE}"
 	echo "PATH                         : ${PATH}"
 	echo "HOST                         : ${HOST}"
-	echo "CC                           : ${CC}"
+	echo "GCC                          : $(${HOST}-gcc -dumpfullversion) ($(${HOST}-gcc -dumpversion))"
+	echo "G++                          : $(${HOST}-g++ -dumpfullversion) ($(${HOST}-g++ -dumpversion))"
+	echo "Libstdc++                    : $(dpkg-query --showformat='${Version}' --show libstdc++6:i386)"
+	echo "GLib                         : $(pkg-config --modversion glib-2.0)"
+	echo "GTK                          : $(pkg-config --modversion gtk+-3.0)"
 	echo "CFLAGS                       : ${CFLAGS}"
 	echo "Configure                    : ${CONFIGURE_OPTIONS}"
 }

--- a/build/ci_mingw64_geany_plugins.sh
+++ b/build/ci_mingw64_geany_plugins.sh
@@ -144,8 +144,13 @@ patch_version_information() {
 		MINOR="${BASH_REMATCH[2]}"
 		PATCH="${BASH_REMATCH[4]}"
 		if [ -z "${PATCH}" ] || [ "${PATCH}" = "0" ]; then
-			MINOR="$((MINOR-1))"
-			PATCH="90"
+			if [ "${MINOR}" = "0" ]; then
+				MAJOR="$((MAJOR-1))"
+				MINOR="99"
+			else
+				MINOR="$((MINOR-1))"
+			fi
+			PATCH="99"
 		else
 			PATCH="$((PATCH-1))"
 		fi


### PR DESCRIPTION
The previous logic failed on 2.0 to make the new version number 1.99.99. This is fixed now even though the code is not perfect or good at all but should work well enough for its purposes.

See also https://github.com/geany/geany/pull/3594.

The additional log information are in pair with Geany (https://github.com/geany/geany/pull/3568/commits/b18c76edc9eb10a5c0097d4231c387885e2f266f).