### PR TITLE
projectorganizer: Use g_pattern_spec_match_string() instead of g_pattern_match_string()

### DIFF
--- a/projectorganizer/src/prjorg-project.c
+++ b/projectorganizer/src/prjorg-project.c
@@ -216,7 +216,7 @@ static gboolean match_basename(gconstpointer pft, gconstpointer user_data)
 	{
 		GPatternSpec *pattern = g_pattern_spec_new(ft->pattern[j]);
 
-		if (g_pattern_match_string(pattern, utf8_base_filename))
+		if (g_pattern_spec_match_string(pattern, utf8_base_filename))
 		{
 			ret = TRUE;
 			g_pattern_spec_free(pattern);

--- a/projectorganizer/src/prjorg-sidebar.c
+++ b/projectorganizer/src/prjorg-sidebar.c
@@ -657,7 +657,7 @@ static void find_file_recursive(GtkTreeIter *iter, gboolean case_sensitive, gboo
 		if (!case_sensitive)
 			SETPTR(utf8_name, g_utf8_strdown(utf8_name, -1));
 
-		if (g_pattern_match_string(pattern, utf8_name))
+		if (g_pattern_spec_match_string(pattern, utf8_name))
 		{
 			gchar *utf8_base_path = get_project_base_path();
 			gchar *utf8_path, *rel_path;
@@ -840,7 +840,7 @@ static gboolean match(TMTag *tag, const gchar *name, gboolean declaration, gbool
 				matches = g_strcmp0(name_case, name) == 0;
 				break;
 			case MATCH_PATTERN:
-				matches = g_pattern_match_string(pspec, name_case);
+				matches = g_pattern_spec_match_string(pspec, name_case);
 				break;
 			case MATCH_PREFIX:
 				matches = g_str_has_prefix(name_case, name);

--- a/projectorganizer/src/prjorg-utils.c
+++ b/projectorganizer/src/prjorg-utils.c
@@ -80,7 +80,7 @@ gboolean patterns_match(GSList *patterns, const gchar *str)
 	foreach_slist (elem, patterns)
 	{
 		GPatternSpec *pattern = elem->data;
-		if (g_pattern_match_string(pattern, str))
+		if (g_pattern_spec_match_string(pattern, str))
 			return TRUE;
 	}
 	return FALSE;
@@ -269,7 +269,7 @@ gchar *try_find_header_source(gchar *utf8_file_name, gboolean is_header, GSList 
 		full_name = elem->data;
 		gchar *base_name = g_path_get_basename(full_name);
 
-		if (g_pattern_match_string(pattern, base_name))
+		if (g_pattern_spec_match_string(pattern, base_name))
 		{
 			if ((is_header && patterns_match(source_patterns, base_name)) ||
 				(!is_header && patterns_match(header_patterns, base_name)))

--- a/projectorganizer/src/prjorg-utils.h
+++ b/projectorganizer/src/prjorg-utils.h
@@ -22,6 +22,10 @@
 #include <gtk/gtk.h>
 #include <geanyplugin.h>
 
+#if ! GLIB_CHECK_VERSION(2, 70, 0)
+# define g_pattern_spec_match_string g_pattern_match_string
+#endif
+
 gchar *get_relative_path(const gchar *utf8_parent, const gchar *utf8_descendant);
 
 gboolean patterns_match(GSList *patterns, const gchar *str);


### PR DESCRIPTION
Eliminates a warning on newer glib versions. Adds a fallback on older versions.