### PR TITLE
geniuspaste: Ask confirmation before pasting

### DIFF
--- a/geniuspaste/TODO
+++ b/geniuspaste/TODO
@@ -4,5 +4,4 @@ TODO
     - recent pastes history
     - URL shortening (?)
     - authentication (per-pastebin)
-    - confirmation dialog/infobar?  pasted data is potentially sensitive
     - support for Gist, which is likely the most used service


### PR DESCRIPTION
The pasted data might contain sensitive information and the pastebin service might be public and might not allow deleting a paste (at least not in a way the plugin supports).  Thus, ask confirmation by default in case the user accidentally triggered the action.

@xiota does this make you a tad more comfortable?  The UI isn't stellar, but it gets the job done and fearless users can disable it.