### PR TITLE
cppcheck: Disable nullPointerOutOfMemory check

### DIFF
--- a/build/cppcheck-geany-plugins.suppressions
+++ b/build/cppcheck-geany-plugins.suppressions
@@ -1,0 +1,4 @@
+# Too many false-positives with GLib code.
+# See also https://github.com/danmar/cppcheck/pull/7068 and
+# https://github.com/danmar/cppcheck/pull/7390
+nullPointerOutOfMemory

--- a/build/cppcheck.mk
+++ b/build/cppcheck.mk
@@ -7,6 +7,7 @@ check-cppcheck: $(srcdir)
 		-q --template=gcc --error-exitcode=2 \
 		--library=gtk \
 		--library=$(top_srcdir)/build/cppcheck-geany-plugins.cfg \
+		--suppressions-list=$(top_srcdir)/build/cppcheck-geany-plugins.suppressions \
 		-I$(GEANY_INCLUDEDIR)/geany \
 		-UGEANY_PRIVATE \
 		-DGETTEXT_PACKAGE=\"$(GETTEXT_PACKAGE)\" \


### PR DESCRIPTION
This produces too many false-positives with GLib code.

See https://github.com/danmar/cppcheck/pull/7068 and https://github.com/danmar/cppcheck/pull/7390.

Closes #1417.