### PR TITLE
vimode: Handle folded lines correctly

### DIFF
--- a/vimode/src/cmd-runner.c
+++ b/vimode/src/cmd-runner.c
@@ -704,6 +704,7 @@ static gboolean process_cmd(CmdDef *cmds, CmdContext *ctx, gboolean ins_mode)
 	{
 		if (orig_mode == VI_MODE_COMMAND_SINGLE)
 			vi_set_mode(VI_MODE_INSERT);
+		ensure_current_line_expanded(ctx->sci);
 	}
 	else if (!consumed && ctx->kpl)
 	{

--- a/vimode/src/excmd-runner.c
+++ b/vimode/src/excmd-runner.c
@@ -465,6 +465,7 @@ void excmd_perform(CmdContext *ctx, const gchar *cmd)
 	{
 		case ':':
 			perform_simple_ex_cmd(ctx, cmd + 1);
+			ensure_current_line_expanded(ctx->sci);
 			break;
 		case '/':
 		case '?':
@@ -483,6 +484,7 @@ void excmd_perform(CmdContext *ctx, const gchar *cmd)
 			pos = perform_search(ctx->sci, ctx->search_text, ctx->num, FALSE);
 			if (pos >= 0)
 				SET_POS(ctx->sci, pos, TRUE);
+			ensure_current_line_expanded(ctx->sci);
 			break;
 		}
 	}

--- a/vimode/src/utils.c
+++ b/vimode/src/utils.c
@@ -219,3 +219,11 @@ void goto_nonempty(ScintillaObject *sci, gint line, gboolean scroll)
 		pos = NEXT(sci, pos);
 	SET_POS(sci, pos, scroll);
 }
+
+
+void ensure_current_line_expanded(ScintillaObject *sci)
+{
+	gint line = GET_CUR_LINE(sci);
+	if (!SSM(sci, SCI_GETLINEVISIBLE, line, 0))
+		SSM(sci, SCI_ENSUREVISIBLE, line, 0);
+}

--- a/vimode/src/utils.h
+++ b/vimode/src/utils.h
@@ -32,5 +32,6 @@ void perform_substitute(ScintillaObject *sci, const gchar *cmd, gint from, gint 
 	const gchar *flag_override);
 
 gint get_line_number_rel(ScintillaObject *sci, gint shift);
+void ensure_current_line_expanded(ScintillaObject *sci);
 
 #endif


### PR DESCRIPTION
This PR addresses some issues of the plugin with folded lines - see the individual commits.

I'd also like to automatically set the cursor position when a block gets folded to be set on the visible line (and not hidden somewhere inside the fold) but right now I don't know how to correctly react to the fold events - see https://sourceforge.net/p/scintilla/bugs/2438/

@scresto09 Do the changes look OK to you and does the plugin behave correctly with them?