### PR TITLE
GeanyLua: geany.fileinfo: Added a field for single-line comments; all 'comment' fields are renamed as in filetype definition files.

### DIFF
--- a/geanylua/docs/geanylua-ref.html
+++ b/geanylua/docs/geanylua-ref.html
@@ -544,8 +544,9 @@ The returned table contains the following fields:
 <tr><td width="5%"></td><td><tt>ext</tt> </td><td> -- The file extension, including the dot, e.g. "<b>.DLL</b>" or "<b>.txt</b>"</td></tr>
 <tr><td width="5%"></td><td><tt>type</tt> </td><td> -- A one-word description of the filetype, e.g. "<b>C</b>" or "<b>Python</b>".</td></tr>
 <tr><td width="5%"></td><td><tt>desc</tt> </td><td> -- A longer description of the filetype, e.g. "<b>Lua source file</b>" or "<b>Cascading StyleSheet</b>".</td></tr>
-<tr><td width="5%"></td><td><tt>opener</tt> </td><td> -- The string used to begin a comment, e.g. "<b class="desc">&lt;!--</b>".</td></tr>
-<tr><td width="5%"></td><td><tt>closer</tt> </td><td> -- The string used to end a comment, e.g. "<b class="desc">--&gt;</b>".</td></tr>
+<tr><td width="5%"></td><td><tt>comment_single</tt> </td><td> -- The string used for a single-line comment, e.g. "<b class="desc">//</b>".</td></tr>
+<tr><td width="5%"></td><td><tt>comment_open</tt> </td><td> -- The string used to begin a multi-line comment, e.g. "<b class="desc">&lt;!--</b>".</td></tr>
+<tr><td width="5%"></td><td><tt>comment_close</tt> </td><td> -- The string used to end a multi-line comment, e.g. "<b class="desc">--&gt;</b>".</td></tr>
 <tr><td width="5%"></td><td><tt>action</tt> </td><td> -- The action command as executed by the context menu</td></tr>
 <!--
 <tr><td width="5%"></td><td><tt>compiler</tt> </td><td> -- The command used to compile this type of file.</td></tr>

--- a/geanylua/glspi_doc.c
+++ b/geanylua/glspi_doc.c
@@ -319,22 +319,23 @@ static gint glspi_fileinfo(lua_State* L)
 		SetTableStr("name", "")
 		SetTableStr("path", "")
 	}
-	SetTableStr("type",   FileTypeStr(name));
-	SetTableStr("desc",   FileTypeStr(title));
-	SetTableStr("opener", FileTypeStr(comment_open));
-	SetTableStr("closer", FileTypeStr(comment_close));
-	SetTableStr("action", FileTypeStr(context_action_cmd));
+	SetTableStr("type",           FileTypeStr(name));
+	SetTableStr("desc",           FileTypeStr(title));
+	SetTableStr("comment_single", FileTypeStr(comment_single));
+	SetTableStr("comment_open",   FileTypeStr(comment_open));
+	SetTableStr("comment_close",  FileTypeStr(comment_close));
+	SetTableStr("action",         FileTypeStr(context_action_cmd));
 /*
 	SetTableStr("compiler", BuildCmdStr(compiler));
 	SetTableStr("linker",   BuildCmdStr(linker));
 	SetTableStr("exec",     BuildCmdStr(run_cmd));
 	SetTableStr("exec2",    BuildCmdStr(run_cmd2));
 */
-	SetTableNum("ftid", GPOINTER_TO_INT(doc->file_type?doc->file_type->id:GEANY_FILETYPES_NONE));
-	SetTableStr("encoding", StrField(doc,encoding));
-	SetTableBool("bom",doc->has_bom);
-	SetTableBool("changed",doc->changed);
-	SetTableBool("readonly",doc->readonly);
+	SetTableNum("ftid",      GPOINTER_TO_INT(doc->file_type?doc->file_type->id:GEANY_FILETYPES_NONE));
+	SetTableStr("encoding",  StrField(doc,encoding));
+	SetTableBool("bom",      doc->has_bom);
+	SetTableBool("changed",  doc->changed);
+	SetTableBool("readonly", doc->readonly);
 	return 1;
 }
 


### PR DESCRIPTION
From [discussion 4174](https://github.com/geany/geany/discussions/4174).

It's really strange: we have information about multi-line comments, but no single-line comments. Let's fix this :)