### PR TITLE
LSP: Enable LSP when we don't know exact project configuration

### DIFF
--- a/lsp/src/lsp-utils.h
+++ b/lsp/src/lsp-utils.h
@@ -29,6 +29,8 @@ typedef struct LspServerConfig LspServerConfig;
 
 typedef enum
 {
+	// plugin loaded manually after the "project-open" signal so we don't know project settings
+	UninitializedConfiguration = -2,
 	UnconfiguredConfiguration = -1,
 	DisabledConfiguration,
 	EnabledConfiguration


### PR DESCRIPTION
When project is open and we load the plugin from the plugin manager, we can't read the exact project configuration because the "project-open" signal that delivers the config file was fired when the plugin wasn't loaded. This means we don't know whether the project enables LSP support or not. Right now, the plugin simply doesn't start the LSP server which is confusing.

Do the opposite - when we don't know whether LSP is enabled or disabled for the project, enable LSP by default.