### PR TITLE
geanyctags: Fix navigation queue

### DIFF
--- a/geanyctags/src/geanyctags.c
+++ b/geanyctags/src/geanyctags.c
@@ -488,10 +488,11 @@ static void find_tags(const gchar *name, gboolean declaration, gboolean case_sen
 			
 			if (num == 1)
 			{
+				GeanyDocument *old_doc = document_get_current();
 				GeanyDocument *doc = document_open_file(path, FALSE, NULL, NULL);
 				if (doc != NULL)
 				{
-					navqueue_goto_line(document_get_current(), doc, last_line_number);
+					navqueue_goto_line(old_doc, doc, last_line_number);
 					gtk_widget_grab_focus(GTK_WIDGET(doc->editor->sci));
 				}
 			}


### PR DESCRIPTION
When activating the "Find Tag Declaration" menu item the line number in a new document was saved as a position to navigate back. We should save the same line number in the old document.