### PR TITLE
treebrowser: Force icon sizes

### DIFF
--- a/treebrowser/src/treebrowser.c
+++ b/treebrowser/src/treebrowser.c
@@ -231,15 +231,17 @@ utils_pixbuf_from_path(gchar *path)
 
 	if (icon != NULL)
 	{
+		const GtkIconLookupFlags flags = GTK_ICON_LOOKUP_USE_BUILTIN | GTK_ICON_LOOKUP_FORCE_SIZE;
+
 		gtk_icon_size_lookup(GTK_ICON_SIZE_MENU, &width, NULL);
-		info = gtk_icon_theme_lookup_by_gicon(gtk_icon_theme_get_default(), icon, width, GTK_ICON_LOOKUP_USE_BUILTIN);
+		info = gtk_icon_theme_lookup_by_gicon(gtk_icon_theme_get_default(), icon, width, flags);
 		g_object_unref(icon);
 		if (!info)
 		{
 			icon = g_themed_icon_new("text-x-generic");
 			if (icon != NULL)
 			{
-				info = gtk_icon_theme_lookup_by_gicon(gtk_icon_theme_get_default(), icon, width, GTK_ICON_LOOKUP_USE_BUILTIN);
+				info = gtk_icon_theme_lookup_by_gicon(gtk_icon_theme_get_default(), icon, width, flags);
 				g_object_unref(icon);
 			}
 		}


### PR DESCRIPTION
Force using the same icon size for all file types even if the theme in use doesn't have the requested size to avoid varying icon sizes.

Closes #1416.

---

@chrisgoldberg1 could you test this?  I cannot reproduce your issue with my icon theme, but it should work.