### PR TITLE
vimode: Various fixes related to various motion commands

### DIFF
--- a/vimode/src/cmd-params.c
+++ b/vimode/src/cmd-params.c
@@ -19,7 +19,7 @@
 #include "cmd-params.h"
 
 void cmd_params_init(CmdParams *param, ScintillaObject *sci,
-	gint num, gboolean num_present, GSList *kpl, gboolean is_operator_cmd,
+	gint num, gboolean num_present, GSList *kpl,
 	gint sel_start, gint sel_len)
 {
 	param->sci = sci;
@@ -27,7 +27,6 @@ void cmd_params_init(CmdParams *param, ScintillaObject *sci,
 	param->num = num;
 	param->num_present = num_present;
 	param->last_kp = kpl != NULL ? g_slist_nth_data(kpl, 0) : NULL;
-	param->is_operator_cmd = is_operator_cmd;
 
 	param->sel_start = sel_start;
 	param->sel_len = sel_len;

--- a/vimode/src/cmd-params.h
+++ b/vimode/src/cmd-params.h
@@ -35,8 +35,6 @@ typedef struct
 	gboolean num_present;
 	/* last key press */
 	KeyPress *last_kp;
-	/* if running as an "operator" command */
-	gboolean is_operator_cmd;
 
 	/* selection start or selection made by movement command */
 	gint sel_start;
@@ -70,7 +68,7 @@ typedef struct
 typedef void (*Cmd)(CmdContext *c, CmdParams *p);
 
 void cmd_params_init(CmdParams *param, ScintillaObject *sci,
-	gint num, gboolean num_present, GSList *kpl, gboolean is_operator_cmd,
+	gint num, gboolean num_present, GSList *kpl,
 	gint sel_start, gint sel_len);
 
 #endif

--- a/vimode/src/cmd-runner.c
+++ b/vimode/src/cmd-runner.c
@@ -614,11 +614,7 @@ static void perform_cmd(CmdDef *def, CmdContext *ctx)
 					sel_start = MIN(new_pos, orig_pos);
 					sel_len = ABS(new_pos - orig_pos);
 					if (sel_len > 0 && is_include_dest_char_movement_cmd)
-					{
 						sel_len++;
-						if (new_pos < orig_pos)
-							sel_start--;
-					}
 				}
 				cmd_params_init(&param, ctx->sci,
 					1, FALSE, top, sel_start, sel_len);

--- a/vimode/src/cmd-runner.c
+++ b/vimode/src/cmd-runner.c
@@ -583,7 +583,7 @@ static void perform_cmd(CmdDef *def, CmdContext *ctx)
 	sel_start = SSM(ctx->sci, SCI_GETSELECTIONSTART, 0, 0);
 	sel_len = SSM(ctx->sci, SCI_GETSELECTIONEND, 0, 0) - sel_start;
 	cmd_params_init(&param, ctx->sci,
-		num_present ? num : 1, num_present, ctx->kpl, FALSE,
+		num_present ? num : 1, num_present, ctx->kpl,
 		sel_start, sel_len);
 
 	SSM(ctx->sci, SCI_BEGINUNDOACTION, 0, 0);
@@ -623,8 +623,7 @@ static void perform_cmd(CmdDef *def, CmdContext *ctx)
 					}
 				}
 				cmd_params_init(&param, ctx->sci,
-					1, FALSE, top, TRUE,
-					sel_start, sel_len);
+					1, FALSE, top, sel_start, sel_len);
 
 				def->cmd(ctx, &param);
 			}

--- a/vimode/src/cmd-runner.c
+++ b/vimode/src/cmd-runner.c
@@ -176,8 +176,6 @@ CmdDef include_dest_char_movement_cmds[] = {
 	{cmd_goto_next_char_before, GDK_KEY_t, 0, 0, 0, TRUE, FALSE},
 	{cmd_goto_next_word_end, GDK_KEY_e, 0, 0, 0, FALSE, FALSE},
 	{cmd_goto_next_word_end_space, GDK_KEY_E, 0, 0, 0, FALSE, FALSE},
-	{cmd_goto_previous_word, GDK_KEY_b, 0, 0, 0, FALSE, FALSE},
-	{cmd_goto_previous_word_space, GDK_KEY_B, 0, 0, 0, FALSE, FALSE},
 	{cmd_goto_matching_brace, GDK_KEY_percent, 0, 0, 0, FALSE, FALSE},
 	{NULL, 0, 0, 0, 0, FALSE, FALSE}
 };

