### PR TITLE
codenav/goto_file: Improvements & fixes (tab key autocomplete, absolute dirs, ~/)

### DIFF
--- a/codenav/src/goto_file.c
+++ b/codenav/src/goto_file.c
@@ -364,9 +364,6 @@ create_dialog(GtkWidget **dialog)
 	 * might attempt to utilize it, before any 'changed' events are fired. */
 	directory_check(GTK_ENTRY(entry), completion);
 
-	/* Manual trigger to show the completion list as soon as the dialog opens */
-	g_signal_emit_by_name(entry, "changed");
-
 	/* Signals */
 	g_signal_connect_after(entry, "changed",
 		G_CALLBACK(directory_check), completion);


### PR DESCRIPTION
Hi, this *supercharges* codenav/goto_file with a wide range of changes, fixes, and new features.

I've included all the smaller commits, in case someone wants to take a closer look at each change, but I can squash them together before merging. This also supersedes #1329.

Features & changes:
- The Tab key can now be used to: 
  *(Inspired from shells, and GtkFileChooser)*
  - Show the completion list when it's hidden
  - Trigger an inline completion
  - Accept a suggested inline completion
- Keep dialog open after user denies creation of not-found file (#1329)
- Allow absolute paths, and recognize `~` as the user's home dir
- If no document is open, the current dir is the user's home dir
- Show error if the entered path is a directory
- ~Show completion list as soon as dialog opens~
  - *Did we actually want this? Input welcome.*
- Bug fixes, improvements, code formatting fixes

Demo:

https://github.com/user-attachments/assets/d8458c58-7f3b-4fc8-bc7c-c123608b446a
