### PR TITLE
geanynumberedbookmarks: make the plugin work when numlock is on

### DIFF
--- a/geanynumberedbookmarks/src/geanynumberedbookmarks.c
+++ b/geanynumberedbookmarks/src/geanynumberedbookmarks.c
@@ -1482,6 +1482,7 @@ static gboolean Key_Released_CallBack(GtkWidget *widget, GdkEventKey *ev, gpoint
 {
 	GeanyDocument *doc;
 	gint i;
+	GdkModifierType state = keybindings_get_modifiers(ev->state);
 
 	doc=document_get_current();
 	if(doc==NULL)
@@ -1491,7 +1492,7 @@ static gboolean Key_Released_CallBack(GtkWidget *widget, GdkEventKey *ev, gpoint
 		return FALSE;
 
 	/* control and number pressed */
-	if(ev->state==4)
+	if(state == GDK_CONTROL_MASK)
 	{
 		i=((gint)(ev->keyval))-'0';
 		if(i<0 || i>9)
@@ -1501,7 +1502,7 @@ static gboolean Key_Released_CallBack(GtkWidget *widget, GdkEventKey *ev, gpoint
 		return TRUE;
 	}
 	/* control+shift+number */
-	if(ev->state==5) {
+	if(state == (GDK_CONTROL_MASK | GDK_SHIFT_MASK)) {
 		/* could use hardware keycode instead of keyvals but if unable to get keyode then don't
 		 * have logical default to fall back on
 		*/


### PR DESCRIPTION
Thanks to Colomban Wendling for the patch.

A lower-risk pre-release variant of https://github.com/geany/geany-plugins/pull/1458.