--- a/vimode/src/cmds/changemode.c
+++ b/vimode/src/cmds/changemode.c
@@ -189,8 +189,6 @@ void cmd_enter_insert_cut_line(CmdContext *c, CmdParams *p)
 void cmd_enter_insert_cut_sel(CmdContext *c, CmdParams *p)
 {
 	gint sel_end_pos = p->sel_start + p->sel_len;
-	if (p->is_operator_cmd && p->line_end_pos < sel_end_pos)
-		sel_end_pos = p->line_end_pos;
 
 	cut_range_change_mode(c, p, p->sel_start, sel_end_pos, FALSE, VI_MODE_INSERT);
 }
@@ -208,8 +206,6 @@ void cmd_enter_insert_cut_line_sel(CmdContext *c, CmdParams *p)
 void cmd_enter_command_cut_sel(CmdContext *c, CmdParams *p)
 {
 	gint sel_end_pos = p->sel_start + p->sel_len;
-	if (p->is_operator_cmd && p->line_end_pos < sel_end_pos)
-		sel_end_pos = p->line_end_pos;
 
 	cut_range_change_mode(c, p, p->sel_start, sel_end_pos, FALSE, VI_MODE_COMMAND);
 }
@@ -228,8 +224,6 @@ void cmd_enter_command_cut_line_sel(CmdContext *c, CmdParams *p)
 void cmd_enter_command_copy_sel(CmdContext *c, CmdParams *p)
 {
 	gint sel_end_pos = p->sel_start + p->sel_len;
-	if (p->is_operator_cmd && p->line_end_pos < sel_end_pos)
-		sel_end_pos = p->line_end_pos;
 
 	c->line_copy = FALSE;
 	SSM(p->sci, SCI_COPYRANGE, p->sel_start, sel_end_pos);

--- a/vimode/src/cmds/excmds.c
+++ b/vimode/src/cmds/excmds.c
@@ -72,7 +72,7 @@ static void prepare_cmd_params(CmdParams *params, CmdContext *c, ExCmdParams *p)
 {
 	gint start = SSM(c->sci, SCI_POSITIONFROMLINE, p->range_from, 0);
 	SET_POS(c->sci, start, TRUE);
-	cmd_params_init(params, c->sci, p->range_to - p->range_from + 1, FALSE, NULL, FALSE, 0, 0);
+	cmd_params_init(params, c->sci, p->range_to - p->range_from + 1, FALSE, NULL, 0, 0);
 }
 
 
@@ -141,7 +141,7 @@ void excmd_copy(CmdContext *c, ExCmdParams *p)
 	gint dest = SSM(c->sci, SCI_POSITIONFROMLINE, p->dest, 0);
 	excmd_yank(c, p);
 	SET_POS(c->sci, dest, TRUE);
-	cmd_params_init(&params, c->sci, 1, FALSE, NULL, FALSE, 0, 0);
+	cmd_params_init(&params, c->sci, 1, FALSE, NULL, 0, 0);
 	cmd_paste_after(c, &params);
 }
 
@@ -159,6 +159,6 @@ void excmd_move(CmdContext *c, ExCmdParams *p)
 		p->dest -= p->range_to - p->range_from + 1;
 	dest = SSM(c->sci, SCI_POSITIONFROMLINE, p->dest, 0);
 	SET_POS(c->sci, dest, TRUE);
-	cmd_params_init(&params, c->sci, 1, FALSE, NULL, FALSE, 0, 0);
+	cmd_params_init(&params, c->sci, 1, FALSE, NULL, 0, 0);
 	cmd_paste_after(c, &params);
 }


### PR DESCRIPTION
Fixes handling of `b`/`B`/`%` when used together with e.g. `d`.

Fixes https://github.com/geany/geany-plugins/issues/1487