### PR TITLE
git-changebar: Rename bool for C23 compatibility

### DIFF
--- a/git-changebar/src/gcb-plugin.c
+++ b/git-changebar/src/gcb-plugin.c
@@ -1411,9 +1411,9 @@ read_setting_boolean (GKeyFile     *kf,
                       const gchar  *key,
                       gpointer      value)
 {
-  gboolean *bool = value;
+  gboolean *boolean = value;
   
-  *bool = utils_get_setting_boolean (kf, group, key, *bool);
+  *boolean = utils_get_setting_boolean (kf, group, key, *boolean);
 }
 
 static void
@@ -1422,9 +1422,9 @@ write_setting_boolean (GKeyFile      *kf,
                        const gchar   *key,
                        gconstpointer  value)
 {
-  const gboolean *bool = value;
+  const gboolean *boolean = value;
   
-  g_key_file_set_boolean (kf, group, key, *bool);
+  g_key_file_set_boolean (kf, group, key, *boolean);
 }
 
 /* loads @filename in @kf and return %FALSE if failed, emitting a warning


### PR DESCRIPTION
C23 is adding a bool keyword:

https://en.cppreference.com/w/c/keyword/bool

With GCC 15 (in development, bug fixing) this causes a failure: `error: expected identifier or '(' before 'bool'`
