### PR TITLE
lsp: Fix incremental synchronization with multi-byte characters

### DIFF
--- a/lsp/src/lsp-sync.c
+++ b/lsp/src/lsp-sync.c
@@ -223,8 +223,11 @@ void lsp_sync_text_document_did_change(LspServer *server, GeanyDocument *doc,
 
 	if (server->use_incremental_sync)
 	{
-		gint range = lsp_utils_lsp_pos_to_scintilla(doc->editor->sci, pos_end) - 
-			lsp_utils_lsp_pos_to_scintilla(doc->editor->sci, pos_start);
+		gint range = SSM(
+			doc->editor->sci, SCI_COUNTCODEUNITS,
+			lsp_utils_lsp_pos_to_scintilla(doc->editor->sci, pos_start),
+			lsp_utils_lsp_pos_to_scintilla(doc->editor->sci, pos_end)
+		);
 
 		node = JSONRPC_MESSAGE_NEW (
 			"textDocument", "{",


### PR DESCRIPTION
At least clangd discards the file if the range doesn't match what it sees, so this has the effect of breaking the LSP features whenever one type a multi-byte character.

---

:warning: beware, this has been barely tested.

I am moderately certain the fix is correct as it's the unit other pieces of the code use, but I didn't check whether the protocol actually expects -- but it seems to work with single-code-point character (I e.g. didn't try anything that would not have the same number of code units than code points).

To reproduce it's easy for me; just type anything non-latin.  E.g. I mistyped `streaù` instead of `stream` (`ù` is next to `m` on a French layout), and suddenly even basic completion or calltips stopped working in that file.

I found this error:
```
E[00:10:36.198] Failed to update /home/ban/progs/ctpl/src/ctpl-input-stream.c: Change's rangeLength (2) doesn't match the computed range length (1).
```
and then it's full of
```
I[00:10:36.506] --> reply:textDocument/semanticTokens/full/delta(45) 0 ms, error: -32602: trying to get AST for non-added document
```

Anyway, with this patch I can apparently mistype as many `ù` as I want and it keeps working.