### PR TITLE
ProjectOrganizer, Workbench: Use GStatBuf for "g_stat()" calls

### DIFF
--- a/projectorganizer/src/prjorg-project.c
+++ b/projectorganizer/src/prjorg-project.c
@@ -234,7 +234,7 @@ static gboolean match_basename(gconstpointer pft, gconstpointer user_data)
  * extension and only if this fails, look at the shebang */
 static GeanyFiletype *filetypes_detect(const gchar *utf8_filename)
 {
-	struct stat s;
+	GStatBuf s;
 	GeanyFiletype *ft = NULL;
 	gchar *locale_filename;
 

--- a/workbench/src/tm_control.c
+++ b/workbench/src/tm_control.c
@@ -165,7 +165,7 @@ static gboolean match_basename(gconstpointer pft, gconstpointer user_data)
  * extension and only if this fails, look at the shebang */
 static GeanyFiletype *filetypes_detect(const gchar *utf8_filename)
 {
-	struct stat s;
+	GStatBuf s;
 	GeanyFiletype *ft = NULL;
 	gchar *locale_filename;
 


### PR DESCRIPTION
For some reason, since the latest MSYS2 update on my Windows system, I got compiler errors that `g_stat()` requires a `GStatBuf` type as second argument.

According to the docs, https://docs.gtk.org/glib/func.stat.html, this is correct and in Geany we also use `GStatBuf` in all places.