### PR TITLE
geanyctags, projectorganizer, vimode: Some README and URL updates

### DIFF
--- a/geanyctags/README
+++ b/geanyctags/README
@@ -11,7 +11,7 @@ GeanyCtags adds a simple support for generating and querying ctags files for a G
 project. It requires that the ctags command is installed in a system path. On
 unix systems, distributions usually provide the ctags package; on Windows, the
 ctags binary can be found in the zip Windows distribution from the ctags home
-page (http://ctags.sourceforge.net).
+page (https://ctags.sourceforge.net).
 
 Even though Geany supports symbol definition searching by itself within the open files
 (and with a plugin support within the whole project), tag regeneration can become
@@ -97,7 +97,7 @@ Downloads
 
 GeanyCtags is part of the combined Geany Plugins release.
 For more information and downloads, please visit
-http://plugins.geany.org/geany-plugins/
+https://plugins.geany.org/geany-plugins/
 
 Development Code
 ================

--- a/geanyctags/README
+++ b/geanyctags/README
@@ -9,9 +9,11 @@ About
 
 GeanyCtags adds a simple support for generating and querying ctags files for a Geany
 project. It requires that the ctags command is installed in a system path. On
-unix systems, distributions usually provide the ctags package; on Windows, the
-ctags binary can be found in the zip Windows distribution from the ctags home
-page (https://ctags.sourceforge.net).
+unix systems, distributions usually provide the ctags (original but orphaned
+and unmaintained) or universal-ctags (forked and maintained) packages. On Windows,
+the universal-ctags binaries can be downloaded from::
+
+    https://github.com/universal-ctags/ctags-win32/releases
 
 Even though Geany supports symbol definition searching by itself within the open files
 (and with a plugin support within the whole project), tag regeneration can become

--- a/geanyctags/README
+++ b/geanyctags/README
@@ -109,9 +109,10 @@ Get the code from::
 Ideas, questions, patches and bug reports
 =========================================
 
-Please direct all questions, bug reports and patches to the plugin author using the
-email address listed below or to the Geany mailing list to get some help from other
-Geany users.
+Please direct all questions, bug reports and patches to the combined geany-plugins
+project at https://github.com/geany/geany-plugins and open the corresponding
+bug report or pull request there. To notify the author of this plugin about
+your post, mention him using his github user name (@techee).
 
 2010-2014 by Jiří Techet
 techet(at)gmail(dot)com

--- a/projectorganizer/README
+++ b/projectorganizer/README
@@ -228,9 +228,10 @@ Get the code from::
 Ideas, questions, patches and bug reports
 =========================================
 
-Please direct all questions, bug reports and patches to the plugin author using the
-email address listed below or to the Geany mailing list to get some help from other
-Geany users.
+Please direct all questions, bug reports and patches to the combined geany-plugins
+project at https://github.com/geany/geany-plugins and open the corresponding
+bug report or pull request there. To notify the author of this plugin about
+your post, mention him using his github user name (@techee).
 
 2010-2014 by Jiří Techet
 techet(at)gmail(dot)com

--- a/projectorganizer/README
+++ b/projectorganizer/README
@@ -216,7 +216,7 @@ Downloads
 
 Project Organizer is part of the combined Geany Plugins release.
 For more information and downloads, please visit
-http://plugins.geany.org/geany-plugins/
+https://plugins.geany.org/geany-plugins/
 
 Development Code
 ================

--- a/projectorganizer/src/prjorg-main.c
+++ b/projectorganizer/src/prjorg-main.c
@@ -223,5 +223,5 @@ void plugin_cleanup(void)
 
 void plugin_help (void)
 {
-	utils_open_browser("http://plugins.geany.org/projectorganizer.html");
+	utils_open_browser("https://plugins.geany.org/projectorganizer.html");
 }

--- a/vimode/README
+++ b/vimode/README
@@ -106,7 +106,7 @@ This is an incomplete list of known limitations of the plugin:
 * only the 'g' flag is supported in the substitute command
 * in search and substitute the regular expressions are based on Scintilla regular
   expressions which differ from Vim. Check the Scintilla documentation at
-  http://www.scintilla.org/ScintillaDoc.html#Searching for more details.
+  https://www.scintilla.org/ScintillaDoc.html#Searching for more details.
   In addition, \c is also supported to allow case-insensitive search.
 
 FAQ
@@ -200,7 +200,7 @@ Downloads
 =========
 
 Vimode is part of the combined Geany Plugins release. For more information and
-downloads, please visit http://plugins.geany.org/geany-plugins/
+downloads, please visit https://plugins.geany.org/geany-plugins/
 
 Source Code
 ===========

--- a/vimode/README
+++ b/vimode/README
@@ -182,8 +182,10 @@ Jiří Techet, <techet(at)gmail(dot)com>.
 
 Bug Reports
 -----------
-To report bugs, please use the Geany-Plugins GitHub page at
-https://github.com/geany/geany-plugins/issues
+Please direct all questions, bug reports and patches to the combined geany-plugins
+project at https://github.com/geany/geany-plugins and open the corresponding
+bug report or pull request there. To notify the author of this plugin about
+your post, mention him using his github user name (@techee).
 
 License
 =======

--- a/vimode/src/backends/backend-geany.c
+++ b/vimode/src/backends/backend-geany.c
@@ -337,5 +337,5 @@ void plugin_cleanup(void)
 
 void plugin_help(void)
 {
-	utils_open_browser("http://plugins.geany.org/vimode.html");
+	utils_open_browser("https://plugins.geany.org/vimode.html");
 }


### PR DESCRIPTION
1. Suggest using Github for reporting bugs and pull requests instead of sending them by email.
2. Use https:// instead of http://
3. Mention universal-ctags as a maintained version of ctags in geanyctags README