### PR TITLE
geanyctags: Suppress a cppcheck warning

### DIFF
--- a/geanyctags/src/readtags.c
+++ b/geanyctags/src/readtags.c
@@ -1389,6 +1389,7 @@ extern tagResult tagsFindPseudoTag (tagFile *const file, tagEntry *const entry,
 {
 	size_t len;
 	tagEntry entry0;
+	/* cppcheck-suppress uninitvar symbolName=&entry0 */
 	tagEntry *entryp = entry? entry: &entry0;
 
 	tagResult r = tagsFirstPseudoTag (file, entryp);


### PR DESCRIPTION
The variable is not initialized, but it's not used there, and will be initialized farther down through an init call.

---

This is with 2.10 from Debian Bookworm.  2.14 and above seem to be smarter, so maybe we don't care about that.

If we do care, we could alternatively add a suppression in the Makefile.am, but that's a bit more fragile and risk getting forgotten. OTOH, this being a copied file, it might get forgotten on next update, although it might not be relevant anymore -- either by being changed or by being "fixed":
```diff
diff --git a/geanyctags/src/Makefile.am b/geanyctags/src/Makefile.am
index ffd38a8c..e908e2cf 100644
--- a/geanyctags/src/Makefile.am
+++ b/geanyctags/src/Makefile.am
@@ -13,4 +13,6 @@ geanyctags_la_CPPFLAGS = $(AM_CPPFLAGS) \
 geanyctags_la_CFLAGS = $(AM_CFLAGS)
 geanyctags_la_LIBADD = $(COMMONLIBS)
 
+AM_CPPCHECKFLAGS = --suppress=uninitvar:$(srcdir)/readtags.c:1392
+
 include $(top_srcdir)/build/cppcheck.mk
```

@techee feel free to close this if you think it's not worth working around, as CI is unaffected I'm not particularly worried, it just makes e.g. releasing under Bookworm a bit harder.