### PR TITLE
Add target for signing release tarballs

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -182,3 +182,12 @@ endif
 if ENABLE_XMLSNIPPETS
 SUBDIRS += xmlsnippets
 endif
+
+
+# sign release tarballs
+sign:
+	for f in $(DIST_ARCHIVES); do \
+		if test -f "$$f"; then \
+			gpg --detach-sign --digest-algo SHA512 "$$f"; \
+		fi \
+	done


### PR DESCRIPTION
Fixes #1472.

---

This is pretty straightforward, similar to Geany's but in a more dist-type agnostic (using `DIST_ARCHIVES` instead of manually listing some expected archives filenames).