### PR TITLE
commander: small improvement on listing and panel width

### DIFF
--- a/commander/src/commander-plugin.c
+++ b/commander/src/commander-plugin.c
@@ -345,7 +345,16 @@ store_populate_menu_items (GtkListStore  *store,
       } else {
         gchar *tmp;
         gchar *tooltip;
-        gchar *label = g_markup_printf_escaped ("<big>%s</big>", item_label);
+        gchar *basename = g_path_get_basename (item_label);
+        gchar *dirname = g_path_get_dirname (item_label);
+        gchar *dirname_basename = g_path_get_basename(dirname);
+        gchar *label;
+
+        if (g_strcmp0(".", dirname_basename)  == 0) {
+          label = g_markup_printf_escaped ("<big>%s</big>", basename);
+        } else {
+          label = g_markup_printf_escaped ("<big>%s/%s</big>", dirname_basename, basename);
+        }
         
         tooltip = gtk_widget_get_tooltip_markup (node->data);
         if (tooltip) {
@@ -365,6 +374,9 @@ store_populate_menu_items (GtkListStore  *store,
                                            -1);
         
         g_free (label);
+        g_free (basename);
+        g_free (dirname);
+        g_free (dirname_basename);
       }
       
       g_free (item_label);
@@ -410,8 +422,11 @@ fill_store (GtkListStore *store)
   /* open files */
   foreach_document (i) {
     gchar *basename = g_path_get_basename (DOC_FILENAME (documents[i]));
-    gchar *label = g_markup_printf_escaped ("<big>%s</big>\n"
+    gchar *dirname = g_path_get_dirname (DOC_FILENAME (documents[i]));
+    gchar *dirname_basename = g_path_get_basename (dirname);
+    gchar *label = g_markup_printf_escaped ("<big>%s/%s</big>\n"
                                             "<small><i>%s</i></small>",
+                                            dirname_basename,
                                             basename,
                                             DOC_FILENAME (documents[i]));
     
@@ -422,6 +437,8 @@ fill_store (GtkListStore *store)
                                        COL_DOCUMENT, documents[i],
                                        -1);
     g_free (basename);
+    g_free (dirname);
+    g_free (dirname_basename);
     g_free (label);
   }
 }
@@ -658,10 +675,17 @@ create_panel (void)
   GtkWidget          *scroll;
   GtkTreeViewColumn  *col;
   GtkCellRenderer    *cell;
-  
+  int                window_width;
+  int                window_height;
+
+  gtk_window_get_size (GTK_WINDOW(geany_data->main_widgets->window), &window_width, &window_height);
+  if (window_width >= 500) {
+    window_width = window_width / 2;
+  }
+
   plugin_data.panel = g_object_new (GTK_TYPE_WINDOW,
                                     "decorated", FALSE,
-                                    "default-width", 500,
+                                    "default-width", window_width,
                                     "default-height", 200,
                                     "transient-for", geany_data->main_widgets->window,
                                     "window-position", GTK_WIN_POS_CENTER_ON_PARENT,


### PR DESCRIPTION
## Motivation

When working  with different directories that have some common files that have long full path names, it's hard to find the right file from the list. This is because the panel's width is 500 and the full path may not be shown completely within the panel as below

```
<-------- visible to  user --------> <----- invisible to users ------------------->

/-----------------------------------\
| /foo/bar/directory/with/very/long-|/path/name1/sample.txt
| Files -> Recent Files -> /foo/bar/|directory/with/very/long-/path1/name/sample.txt
| /foo/bar/directory/with/very/long-|/path/name2/sample.txt
| Files -> Recent Files -> /foo/bar/|directory/with/very/long-/path2/name/sample.txt
\-----------------------------------/

```

In this illustration, when  looking up  `sample.txt`, the user has no idea about the directory  information (both `path/name1` and `path/name2` do matching)

## The patches

- [ ] The panel's width is  one half of the width of the Geany window when this amount is greater than or equals to 250
- [ ] Otherwise the panel's width defaults to the width of the Geany window
- [ ] For labels, don't display  full names; only display the parent directory's basename and the file name

The previous illustration now becomes

```
/-----------------------------------\
| name1/sample.txt                  |
| Files -> Recent Files -> /foo/bar/|directory/with/very/long-/path/name1/sample.txt
| name2/sample.txt                  |
| Files -> Recent Files -> /foo/bar/|directory/with/very/long-/path/name2/sample.txt
\-----------------------------------/
```

and this helps user to quickly find the right files. 

Of course this doesn't solve all edge cases when there are a few more levels of  duplication in full path names.
