### PR TITLE
vimode: Fix a couple warnings

### DIFF
--- a/vimode/src/cmds/motion-word.c
+++ b/vimode/src/cmds/motion-word.c
@@ -37,7 +37,7 @@ static void move_right(ScintillaObject *sci, gchar *ch, gint *pos)
 
 static gboolean is_wordchar(gchar c)
 {
-	return g_ascii_isalnum(c) || c == '_' || (c >= 192 && c <= 255);
+	return g_ascii_isalnum(c) || c == '_' || ((guchar) c) >= 192;
 }
 
 
@@ -300,7 +300,7 @@ void cmd_goto_previous_word_end_space(CmdContext *c, CmdParams *p)
 void get_word_range(ScintillaObject *sci, gboolean word_space, gboolean inner,
 	gint pos, gint num, gint *sel_start, gint *sel_len)
 {
-	guint i;
+	gint i;
 	gint start_pos = pos;
 	gint end_pos;
 	gchar ch = SSM(sci, SCI_GETCHARAT, pos, 0);


### PR DESCRIPTION
> ```
> vimode/src/cmds/motion-word.c: In function ‘is_wordchar’:
> vimode/src/cmds/motion-word.c:40:53: warning: comparison is always false due to limited range of data type [-Wtype-limits]
>    40 |         return g_ascii_isalnum(c) || c == '_' || (c >= 192 && c <= 255);
>       |                                                     ^~
> vimode/src/cmds/motion-word.c:40:65: warning: comparison is always true due to limited range of data type [-Wtype-limits]
>    40 |         return g_ascii_isalnum(c) || c == '_' || (c >= 192 && c <= 255);
>       |                                                                 ^~
> ```

This is due to `gchar` being signed on some (most) architectures, and thus comparing to anything larger than 0x7f is likely not to yield expected results.  Fix this by casting to `guchar` first.

> ```
> vimode/src/cmds/motion-word.c: In function ‘get_word_range’:
> vimode/src/cmds/motion-word.c:327:31: warning: comparison of integer expressions of different signedness: ‘guint’ {aka ‘unsigned int’} and ‘gint’ {aka ‘int’} [-Wsign-compare]
>   327 |                 for (i = 0; i < num; i++)
>       |                               ^
> vimode/src/cmds/motion-word.c:366:31: warning: comparison of integer expressions of different signedness: ‘guint’ {aka ‘unsigned int’} and ‘gint’ {aka ‘int’} [-Wsign-compare]
>   366 |                 for (i = 0; i < num; i++)
>       |                               ^
> ```

`i` should have the same type as `num`, which is trivial to fix here as `i` is merely a loop counter, not used for anything else.