### PR TITLE
Fix nullPointerOutOfMemory warnings of cppcheck 2.17.0

### DIFF
--- a/addons/src/ao_xmltagging.c
+++ b/addons/src/ao_xmltagging.c
@@ -93,7 +93,7 @@ void ao_xmltagging(void)
 			/* Getting the tag */
 			tag = g_string_new(gtk_entry_get_text(GTK_ENTRY(textbox)));
 
-			if (tag->len > 0)
+			if (tag && tag->len > 0)
 			{
 				gsize end = 0;
 				gchar *end_tag;

--- a/codenav/src/codenavigation.c
+++ b/codenav/src/codenavigation.c
@@ -238,6 +238,12 @@ on_configure_response(GtkDialog* dialog, gint response, gpointer user_data)
 	config_filename = g_strconcat(geany->app->configdir, G_DIR_SEPARATOR_S,
 								"plugins", G_DIR_SEPARATOR_S, "codenav", 
 								G_DIR_SEPARATOR_S, "codenav.conf", NULL);
+	if(! config_filename)
+	{
+		g_key_file_free(config);
+		return;
+	}
+
 	config_dir      = g_path_get_dirname(config_filename);
 	
 	/* Allocate the list */

--- a/codenav/src/switch_head_impl.c
+++ b/codenav/src/switch_head_impl.c
@@ -148,19 +148,25 @@ fill_languages_list(const gchar** impl_list, const gchar** head_list, gsize n)
 
 	for ( i=0; i<n; i++ ) {
 		lang = g_malloc0(sizeof(Language));
-		
+		if(!lang)
+			return;  // TODO clean resources
+
 		/* check if current item has no head or impl */
 		if ( strlen(impl_list[i])==0 || strlen(head_list[i])==0 )
 			continue;
 		
 		/* Set language implementation extensions */
 		splitted_list = g_strsplit(impl_list[i], ",", 0);
+		if(!splitted_list)
+			return;  // TODO clean resources
 		for ( j=0; splitted_list[j] != NULL; j++ )
 			IMPL_PREPEND(splitted_list[j]);
 		g_strfreev(splitted_list);
 		
 		/* Set language header extensions */
 		splitted_list = g_strsplit(head_list[i], ",", 0);
+		if(!splitted_list)
+			return;  // TODO clean resources
 		for ( j=0; splitted_list[j] != NULL; j++ )
 			HEAD_PREPEND(splitted_list[j]);
 		g_strfreev(splitted_list);

--- a/codenav/src/utils.c
+++ b/codenav/src/utils.c
@@ -65,6 +65,9 @@ copy_and_remove_extension(gchar* path)
 		return NULL;
 
 	str = g_strdup(path);
+	if(!str)
+		return NULL;
+
 	pc = str;
 	while(*pc != '\0')
 	{

--- a/commander/src/commander-plugin.c
+++ b/commander/src/commander-plugin.c
@@ -354,6 +354,8 @@ store_populate_menu_items (GtkListStore  *store,
         }
         
         tmp = g_markup_escape_text (path, -1);
+        if (! tmp)
+          return; // TODO free resources
         SETPTR (label, g_strconcat (label, "\n<small><i>", tmp, "</i></small>", NULL));
         g_free (tmp);
         

--- a/geanyctags/src/geanyctags.c
+++ b/geanyctags/src/geanyctags.c
@@ -299,6 +299,8 @@ static void show_entry(tagEntry *entry)
 	if (kind)
 	{
 		kind_str = g_strconcat(kind, ":  ", NULL);
+		if (! kind_str)
+			return; // TODO free resources
 		SETPTR(kind_str, g_strdup_printf("%-14s", kind_str));
 	}
 	else

--- a/geanygendoc/src/ggd-file-type-manager.c
+++ b/geanygendoc/src/ggd-file-type-manager.c
@@ -122,7 +122,11 @@ ggd_file_type_manager_get_conf_path_intern (GeanyFiletype  *geany_ft,
   gchar  *filename;
   
   ft_name_down = g_ascii_strdown (geany_ft->name, -1);
+  if (! ft_name_down)
+    return NULL; // TODO free resources
   ft_name_conf = g_strconcat (ft_name_down, ".conf", NULL);
+  if (! ft_name_conf)
+    return NULL; // TODO free resources
   g_free (ft_name_down);
   filename = ggd_get_config_file (ft_name_conf, "filetypes", prems_req, error);
   g_free (ft_name_conf);


### PR DESCRIPTION
The latest cppcheck version (2.17.0) introduces a new check to check for properly handling errors on memory allocation failures (https://sourceforge.net/p/cppcheck/news/2025/02/cppcheck-2170/).

Multiple plugins are affected, some more, others less.

I wonder if it is worth to update all occurrences or ignore this check completely since at least the GLib memory allocation functions seems to terminate the whole application on errors (at the beginning of https://docs.gtk.org/glib/memory.html) and so our code to handle the errors probably will never be called.

On the opther hand, it might be still useful if any memory allocation returns NULL because of invalid input or other reasons without terminating the whole application.

I made a start in this PR but it's probably only about 5-10% of the necessary changes and in many places I just added TODOs to properly handle errors.

What do you think? @b4n @techee 
