### PR TITLE
Windows: Let "curl" retry package downloads and show errors

### DIFF
--- a/build/gtk-bundle-from-msys2.sh
+++ b/build/gtk-bundle-from-msys2.sh
@@ -172,7 +172,7 @@ extract_packages() {
 		else
 			echo "Download $pkg using curl"
 			filename=$(basename "$pkg")
-			curl -s -o "$filename" -L "$pkg"
+			curl --silent --show-error --retry 3 --location --output "$filename" "$pkg"
 			tar xf "$filename"
 			rm "$filename"
 		fi


### PR DESCRIPTION
Before, any error messages were suppressed.

This helps on flaky internet connections or other transient network errors.