### PR TITLE
GitChangebar: disable Scintilla's Change History in diff tooltip

### DIFF
--- a/git-changebar/src/gcb-plugin.c
+++ b/git-changebar/src/gcb-plugin.c
@@ -837,6 +837,7 @@ get_widget_for_buf_range (GeanyDocument *doc,
   /* hide stuff we don't wanna see */
   scintilla_send_message (sci, SCI_SETHSCROLLBAR, 0, 0);
   scintilla_send_message (sci, SCI_SETVSCROLLBAR, 0, 0);
+  scintilla_send_message (sci, SCI_SETCHANGEHISTORY, SC_CHANGE_HISTORY_DISABLED, 0);
   for (i = 0; i < SC_MAX_MARGIN; i++) {
     scintilla_send_message (sci, SCI_SETMARGINWIDTHN, i, 0);
   }


### PR DESCRIPTION
If the "Change history" feature is enabled in Geany, it might lead to styling issues in the tooltip displaying the diff of the current hunk. So always disable this feature for the tooltip where it is not needed.

I don't think we ever need the "Change history" in the diff tooltip, as the tooltip itself is already the improved version of the change history :).

![gcb_200](https://github.com/geany/geany-plugins/assets/617017/2b307df5-fccf-475c-901c-619e8c72541e)
This happens when the "Change history" feature is enabled in Geany, so it gets also enabled in the Scintilla widget for the tooltip where we don't need it.
For some reason, by setting the margin widths to 0 in https://github.com/geany/geany-plugins/blob/master/git-changebar/src/gcb-plugin.c#L840 the background colors in the Scintilla widget are reset to white (or something else happens with a similar result, I don't understand completely the relation between the margin visibility and the line background color).
Anyway, disable change history prevents this issue.