### PR TITLE
Fix warnings for g_string_free() calls not using the return value

### DIFF
--- a/geniuspaste/src/geniuspaste.c
+++ b/geniuspaste/src/geniuspaste.c
@@ -619,12 +619,15 @@ static SoupMessage *json_request_new(const gchar *method,
     SoupMessage  *msg = soup_message_new(method, url);
     GString      *str = g_string_new(NULL);
     GBytes       *bytes;
+    gchar        *data;
+    gsize         data_len;
 
     g_string_append_c(str, '{');
     g_datalist_foreach(fields, append_json_data_item, str);
     g_string_append_c(str, '}');
-    bytes = g_bytes_new_take(str->str, str->len);
-    (void) g_string_free(str, FALSE); /* buffer already taken above */
+    data_len = str->len;
+    data = g_string_free(str, FALSE);
+    bytes = g_bytes_new_take(data, data_len);
     soup_message_set_request_body_from_bytes(msg, "application/json", bytes);
     g_bytes_unref(bytes);
 

--- a/markdown/peg-markdown/markdown_lib.c
+++ b/markdown/peg-markdown/markdown_lib.c
@@ -171,11 +171,8 @@ GString * markdown_to_g_string(char *text, int extensions, int output_format) {
  * Returns a null-terminated string, which must be freed after use. */
 char * markdown_to_string(char *text, int extensions, int output_format) {
     GString *out;
-    char *char_out;
     out = markdown_to_g_string(text, extensions, output_format);
-    char_out = out->str;
-    g_string_free(out, FALSE);
-    return char_out;
+    return g_string_free(out, FALSE);
 }
 
 /* vim:set ts=4 sw=4: */

--- a/vimode/src/excmd-runner.c
+++ b/vimode/src/excmd-runner.c
@@ -217,8 +217,7 @@ static void next_token(const gchar **p, Token *tk)
 		}
 		if (**p == c)
 			(*p)++;
-		init_tk(tk, TK_PATTERN, 0, s->str);
-		g_string_free(s, FALSE);
+		init_tk(tk, TK_PATTERN, 0, g_string_free(s, FALSE));
 		return ;
 	}
 

--- a/workbench/src/wb_project.c
+++ b/workbench/src/wb_project.c
@@ -1191,7 +1191,6 @@ gchar *wb_project_dir_get_info (WB_PROJECT_DIR *dir)
 		return g_strdup("");
 
 	GString *temp = g_string_new(NULL);
-	gchar *text;
 	g_string_append_printf(temp, _("Directory-Name: %s\n"), wb_project_dir_get_name(dir));
 	g_string_append_printf(temp, _("Base-Directory: %s\n"), wb_project_dir_get_base_dir(dir));
 
@@ -1235,10 +1234,7 @@ gchar *wb_project_dir_get_info (WB_PROJECT_DIR *dir)
 	g_string_append_printf(temp, _("Number of Files: %u\n"), dir->file_count);
 
 	/* Steal string content */
-	text = temp->str;
-	g_string_free (temp, FALSE);
-
-	return text;
+	return g_string_free (temp, FALSE);
 }
 
 
@@ -1251,7 +1247,6 @@ gchar *wb_project_dir_get_info (WB_PROJECT_DIR *dir)
 gchar *wb_project_get_info (WB_PROJECT *prj)
 {
 	GString *temp = NULL;
-	gchar *text;
 
 	if (prj == NULL)
 		return g_strdup("");
@@ -1266,10 +1261,7 @@ gchar *wb_project_get_info (WB_PROJECT *prj)
 	}
 
 	/* Steal string content */
-	text = temp->str;
-	g_string_free (temp, FALSE);
-
-	return text;
+	return g_string_free (temp, FALSE);
 }
 
 


### PR DESCRIPTION
Newer GLib warns if the return value from `g_string_free(str, FALSE)` is not used, so adjust the code to actually use it.

GeniusPaste's tried to cast it away, but it doesn't seem to work, at least not anymore.  Fix this by taking the more convoluted approach.

CC @techee @LarsGit223 @xiota, yet looking at the changes for those plugins I'm not sure workbench and markdown readlly have a maintainer anymore.