### PR TITLE
Adjust requirements to be a bit more realistic

### DIFF
--- a/addons/README
+++ b/addons/README
@@ -121,8 +121,7 @@ the extension.
 Requirements
 ------------
 
-* GTK >= 2.8.0
-* Geany >= 0.21
+* Geany >= 2.0
 
 License
 -------

--- a/autoclose/README
+++ b/autoclose/README
@@ -48,7 +48,7 @@ load it in Geany's plugin manager. You may change module preferences.
 Requirements
 ------------
 
-* GTK >= 2.8.0
+* Geany >= 1.26
 
 License
 -------

--- a/automark/README
+++ b/automark/README
@@ -25,7 +25,7 @@ be highlighted. The highlight color is "marker_search".
 Requirements
 ------------
 
-* GTK >= 2.8.0
+* Geany >= 1.26
 
 License
 -------

--- a/codenav/README
+++ b/codenav/README
@@ -39,7 +39,7 @@ can also enter an absolute or relative path to a file.
 Requirements
 ------------
 
-* GTK >= 2.8.0
+* Geany >= 1.26
 
 License
 -------

--- a/defineformat/README
+++ b/defineformat/README
@@ -21,7 +21,7 @@ Try it: open C/C++ file and type:
 Requirements
 ------------
 
-* GTK >= 2.8.0
+* Geany >= 1.26
 
 License
 -------

--- a/geanydoc/README
+++ b/geanydoc/README
@@ -61,8 +61,7 @@ Coding
 ======
 
 Use static functions where possible.
-Try to use GLib types and functions - e.g. g_free instead of free and
-try to use only GLib 2.6 and GTK 2.6 functions.
+Try to use GLib types and functions - e.g. g_free instead of free.
 
 Style
 =====

--- a/geanygendoc/README
+++ b/geanygendoc/README
@@ -16,10 +16,7 @@ Requirements
 
 You will need the following packages to build GeanyGenDoc:
 
-* Geany >= 0.19 (http://www.geany.org/)
-* GTK+ >= 2.12 (http://www.gtk.org)
-* GLib >= 2.14 (http://www.gtk.org)
-* GIO >= 2.18 (http://www.gtk.org)
+* Geany >= 1.27 (http://www.geany.org/)
 * CTPL >= 0.3 (http://ctpl.tuxfamily.org/)
 * A working C compiler (GCC for example, http://gcc.gnu.org/)
 * A working make implementation (GNU make is recommended,

--- a/geanyminiscript/README
+++ b/geanyminiscript/README
@@ -38,7 +38,7 @@ The output can be ::
 Requirements
 ============
 
-For compiling gms you need Geany,GTK2 includes, and GTK2 library.
+For compiling gms you need Geany, GTK includes, and GTK library.
 
 Furthermore you need, of course, a C compiler and the Make tool; The
 GNU versions of these tools are recommended.
@@ -90,9 +90,7 @@ Coding
 ======
 
 Use static functions where possible.
-Try to use GLib types and functions - e.g. g_free instead of free and
-try to use only GLib 2.6 and GTK 2.6 functions. At least for the moment,
-we want to keep the minimum requirement for GTK at 2.6.
+Try to use GLib types and functions - e.g. g_free instead of free.
 
 Download
 ========

--- a/geanyprj/README
+++ b/geanyprj/README
@@ -111,8 +111,7 @@ Coding
 ======
 
 Use static functions where possible.
-Try to use GLib types and functions - e.g. g_free instead of free and
-try to use only GLib 2.6 and GTK 2.6 functions.
+Try to use GLib types and functions - e.g. g_free instead of free.
 
 Style
 =====

--- a/geanyvc/README
+++ b/geanyvc/README
@@ -110,9 +110,8 @@ recommended to activate e.g. svk only if you want to use it.
 Requirements
 ------------
 
-* GTK >= 2.8.0
 * gtkspell >=2.0 for a spell checking
-* Geany >= 0.19
+* Geany >= 1.25
 
 License
 -------

--- a/keyrecord/README
+++ b/keyrecord/README
@@ -25,7 +25,7 @@ with the plugin then looks like follows: [record hotkey] [keystroke] ...
 Requirements
 ------------
 
-* GTK >= 2.8.0
+* Geany >= 1.26
 
 Contact developers
 ------------------

--- a/sendmail/README
+++ b/sendmail/README
@@ -17,7 +17,7 @@ This is not a direct binding to sendmail, even if it could be used for.
 Requirements
 ------------
 
-For compiling the plugin yourself, you will need the GTK (>= 2.8.0)
+For compiling the plugin yourself, you will need the GTK
 libraries and header files. You will also need its dependency
 libraries and header files, such as Pango, Glib and ATK. All these
 files are available at http://www.gtk.org.

--- a/shiftcolumn/README
+++ b/shiftcolumn/README
@@ -9,7 +9,7 @@ This plugin allows you to move blocks of text horizontally in left or right dire
 
 Requirements
 ------------
-For compiling the plugin yourself, you will need the GTK (>= 2.8.0) libraries
+For compiling the plugin yourself, you will need the GTK libraries
 and header files. You will also need its dependency libraries and header
 files, such as Pango, Glib and ATK. All these files are available at
 http://www.gtk.org.

--- a/spellcheck/README
+++ b/spellcheck/README
@@ -131,8 +131,7 @@ Known issues
 Requirements
 ------------
 
-* GTK >= 2.8.0
-* Geany >= 0.21
+* Geany >= 2.1
 
 License
 -------

--- a/treebrowser/README
+++ b/treebrowser/README
@@ -27,9 +27,8 @@ Features
 
 Requirements
 ============
-* GTK >= 2.8.0
-* GIO >= 2.0 (optional)
-* Geany >= 0.17
+
+* Geany >= 1.25
 
 
 Usage

--- a/xmlsnippets/README
+++ b/xmlsnippets/README
@@ -34,7 +34,7 @@ Geany will deal with other tags.
 
 Requirements
 ------------
-For compiling the plugin yourself, you will need the GTK (>= 2.8.0) libraries
+For compiling the plugin yourself, you will need the GTK libraries
 and header files. You will also need its dependency libraries and header
 files, such as Pango, Glib and ATK. All these files are available at
 http://www.gtk.org.


### PR DESCRIPTION
Especially drop references to GTK 2.8 which had lead to some confusion, and is so ancient that it's actually not supported by Geany for ages.

Try not to be too eager bumping the versions and only mention what is actually needed though.

Closes geany/geany#4466.