### PR TITLE
Delete indicators when a selection exists

### DIFF
--- a/automark/src/automark.c
+++ b/automark/src/automark.c
@@ -110,7 +110,10 @@ automark(gpointer user_data)
 
 	/* Do not highlight while selecting text and allow other markers to work */
 	if (sci_has_selection(sci))
+	{
+		editor_indicator_clear(editor, AUTOMARK_INDICATOR);
 		return FALSE;
+	}
 
 	text = get_current_word(editor->sci);
 


### PR DESCRIPTION
When a user double clicked a word, the word was selected and highlighted with automark, but no new highlightings appeared on scrolling the file. The word was highlighted near the selection only.

In this case, it is better not to highlight this word anywhere, so as not to confuse the user.