### PR TITLE
numberedbookmarks: fix Ctrl+num and Ctrl+Shift+num on various keyboard layouts

### DIFF
--- a/geanynumberedbookmarks/src/geanynumberedbookmarks.c
+++ b/geanynumberedbookmarks/src/geanynumberedbookmarks.c
@@ -73,7 +73,7 @@ static gboolean bTryToLoadMarkers=FALSE; /* If the file has changed, attempt to 
 static gboolean bAlwaysSaveMarkers=FALSE; /* Always save markers, even if file has not changed */
 
 /* internal variables */
-static gint iShiftNumbers[]={41,33,34,163,36,37,94,38,42,40};
+static gint iShiftNumbers[]={41,33,64,35,36,37,94,38,42,40};
 static gint iNoShiftNumbers[]={48,49,50,51,52,53,54,55,56,57};
 static FileData *fdKnownFilesSettings=NULL;
 static gulong key_release_signal_id;


### PR DESCRIPTION
Inside `plugin_init()`, the current version precomputes key values for number keys after pressing shift (on US keyboard, `!` for `1`, `@`, for `2`, etc.) and uses these values for detecting key presses. However, it makes some assumptions that are not quite correct for all keyboard layouts:

1. It assumes that keyboard layout cannot change and precomputes key values once on plugin init. It is quite common to change keyboard layout while using an editor and the precomputed values aren't correct in this case.
2. It assumes that numbers are typed directly for all keyboard layouts without pressing shift. This is incorrect e.g. for the Czech keyboard where numbers are typed by Shift plus a key from the top row. In this case the current code doesn't precompute Shift+key values correctly
3. By assuming that numbers are typed without shift, it detects Ctrl+numkey incorrectly on keyboard layouts requiring shift.

This patch fixes these issues in the following way:
1. It moves key precomputation outside `plugin_init()` and performs it every time Ctrl+key or Ctrl+Shift+key is pressed.
2. It stores precomputed numeric key values both for Shift+key and NonShift+key variants. Since the Shift key gets consumed by GTK and we can't be sure whether it was pressed or not, we can use these two groups and based on key presence in one of them we can determine whether Shift was pressed or not and perform the corresponding action.