### PR TITLE
CI: Update to Ubuntu 22.04 runners as 20.04 are getting deprecated

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -201,7 +201,7 @@ jobs:
 
   mingw64:
     name: Mingw-w64 Build (Windows)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     env:
       GEANY_SOURCE_PATH:        ${{ github.workspace }}/.geany_source


### PR DESCRIPTION
See https://github.com/actions/runner-images/issues/11101