### PR TITLE
Fix handling of locals

### DIFF
--- a/geanygendoc/data/filetypes/c.conf
+++ b/geanygendoc/data/filetypes/c.conf
@@ -41,6 +41,8 @@ doctypes = {
     struct.prototype.policy = FORWARD;
     member.policy           = FORWARD;
     enumval.policy          = FORWARD;
+    # usually, locals are just not documented and get in the way
+    local.policy            = FORWARD;
     
     function = {
       template = "/**\n * {symbol}:\n{for arg in argument_list} * @{arg}: {cursor}\n{end} * \n * {cursor}\n{if returns} * \n * Returns: \n{end}{if write_since}{if returns} * \n{end} * Since: \n{end} */\n";
@@ -73,6 +75,9 @@ doctypes = {
   }
 
   doxygen = {
+    # usually, locals are just not documented and get in the way
+    local.policy = FORWARD;
+
     function.template = "/**\n * {doxygen_prefix}brief {cursor}\n{for a in argument_list} * {doxygen_prefix}param {a} \n{end}{if returns} * {doxygen_prefix}returns \n{end}{if write_since} * {doxygen_prefix}since \n{end} * \n * \n */\n";
     macro.template    = "/**\n * {doxygen_prefix}brief {cursor}\n{for a in argument_list} * {doxygen_prefix}param {a} \n{end}{if returns} * {doxygen_prefix}returns \n{end}{if write_since} * {doxygen_prefix}since \n{end} * \n * \n */\n";
     struct.member = {

--- a/geanygendoc/docs/manual.rst
+++ b/geanygendoc/docs/manual.rst
@@ -348,6 +348,8 @@ Known types
   A function.
 ``interface``
   An interface.
+``local``
+  A local variable.
 ``member``
   A member (of a structure for example).
 ``method``

--- a/geanygendoc/src/ggd-tag-utils.c
+++ b/geanygendoc/src/ggd-tag-utils.c
@@ -255,6 +255,7 @@ static const struct {
   { tm_tag_field_t,           "field"     },
   { tm_tag_function_t,        "function"  },
   { tm_tag_interface_t,       "interface" },
+  { tm_tag_local_var_t,       "local"     },
   { tm_tag_member_t,          "member"    },
   { tm_tag_method_t,          "method"    },
   { tm_tag_namespace_t,       "namespace" },

--- a/geanygendoc/src/ggd.c
+++ b/geanygendoc/src/ggd.c
@@ -208,7 +208,7 @@ get_env_for_tag (GgdFileType   *ft,
       CtplValue    *v;
       GList        *tmp = children;
       
-      if (el->type & setting->matches) {
+      if (type_name && el->type & setting->matches) {
         v = g_hash_table_lookup (vars, type_name);
         if (! v) {
           v = ctpl_value_new_array (CTPL_VTYPE_STRING, 0, NULL);


### PR DESCRIPTION
This is a two-parts fix required for usage with 2.0:

8cad88d72c343fd1091b6dab85ecb226c062a9da: Fix a crash when encountering an unknown tag type (e.g. locals)
3af0bf5117a1143b20286f5ee9fb0a2c35916d6b: Add support for locals, and do something useful with them by default.

Without the first one, triggering documentation generation when a local is the "current" symbol crashes the plugin (and thus Geany).
Without the second one in addition, it's annoying because locals "catch" the generation request, although in most cases they should be skipped.

Both of these are particularly important with 2.0 because we now generate locals for purpose of improved scope completion, and thus we have a *lot* of them for parsers supporting it (e.g. the C and C++ one, which is the main default target of the plugin).