### PR TITLE
Add .editorconfig so github uses the correct tab size (4)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_size = 4
+end_of_line = lf
+
+[*.{c,h,cxx,am,m4}]
+indent_style = tab
+
+[*.{py}]
+indent_style = space
+


### PR DESCRIPTION
See the related discussion in https://github.com/geany/geany/pull/1193.

The branch with this commit is here

https://github.com/techee/geany-plugins/tree/editorconfig

so the effect of this PR can be examined by browsing the code there.