### PR TITLE
LaTeX: Switch handling of insert (list) environments over to snippets workflow

### DIFF
--- a/latex/src/latexenvironments.c
+++ b/latex/src/latexenvironments.c
@@ -121,7 +121,8 @@ void glatex_insert_environment(const gchar *environment, gint type)
 					environment,
 					"}{}\n%cursor%\n\\end{",
 					environment,
-					"}");
+					"}",
+					NULL);
 			}
 			else /* We don't have a block-like environment */
 			{
@@ -130,9 +131,10 @@ void glatex_insert_environment(const gchar *environment, gint type)
 					tmpstring = g_strconcat(
 						"\\begin{",
 						environment,
-						"}\n\t\\item %cursor% \n\\end{",
+						"}\n\t\\item %cursor%\n\\end{",
 						environment,
-						"}");
+						"}",
+						NULL);
 				}
 				else
 				{
@@ -141,7 +143,8 @@ void glatex_insert_environment(const gchar *environment, gint type)
 						environment,
 						"}\n%cursor%\n\\end{",
 						environment,
-						"}");
+						"}",
+						NULL);
 				}
 			}
 			glatex_insert_snippet(tmpstring);

--- a/latex/src/latexenvironments.c
+++ b/latex/src/latexenvironments.c
@@ -1,7 +1,7 @@
 /*
  *	  latexenvironments.c
  *
- *	  Copyright 2009-2012 Frank Lanitz <frank(at)frank(dot)uvena(dot)de>
+ *	  Copyright 2009-2024 Frank Lanitz <frank(at)frank(dot)uvena(dot)de>
  *
  *	  This program is free software; you can redistribute it and/or modify
  *	  it under the terms of the GNU General Public License as published by
@@ -69,6 +69,7 @@ void glatex_insert_environment(const gchar *environment, gint type)
 	/* Only do anything if it is realy needed to */
 	if (doc != NULL && environment != NULL)
 	{
+		/* Checking whether we do have a selection */
 		if (sci_has_selection(doc->editor->sci))
 		{
 			gchar *selection  = NULL;
@@ -92,12 +93,9 @@ void glatex_insert_environment(const gchar *environment, gint type)
 			g_free(replacement);
 
 		}
-		else
+		else /* No selection found*/
 		{
-			gint indent, pos;
-			GString *tmpstring = NULL;
-			gchar *tmp = NULL;
-			static const GeanyIndentPrefs *indention_prefs = NULL;
+			gchar *tmpstring = NULL;
 
 			if (type == -1)
 			{
@@ -114,49 +112,40 @@ void glatex_insert_environment(const gchar *environment, gint type)
 					}
 				}
 			}
-			pos = sci_get_current_position(doc->editor->sci);
-
 			sci_start_undo_action(doc->editor->sci);
-
-			tmpstring = g_string_new("\\begin{");
-			g_string_append(tmpstring, environment);
 
 			if (utils_str_equal(environment, "block") == TRUE)
 			{
-				g_string_append(tmpstring, "}{}");
+				tmpstring = g_strconcat(
+					"\\begin{",
+					environment,
+					"}{}\n%cursor%\n\\end{",
+					environment,
+					"}");
 			}
-			else
+			else /* We don't have a block-like environment */
 			{
-				g_string_append(tmpstring, "}");
+				if (type == GLATEX_ENVIRONMENT_TYPE_LIST)
+				{
+					tmpstring = g_strconcat(
+						"\\begin{",
+						environment,
+						"}\n\t\\item %cursor% \n\\end{",
+						environment,
+						"}");
+				}
+				else
+				{
+					tmpstring = g_strconcat(
+						"\\begin{",
+						environment,
+						"}\n%cursor%\n\\end{",
+						environment,
+						"}");
+				}
 			}
-			g_string_append(tmpstring, "\n");
-
-
-			if (type == GLATEX_ENVIRONMENT_TYPE_LIST)
-			{
-				g_string_append(tmpstring, "\t\\item ");
-			}
-
-			tmp = g_string_free(tmpstring, FALSE);
-			glatex_insert_string(tmp, TRUE);
-			g_free(tmp);
-
-			indent = sci_get_line_indentation(doc->editor->sci,
-				sci_get_line_from_position(doc->editor->sci, pos));
-
-			tmp = g_strdup_printf("\n\\end{%s}", environment);
-			glatex_insert_string(tmp, FALSE);
-			g_free(tmp);
-
-			indention_prefs = editor_get_indent_prefs(doc->editor);
-			if (type == GLATEX_ENVIRONMENT_TYPE_LIST)
-			{
-				sci_set_line_indentation(doc->editor->sci,
-					sci_get_current_line(doc->editor->sci),
-					indent + indention_prefs->width);
-			}
-			sci_set_line_indentation(doc->editor->sci,
-				sci_get_current_line(doc->editor->sci) + 1, indent);
+			glatex_insert_snippet(tmpstring);
+			g_free(tmpstring);
 			sci_end_undo_action(doc->editor->sci);
 		}
 	}

--- a/latex/src/latexutils.c
+++ b/latex/src/latexutils.c
@@ -89,12 +89,22 @@ void glatex_usepackage(const gchar *pkg, const gchar *options)
 	ui_set_statusbar(TRUE, _("Could not determine where to insert package: %s"), pkg );
 }
 
-
 void glatex_enter_key_pressed_in_entry(G_GNUC_UNUSED GtkWidget *widget, gpointer dialog)
 {
 	gtk_dialog_response(GTK_DIALOG(dialog), GTK_RESPONSE_ACCEPT);
 }
 
+void glatex_insert_snippet(const gchar *string)
+{
+	GeanyDocument *doc = NULL;
+
+	doc = document_get_current();
+	if (doc != NULL && string != NULL)
+	{
+		gint pos = sci_get_current_position(doc->editor->sci);
+		editor_insert_snippet(doc->editor, pos, string);
+	}
+}
 
 void
 glatex_insert_string(const gchar *string, gboolean reset_position)
@@ -116,7 +126,6 @@ glatex_insert_string(const gchar *string, gboolean reset_position)
 		editor_insert_text_block(doc->editor, string, pos, len, 0, TRUE);
 	}
 }
-
 
 void glatex_replace_special_character(void)
 {

--- a/latex/src/latexutils.h
+++ b/latex/src/latexutils.h
@@ -26,6 +26,7 @@
 gchar **glatex_read_file_in_array(const gchar *filename);
 void glatex_usepackage(const gchar *pkg, const gchar *options);
 void glatex_enter_key_pressed_in_entry(G_GNUC_UNUSED GtkWidget *widget, gpointer dialog);
+void glatex_insert_snippet(const gchar *string);
 void glatex_insert_string(const gchar *string, gboolean reset_position);
 void glatex_replace_special_character(void);
 


### PR DESCRIPTION
This MR migrates the feature to insert any environment over to Geany's snippets workflow. Hence we don't need to bother about indention, like breaks etc. this much anymore. Also due to the cursor-feature it ensures to position the cursor at the right place , independent from the line break, indention etc. 

Due to this rework it makes the code also a little more readable and fixes #1071 