### PR TITLE
projectorganizer: prjorg-sidebar.c: Cast g_ptr_array_free to gchar**

### DIFF
--- a/projectorganizer/src/prjorg-sidebar.c
+++ b/projectorganizer/src/prjorg-sidebar.c
@@ -1562,7 +1562,7 @@ gchar **prjorg_sidebar_get_expanded_paths(void)
 		(GtkTreeViewMappingFunc)on_map_expanded, expanded_paths);
 	g_ptr_array_add(expanded_paths, NULL);
 
-	return g_ptr_array_free(expanded_paths, FALSE);
+	return (gchar **) g_ptr_array_free(expanded_paths, FALSE);
 }
 
 


### PR DESCRIPTION
Grepping the source code shows this is already done in pohelper/src/gph-plugin.c at line 903.

Tests run: Compiles on GCC 14

Fixes #1297

Bug report from Gentoo: https://bugs.gentoo.org/919446