### PR TITLE
Geany Plugins Test Signing Workflow

### DIFF
--- a/.github/workflows/windows-msys2-build.yml
+++ b/.github/workflows/windows-msys2-build.yml
@@ -85,3 +85,21 @@ jobs:
           retention-days: 3
           overwrite: true
           if-no-files-found: error
+      - name: SignPath Signing
+        uses: signpath/github-action-submit-signing-request@v1.2
+        with:
+          api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
+          organization-id: '${{ vars.SIGNPATH_ORGANIZATION_ID }}'
+          project-slug: 'geany-plugins'
+          signing-policy-slug: 'test-signing'
+          github-artifact-id: '${{ steps.upload-unsigned-artifact.outputs.artifact-id }}'
+          wait-for-completion: true
+          output-artifact-directory: geany-plugins-signed
+      - name: Upload Signed Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: geany-plugins-signed
+          path: geany-plugins-signed
+          retention-days: 3
+          overwrite: true
+          if-no-files-found: error


### PR DESCRIPTION
Similar to https://github.com/geany/geany/pull/4361 if @b4n can help, the organisation id is different for geany-plugins "90ff2952-3d9c-4190-ad3d-f809c3ebddb4" and he knows how to generate the secret ( for user https://app.signpath.io/Web/90ff2952-3d9c-4190-ad3d-f809c3ebddb4/CIUsers/244637f1-b412-4791-ada2-e8103a43d25d )