### PR TITLE
LSP: Remove keybindings for goto definition/declaration

### DIFF
--- a/lsp/src/lsp-main.c
+++ b/lsp/src/lsp-main.c
@@ -1514,15 +1514,13 @@ static void create_menu_items()
 	gtk_container_add(GTK_CONTAINER(menu), menu_items.goto_def);
 	g_signal_connect(menu_items.goto_def, "activate", G_CALLBACK(on_menu_invoked),
 		GUINT_TO_POINTER(KB_GOTO_DEFINITION));
-	keybindings_set_item(group, KB_GOTO_DEFINITION, NULL, 0, 0, "goto_definition",
-		_("Go to definition"), menu_items.goto_def);
+	// no keybinding - use goto of Geany
 
 	menu_items.goto_decl = gtk_menu_item_new_with_mnemonic(_("Go to D_eclaration"));
 	gtk_container_add(GTK_CONTAINER(menu), menu_items.goto_decl);
 	g_signal_connect(menu_items.goto_decl, "activate", G_CALLBACK(on_menu_invoked),
 		GUINT_TO_POINTER(KB_GOTO_DECLARATION));
-	keybindings_set_item(group, KB_GOTO_DECLARATION, NULL, 0, 0, "goto_declaration",
-		_("Go to declaration"), menu_items.goto_decl);
+	// no keybinding - use goto of Geany
 
 	menu_items.goto_type_def = gtk_menu_item_new_with_mnemonic(_("Go to _Type Definition"));
 	gtk_container_add(GTK_CONTAINER(menu), menu_items.goto_type_def);


### PR DESCRIPTION
There are already keybindings for standard Geany goto definition/declaration that will get propagated to the LSP server so there is not a real need for another pair of keybindings doing nearly the same. This is confusing for users (see https://github.com/techee/geany-lsp/discussions/79).

The only exception when this could get useful is when users configure the plugin not to use LSP for goto in which case standard Geany goto is used when using Geany goto definition/declaration. In this case, the extra keybinding would still use LSP features and users could choose between the two by using two different keybindings. However, such as feature is hard to discover and probably not used by many and better to make the UI less confusing for users.

@frlan @b4n This patch removes 2 translatable strings. Probably not a problem, just can the patch be merged now or should it wait until all translators submit their updates?