### PR TITLE
updatechecker: Fix logic comparing version numbers

### DIFF
--- a/updatechecker/src/updatechecker.c
+++ b/updatechecker/src/updatechecker.c
@@ -166,16 +166,22 @@ version_compare(const gchar *current_version)
     parse_version_string(current_version, &geany_current.major,
         &geany_current.minor, &geany_current.mini, &geany_current.extra);
 
-    if ((geany_running.major < geany_current.major) ||
-        (geany_running.minor < geany_current.minor) ||
-        (geany_running.minor < geany_current.minor))
-    {
+    if (geany_running.major < geany_current.major)
         return TRUE;
-    }
-    else
-    {
+    if (geany_running.major > geany_current.major)
         return FALSE;
-    }
+
+    if (geany_running.minor < geany_current.minor)
+        return TRUE;
+    if (geany_running.minor > geany_current.minor)
+        return FALSE;
+
+    if (geany_running.mini < geany_current.mini)
+        return TRUE;
+    if (geany_running.mini > geany_current.mini)
+        return FALSE;
+
+    return FALSE;
 }
 
 


### PR DESCRIPTION
The condition is wrong and for version 2.0 it will constantly report there's an update available when upgrading from 1.x (where x > 0).

I had a "visionary" moment regarding possible 2.0 problems and had a look at the updatechecker plugin if it handles major versions - id does, but wrongly (in addition, there are two identical conditions for the "minor" version but the "mini" version check is missing).

I haven't tested this at all (not sure how to test when there's no actual release).

@b4n @eht16 I think this or some other variant of this patch should go to 2.0.