### PR TITLE
Surround word with "\\<" and "\\>" for search_current().

### DIFF
--- a/vimode/src/cmds/special.c
+++ b/vimode/src/cmds/special.c
@@ -94,7 +94,7 @@ static void search_current(CmdContext *c, CmdParams *p, gboolean next)
 	else
 	{
 		const gchar *prefix = next ? "/" : "?";
-		c->search_text = g_strconcat(prefix, word, NULL);
+		c->search_text = g_strconcat(prefix, "\\<", word, "\\>", NULL);
 	}
 	g_free(word);
 


### PR DESCRIPTION
The crosshatch (#) and asterisk (*) commands in Vim perform exact word searches. For example, with the cursor on "word", the asterisk would perform "/\\<word\\>" to search for the next exact occurrence of "word".