### PR TITLE
git-changebar: Re-set first visible line after Scintilla size request

### DIFF
--- a/git-changebar/src/gcb-plugin.c
+++ b/git-changebar/src/gcb-plugin.c
@@ -878,6 +878,9 @@ get_widget_for_buf_range (GeanyDocument *doc,
                                MIN (width + 2, alloc.width),
                                MIN (height + 1, alloc.height));
   
+  /* Size request seems to scroll Scintilla view so we have to re-set visible lines again */
+  scintilla_send_message (sci, SCI_SETFIRSTVISIBLELINE, line_start, 0);
+  
   return GTK_WIDGET (sci);
 }
 


### PR DESCRIPTION
After updating to Scintilla 5.3.7 the Scintilla popup with the diff against git shows the wrong number.

It seems that gtk_widget_set_size_request() scrolls Scintilla view so despite it was set previously, it isn't set correctly after this call and has to be re-set.

Note that the call to SCI_SETFIRSTVISIBLELINE has to stay at the original location too, otherwise subsequent calculation using SCI_POINTXFROMPOSITION doesn't work because the line may not be visible.

@b4n Does this look OK to you? Maybe there's a better way to fix this problem so take this only as a hint where the problem is.

Fixes #1279 