### PR TITLE
tableconvert: Add DokuWiki documentation to README

### DIFF
--- a/tableconvert/ChangeLog
+++ b/tableconvert/ChangeLog
@@ -1,3 +1,8 @@
+2026-04-29  Frank Lanitz  <frank@geany.org>
+
+ * Added documentation for DokuWiki to README
+
+
 2014-10-20  Frank Lanitz  <frank@frank.uvena.de>
 
  * Adding support for DokuWiki

--- a/tableconvert/README
+++ b/tableconvert/README
@@ -41,6 +41,7 @@ Currently the plugin is supporting
 * HTML
 * LaTeX
 * SQL
+* DokuWiki
 
 Rectangle selections are currently not supported and might lead to
 some weird output you didn't expect -- just don't try it if you have
@@ -88,6 +89,24 @@ will be transformed to
 |		('foo', 'baa'),
 |		('baa', 'foo')
 |	)
+
+
+DokuWiki
+^^^^^^^^
+
+DokuWiki tables use pipe characters for regular cells and caret
+characters for header cells. Tabulators are replaced with ' | ' for
+body columns and ' ^ ' for header columns.
+
+A tabulator separated list as e.g.
+
+|	Header1	Header2
+|	Value1	Value2
+
+will be transformed to
+
+|	^ Header1 ^ Header2 ^
+|	| Value1 | Value2 |
 
 
 Development


### PR DESCRIPTION
Added DokuWiki to the list of supported formats and included a dedicated section explaining the table format with an example.