### PR TITLE
lsp: Fix build with GLib 2.58

### DIFF
--- a/lsp/deps/json-glib/json-scanner.c
+++ b/lsp/deps/json-glib/json-scanner.c
@@ -1078,7 +1078,10 @@ json_scanner_get_token_ll (JsonScanner    *scanner,
               ch = 0;
               break;
             }
+#ifdef G_GNUC_FALLTHROUGH /* GLib >= 2.60 */
             G_GNUC_FALLTHROUGH;
+#endif
+            /* Fallthrough */
 
 	case '0':
 	case '1':

--- a/lsp/src/spawn/lspunixoutputstream.c
+++ b/lsp/src/spawn/lspunixoutputstream.c
@@ -93,7 +93,9 @@ lsp_unix_output_stream_class_init (LspUnixOutputStreamClass *klass)
   gobject_class->set_property = lsp_unix_output_stream_set_property;
 
   stream_class->write_fn = lsp_unix_output_stream_write;
+#if GLIB_CHECK_VERSION (2, 60, 0)
   stream_class->writev_fn = NULL;
+#endif
   stream_class->close_fn = lsp_unix_output_stream_close;
 
    /**


### PR DESCRIPTION
@techee First 2.1 issue breakage :)  Current LSP doesn't build on GLib 2.58 (GP only depend on 2.56 through Geany 2.1).

We have 2 options:
* Make LSP depend on 2.68 (for `g_string_replace()`)
* Do something similar to this PR to support 2.56 (I don't have any 2.56 so I can't verify for sure, but could check the new API in 2.58 to manually check).
  * The most annoying piece might be the json-glib change, which might need to either be a patch, or conditionally defining `G_GNUC_FALLTHROUGH` from the build system (on GLib < 2.60)

I know you want the patches against the LSP repo, but I'm starting it here because it's mostly concerning the GP integration. I can PR against that repo when we know what to do -- or you can take whatever you like and make your own, I don't mind :)