### PR TITLE
Windows MSYS2 build to use new toolchain UCRT64

### DIFF
--- a/.github/workflows/windows-msys2-build.yml
+++ b/.github/workflows/windows-msys2-build.yml
@@ -1,5 +1,15 @@
 name: Windows/MSYS2 Build
-on: [workflow_dispatch]
+on:
+  workflow_dispatch:
+    inputs:
+      sign_build:
+        description: 'Set to true to sign the build artifact.'
+        required: false
+        default: 'false'
+        type: boolean
+  pull_request:
+    branches:
+      - master
 
 jobs:
   msys2-mingw64:
@@ -9,36 +19,36 @@ jobs:
         shell: msys2 {0}
     steps:
       - name: Checkout Geany-Plugins
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Checkout Geany
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: geany/geany
           path: .geany_source
       - name: Setup MSYS2
         uses: msys2/setup-msys2@v2
         with:
-          msystem: MINGW64
+          msystem: UCRT64
           update: true
           install: |
-            mingw-w64-x86_64-gcc
-            mingw-w64-x86_64-autotools
-            mingw-w64-x86_64-gtk3
-            mingw-w64-x86_64-python-docutils
-            mingw-w64-x86_64-check
-            mingw-w64-x86_64-cppcheck
-            mingw-w64-x86_64-ctpl-git
-            mingw-w64-x86_64-enchant
-            mingw-w64-x86_64-gpgme
-            mingw-w64-x86_64-gtkspell3
-            mingw-w64-x86_64-libgit2
-            mingw-w64-x86_64-libsoup3
-            mingw-w64-x86_64-lua51
+            mingw-w64-ucrt-x86_64-gcc
+            mingw-w64-ucrt-x86_64-autotools
+            mingw-w64-ucrt-x86_64-gtk3
+            mingw-w64-ucrt-x86_64-python-docutils
+            mingw-w64-ucrt-x86_64-check
+            mingw-w64-ucrt-x86_64-cppcheck
+            mingw-w64-ucrt-x86_64-ctpl-git
+            mingw-w64-ucrt-x86_64-enchant
+            mingw-w64-ucrt-x86_64-gpgme
+            mingw-w64-ucrt-x86_64-gtkspell3
+            mingw-w64-ucrt-x86_64-libgit2
+            mingw-w64-ucrt-x86_64-libsoup3
+            mingw-w64-ucrt-x86_64-lua51
             patch
             rsync
             unzip
             dos2unix
-            mingw-w64-x86_64-nsis
+            mingw-w64-ucrt-x86_64-nsis
       - name: GTK-Bundle-Geany-Plugins
         run: |
           mkdir -p geany_build/bundle/geany-plugins-dependencies
@@ -82,6 +92,26 @@ jobs:
         with:
           name: geany-plugins-unsigned
           path: geany_build/*.exe
+          retention-days: 3
+          overwrite: true
+          if-no-files-found: error
+      - name: SignPath Signing
+        if: ${{ github.event.inputs.sign_build == 'true' }}
+        uses: signpath/github-action-submit-signing-request@v1
+        with:
+          api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
+          organization-id: '${{ vars.SIGNPATH_ORGANIZATION_ID }}'
+          project-slug: 'geany-plugins'
+          signing-policy-slug: 'release-signing'
+          github-artifact-id: '${{ steps.upload-unsigned-artifact.outputs.artifact-id }}'
+          wait-for-completion: true
+          output-artifact-directory: geany-plugins-signed
+      - name: Upload Signed Artifact
+        if: ${{ github.event.inputs.sign_build == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: geany-plugins-signed
+          path: geany-plugins-signed
           retention-days: 3
           overwrite: true
           if-no-files-found: error

--- a/build/gtk-bundle-from-msys2.sh
+++ b/build/gtk-bundle-from-msys2.sh
@@ -6,7 +6,7 @@
 # shell. The extracted files will be placed into the current
 # directory.
 
-ABI=x86_64  # do not change, i686 is not supported any longer
+ABI="ucrt-x86_64"  # do not change, i686 is not supported any longer
 use_cache="no"
 make_zip="no"
 gtkv="3"
@@ -14,7 +14,7 @@ run_pi="y"
 cross="no"
 
 # Wine commands for 64bit binaries, used only when "-x" is set
-EXE_WRAPPER_64="mingw-w64-x86_64-wine"
+EXE_WRAPPER_64="mingw-w64-ucrt-x86_64-wine"
 
 # ctags - binary for GeanyCTags plugin
 # ctpl-git - for GeanyGenDoc plugin
@@ -137,7 +137,7 @@ _getpkg() {
 	if [ "$use_cache" = "yes" ]; then
 		package_info=$(pacman -Qi mingw-w64-$ABI-$1)
 		package_version=$(echo "$package_info" | grep "^Version " | cut -d':' -f 2 | tr -d '[[:space:]]')
-		# use @(gz|xz|zst) to filter out signature files (e.g. mingw-w64-x86_64-...-any.pkg.tar.zst.sig)
+		# use @(gz|xz|zst) to filter out signature files (e.g. mingw-w64-ucrt-x86_64-...-any.pkg.tar.zst.sig)
 		ls $cachedir/mingw-w64-${ABI}-${1}-${package_version}-*.tar.@(gz|xz|zst) | sort -V | tail -n 1
 	else
 		# -dd to ignore dependencies as we listed them already above in $packages and
@@ -184,16 +184,16 @@ extract_packages() {
 
 move_extracted_files() {
 	echo "Move extracted data to destination directory"
-	if [ -d mingw64 ]; then
+	if [ -d ucrt64 ]; then
 		for d in bin etc home include lib libexec locale sbin share ssl var; do
-			if [ -d "mingw64/$d" ]; then
+			if [ -d "ucrt64/$d" ]; then
 				rm -rf $d
 				# prevent sporadic 'permission denied' errors on my system, not sure why they happen
 				sleep 0.5
-				mv mingw64/$d .
+				mv ucrt64/$d .
 			fi
 		done
-		rmdir mingw64
+		rmdir ucrt64
 	fi
 }
 


### PR DESCRIPTION
Windows MSYS2 build
- use new toolchain UCRT64
- be triggered also on PRs
- do not sign the artifact unless specified in the manually triggered workflow
