### PR TITLE
[various] Reduce compiler warnings from g_slist_foreach and other common issues

### DIFF
--- a/codenav/src/codenavigation.c
+++ b/codenav/src/codenavigation.c
@@ -162,7 +162,7 @@ static void load_configuration(void)
  * @return the GtkDialog from Geany
  * 
  */
-GtkWidget *plugin_codenav_configure(G_GNUC_UNUSED GeanyPlugin *plugin, GtkDialog *dialog, G_GNUC_UNUSED gpointer pdata)
+static GtkWidget *plugin_codenav_configure(G_GNUC_UNUSED GeanyPlugin *plugin, GtkDialog *dialog, G_GNUC_UNUSED gpointer pdata)
 {
 	GtkWidget *vbox;
 

--- a/codenav/src/goto_file.c
+++ b/codenav/src/goto_file.c
@@ -131,8 +131,7 @@ build_file_list(const gchar* dirname, const gchar* prefix)
 		g_free(pathfile);
 	}
 	
-	g_slist_foreach(files_list, (GFunc) g_free, NULL);
-	g_slist_free(files_list);
+	g_slist_free_full(files_list, g_free);
 	
 	return GTK_TREE_MODEL(ret_list);
  

--- a/codenav/src/switch_head_impl.c
+++ b/codenav/src/switch_head_impl.c
@@ -116,12 +116,8 @@ void languages_clean(void)
 	for(iter = languages ; iter != NULL ; iter = iter->next)
 	{
 		Language* lang = (Language*)(iter->data);
-
-		g_slist_foreach(lang->head_extensions, (GFunc)(&g_free), NULL);
-		g_slist_free(lang->head_extensions);
-
-		g_slist_foreach(lang->impl_extensions, (GFunc)(&g_free), NULL);
-		g_slist_free(lang->impl_extensions);
+		g_slist_free_full(lang->head_extensions, g_free);
+		g_slist_free_full(lang->impl_extensions, g_free);
 	}
 
 	g_slist_free(languages);
@@ -427,7 +423,7 @@ menu_item_activate(guint key_id)
 
 		/* Free the memory */
 free_mem:
-		g_slist_foreach(filenames_to_test, (GFunc)(&g_free), NULL);
+		g_slist_free_full(filenames_to_test, g_free);
 		g_free(dirname);
 		g_free(basename_no_extension);
 		g_free(extension);

--- a/debugger/src/bptree.c
+++ b/debugger/src/bptree.c
@@ -588,8 +588,7 @@ static gboolean on_key_pressed(GtkWidget *widget, GdkEvent *event, gpointer user
 	}
 
 	/* free rows list */
-	g_list_foreach (rows, (GFunc)gtk_tree_path_free, NULL);
-	g_list_free (rows);
+	g_list_free(rows, gtk_tree_path_free);
 
 	return FALSE;
 }

--- a/debugger/src/bptree.c
+++ b/debugger/src/bptree.c
@@ -588,7 +588,7 @@ static gboolean on_key_pressed(GtkWidget *widget, GdkEvent *event, gpointer user
 	}
 
 	/* free rows list */
-	g_list_free(rows, gtk_tree_path_free);
+	g_list_free_full(rows, (GDestroyNotify) gtk_tree_path_free);
 
 	return FALSE;
 }

--- a/debugger/src/dbm_gdb.c
+++ b/debugger/src/dbm_gdb.c
@@ -177,18 +177,15 @@ static void on_gdb_exit(GPid pid, gint status, gpointer data)
 	shutdown_channel(&gdb_ch_out);
 
 	/* delete autos */
-	g_list_foreach(autos, (GFunc)g_free, NULL);
-	g_list_free(autos);
+	g_list_free_full(autos, g_free);
 	autos = NULL;
 
 	/* delete watches */
-	g_list_foreach(watches, (GFunc)g_free, NULL);
-	g_list_free(watches);
+	g_list_free_full(watches, g_free);
 	watches = NULL;
 
 	/* delete files */
-	g_list_foreach(files, (GFunc)g_free, NULL);
-	g_list_free(files);
+	g_list_free_full(files, g_free);
 	files = NULL;
 
 	g_source_remove(gdb_src_id);
@@ -277,8 +274,7 @@ static void free_commands_queue(GList *queue)
 {
 	/* all commands completed */
 	queue = g_list_first(queue);
-	g_list_foreach(queue, (GFunc)free_queue_item, NULL);
-	g_list_free(queue);
+	g_list_free_full(queue, free_queue_item);
 }
 
 /*
@@ -329,8 +325,7 @@ static gboolean on_read_async_output(GIOChannel * src, GIOCondition cond, gpoint
 		}
 
 		lines = read_until_prompt();
-		g_list_foreach(lines, (GFunc)g_free, NULL);
-		g_list_free (lines);
+		g_list_free_full(lines, g_free);
 
 		if (!strcmp(record->klass, "done"))
 		{
@@ -680,8 +675,7 @@ static result_class exec_sync_command(const gchar* command, gboolean wait4prompt
 		gdb_mi_record_free(record);
 	}
 
-	g_list_foreach(lines, (GFunc)g_free, NULL);
-	g_list_free(lines);
+	g_list_free_full(lines, g_free);
 
 	return rc;
 }
@@ -763,8 +757,7 @@ static gboolean run(const gchar* file, const gchar* commandline, GList* env, GLi
 		}
 		g_free(unescaped);
 	}
-	g_list_foreach(lines, (GFunc)g_free, NULL);
-	g_list_free(lines);
+	g_list_free_full(lines, g_free);
 
 	/* add initial watches to the list */
 	while (witer)
@@ -1270,8 +1263,7 @@ static void update_files(void)
 	if (files)
 	{
 		/* free previous list */
-		g_list_foreach(files, (GFunc)g_free, NULL);
-		g_list_free(files);
+		g_list_free_full(files,g_free);
 		files = NULL;
 	}
 
@@ -1381,8 +1373,7 @@ static void update_autos(void)
 		exec_sync_command(command, TRUE, NULL);
 	}
 
-	g_list_foreach(autos, (GFunc)variable_free, NULL);
-	g_list_free(autos);
+	g_list_free_full(autos, variable_free);
 	autos = NULL;
 
 	/* add current autos to the list */

--- a/debugger/src/dbm_gdb.c
+++ b/debugger/src/dbm_gdb.c
@@ -274,7 +274,7 @@ static void free_commands_queue(GList *queue)
 {
 	/* all commands completed */
 	queue = g_list_first(queue);
-	g_list_free_full(queue, free_queue_item);
+	g_list_free_full(queue, (GDestroyNotify) free_queue_item);
 }
 
 /*
@@ -1263,7 +1263,7 @@ static void update_files(void)
 	if (files)
 	{
 		/* free previous list */
-		g_list_free_full(files,g_free);
+		g_list_free_full(files, g_free);
 		files = NULL;
 	}
 
@@ -1373,7 +1373,7 @@ static void update_autos(void)
 		exec_sync_command(command, TRUE, NULL);
 	}
 
-	g_list_free_full(autos, variable_free);
+	g_list_free_full(autos, (GDestroyNotify) variable_free);
 	autos = NULL;
 
 	/* add current autos to the list */

--- a/debugger/src/dconfig.c
+++ b/debugger/src/dconfig.c
@@ -212,8 +212,7 @@ static void save_to_keyfile(GKeyFile *keyfile)
 		env_index++;
 		iter = iter->next;
 	}
-	g_list_foreach(_env, (GFunc)g_free, NULL);
-	g_list_free(_env);
+	g_list_free_full(_env, g_free);
 	
 	/* watches */
 	watches = wtree_get_watches();
@@ -230,8 +229,7 @@ static void save_to_keyfile(GKeyFile *keyfile)
 
 		watch_index++;
 	}
-	g_list_foreach(watches, (GFunc)g_free, NULL);
-	g_list_free(watches);
+	g_list_free_full(watches,g_free);
 
 	/* breakpoints */
 	_breaks = breaks_get_all();

--- a/debugger/src/debug.c
+++ b/debugger/src/debug.c
@@ -496,7 +496,7 @@ static gboolean on_watch_key_pressed_callback(GtkWidget *widget, GdkEvent  *even
 		gtk_tree_path_free(path_to_select);	
 
 		/* free references list */
-		g_list_free_full(references, gtk_tree_row_reference_free);
+		g_list_free_full(references, (GDestroyNotify) gtk_tree_row_reference_free);
 
 		config_set_debug_changed();
 	}
@@ -504,7 +504,7 @@ static gboolean on_watch_key_pressed_callback(GtkWidget *widget, GdkEvent  *even
 	gtk_tree_path_free(empty_path);
 
 	/* free rows list */
-	g_list_free_full(rows, (GDestroyNotify)gtk_tree_path_free);
+	g_list_free_full(rows, (GDestroyNotify) gtk_tree_path_free);
 
 	return FALSE;
 }
@@ -638,7 +638,7 @@ static void on_debugger_run (void)
 	if (stack)
 	{
 		remove_stack_markers();
-		g_list_free_full(stack, frame_unref);
+		g_list_free_full(stack, (GDestroyNotify) frame_unref);
 		stack = NULL;
 
 		stree_remove_frames();
@@ -792,7 +792,7 @@ static void on_debugger_exited (int code)
 	if (stack)
 	{
 		remove_stack_markers();
-		g_list_free_full(stack, frame_unref);
+		g_list_free_full(stack, (GDestroyNotify) frame_unref);
 		stack = NULL;
 	}
 	
@@ -971,7 +971,7 @@ static void on_select_thread(int thread_id)
 
 	if ((success = active_module->set_active_thread(thread_id)))
 	{
-		g_list_free_full(stack, (GDestroyNotify)frame_unref);
+		g_list_free_full(stack, (GDestroyNotify) frame_unref);
 		stack = active_module->get_stack();
 
 		/* update the stack tree */
@@ -1118,7 +1118,7 @@ void debug_destroy(void)
 	if (stack)
 	{
 		remove_stack_markers();
-		g_list_free_full(stack, frame_unref);
+		g_list_free_full(stack, (GDestroyNotify) frame_unref);
 		stack = NULL;
 	}
 	
@@ -1402,7 +1402,7 @@ gchar* debug_get_calltip_for_expression(gchar* expression)
 					{
 						g_string_append(calltip_str, "\n\t\t........");
 					}
-					g_list_free_full(children, variable_free);
+					g_list_free_full(children, (GDestroyNotify) variable_free);
 				}
 				calltip = g_string_free(calltip_str, FALSE);
 			}

--- a/debugger/src/debug.c
+++ b/debugger/src/debug.c
@@ -496,8 +496,7 @@ static gboolean on_watch_key_pressed_callback(GtkWidget *widget, GdkEvent  *even
 		gtk_tree_path_free(path_to_select);	
 
 		/* free references list */
-		g_list_foreach (references, (GFunc)gtk_tree_row_reference_free, NULL);
-		g_list_free (references);
+		g_list_free_full(references, gtk_tree_row_reference_free);
 
 		config_set_debug_changed();
 	}
@@ -505,8 +504,7 @@ static gboolean on_watch_key_pressed_callback(GtkWidget *widget, GdkEvent  *even
 	gtk_tree_path_free(empty_path);
 
 	/* free rows list */
-	g_list_foreach (rows, (GFunc)gtk_tree_path_free, NULL);
-	g_list_free (rows);
+	g_list_free_full(rows, (GDestroyNotify)gtk_tree_path_free);
 
 	return FALSE;
 }
@@ -640,8 +638,7 @@ static void on_debugger_run (void)
 	if (stack)
 	{
 		remove_stack_markers();
-		g_list_foreach(stack, (GFunc)frame_unref, NULL);
-		g_list_free(stack);
+		g_list_free_full(stack, frame_unref);
 		stack = NULL;
 
 		stree_remove_frames();
@@ -795,8 +792,7 @@ static void on_debugger_exited (int code)
 	if (stack)
 	{
 		remove_stack_markers();
-		g_list_foreach(stack, (GFunc)frame_unref, NULL);
-		g_list_free(stack);
+		g_list_free_full(stack, frame_unref);
 		stack = NULL;
 	}
 	
@@ -1122,8 +1118,7 @@ void debug_destroy(void)
 	if (stack)
 	{
 		remove_stack_markers();
-		g_list_foreach(stack, (GFunc)frame_unref, NULL);
-		g_list_free(stack);
+		g_list_free_full(stack, frame_unref);
 		stack = NULL;
 	}
 	
@@ -1224,11 +1219,9 @@ void debug_run(void)
 		g_free(target);
 		g_free(commandline);
 
-		g_list_foreach(env, (GFunc)g_free, NULL);
-		g_list_free(env);
+		g_list_free_full(env, g_free);
 
-		g_list_foreach(watches, (GFunc)g_free, NULL);
-		g_list_free(watches);
+		g_list_free_full(watches, g_free);
 
 		g_list_free(breaks);
 	}
@@ -1409,8 +1402,7 @@ gchar* debug_get_calltip_for_expression(gchar* expression)
 					{
 						g_string_append(calltip_str, "\n\t\t........");
 					}
-					g_list_foreach(children, (GFunc)variable_free, NULL);
-					g_list_free(children);
+					g_list_free_full(children, variable_free);
 				}
 				calltip = g_string_free(calltip_str, FALSE);
 			}

--- a/debugger/src/envtree.c
+++ b/debugger/src/envtree.c
@@ -166,7 +166,7 @@ static void delete_selected_rows(void)
 		gtk_tree_path_free(path);
 
 		/* free references list */
-		g_list_free_full(references, gtk_tree_row_reference_free);
+		g_list_free_full(references, (GDestroyNotify) gtk_tree_row_reference_free);
 	}
 	
 	/* free selection reference */
@@ -175,7 +175,7 @@ static void delete_selected_rows(void)
 	gtk_tree_path_free(empty_path);
 
 	/* free rows list */
-	g_list_free_full(rows, gtk_tree_path_free);
+	g_list_free_full(rows, (GDestroyNotify)  gtk_tree_path_free);
 }
 
 /*

--- a/debugger/src/envtree.c
+++ b/debugger/src/envtree.c
@@ -166,8 +166,7 @@ static void delete_selected_rows(void)
 		gtk_tree_path_free(path);
 
 		/* free references list */
-		g_list_foreach (references, (GFunc)gtk_tree_row_reference_free, NULL);
-		g_list_free (references);
+		g_list_free_full(references, gtk_tree_row_reference_free);
 	}
 	
 	/* free selection reference */
@@ -176,8 +175,7 @@ static void delete_selected_rows(void)
 	gtk_tree_path_free(empty_path);
 
 	/* free rows list */
-	g_list_foreach (rows, (GFunc)gtk_tree_path_free, NULL);
-	g_list_free (rows);
+	g_list_free_full(rows, gtk_tree_path_free);
 }
 
 /*

--- a/debugger/src/vtree.c
+++ b/debugger/src/vtree.c
@@ -64,8 +64,7 @@ static gboolean on_key_pressed(GtkWidget *widget, GdkEvent *event, gpointer user
 			else
 				gtk_tree_view_collapse_row(GTK_TREE_VIEW(widget), (GtkTreePath*)rows->data);
 			
-			g_list_foreach(rows, (GFunc)gtk_tree_path_free, NULL);		
-			g_list_free(rows);
+			g_list_free_full(rows, (GDestroyNotify)gtk_tree_path_free);
 		}
 	}
 

--- a/debugger/src/watch_model.c
+++ b/debugger/src/watch_model.c
@@ -206,8 +206,7 @@ inline static GList *lookup_variable(GList *vars, gchar *name)
  */
 void free_variables_list(GList *vars)
 {
-	g_list_foreach(vars, (GFunc)variable_free, NULL);
-	g_list_free(vars);
+	g_list_free_full(vars, variable_free);
 }
 
 /*

--- a/debugger/src/watch_model.c
+++ b/debugger/src/watch_model.c
@@ -206,7 +206,7 @@ inline static GList *lookup_variable(GList *vars, gchar *name)
  */
 void free_variables_list(GList *vars)
 {
-	g_list_free_full(vars, variable_free);
+	g_list_free_full(vars, (GDestroyNotify) variable_free);
 }
 
 /*

--- a/geanyctags/src/geanyctags.c
+++ b/geanyctags/src/geanyctags.c
@@ -180,7 +180,7 @@ static gchar *get_tags_filename(void)
 	}
 	return ret;
 }
-
+#ifndef G_OS_WIN32
 static gchar *generate_find_string(GeanyProject *prj)
 {
 	gchar *ret;
@@ -198,6 +198,7 @@ static gchar *generate_find_string(GeanyProject *prj)
 	}
 	return ret;
 }
+#endif
 
 
 static gchar *get_base_path(void)

--- a/geanylua/glspi.h
+++ b/geanylua/glspi.h
@@ -137,6 +137,12 @@ void glspi_init_sci_funcs(lua_State *L);
 void glspi_init_gsdlg_module(lua_State *L, GsDlgRunHook hook, GtkWindow *toplevel);
 void glspi_run_script(const gchar *script_file, gint caller, GKeyFile*proj, const gchar *script_dir);
 
+gint luaopen_libgeanylua(lua_State *L);
+void glspi_init (GeanyData *data, GeanyPlugin *plugin);
+void glspi_cleanup(void);
+void glspi_configure(GtkWidget *parent);
+
+
 /* Pass TRUE to create hashes, FALSE to destroy them */
 void glspi_set_sci_cmd_hash(gboolean create);
 void glspi_set_key_cmd_hash(gboolean create);

--- a/geanylua/glspi_kfile.c
+++ b/geanylua/glspi_kfile.c
@@ -11,6 +11,7 @@
 #include <lua.h>
 #include <lualib.h>
 #include <lauxlib.h>
+#include "glspi_kfile.h"
 
 #define LUA_MODULE_NAME "keyfile"
 #define MetaName "_g_key_file_metatable"
@@ -63,15 +64,8 @@ static gint fail_arg_type(lua_State *L, const gchar *func, gint argnum, const gc
 
 static const gchar*LuaKeyFileType="GKeyFile";
 
-typedef struct _LuaKeyFile
-{
-	const gchar*id;
-	GKeyFile*kf;
-	gboolean managed;
-} LuaKeyFile;
 
 
-typedef gint (*KeyfileAssignFunc) (lua_State *L, GKeyFile*kf);
 
 static gint glspi_kfile_assign(lua_State *L, GKeyFile*kf)
 {

--- a/geanylua/glspi_kfile.h
+++ b/geanylua/glspi_kfile.h
@@ -1,0 +1,22 @@
+/*
+ * glspi_kfile.h - This file is part of the Lua scripting plugin for the Geany IDE
+ * See the file "geanylua.c" for copyright information.
+ */
+
+/* Minimal interface to a GKeyFile object */
+
+#ifndef __GLSPI_KFILE_H
+#define __GLSPI_KFILE_H
+
+typedef struct _LuaKeyFile
+{
+	const gchar*id;
+	GKeyFile*kf;
+	gboolean managed;
+} LuaKeyFile;
+
+
+typedef gint (*KeyfileAssignFunc) (lua_State *L, GKeyFile*kf);
+
+void glspi_init_kfile_module(lua_State *L, KeyfileAssignFunc *func);
+#endif

--- a/geanylua/gsdlg.h
+++ b/geanylua/gsdlg.h
@@ -39,6 +39,7 @@ which case the GSDLG_API functions will be available externally.
 #define GSDLG_API
 #endif
 
+#include <lua.h>
 #include <gtk/gtk.h>
 
 typedef const gchar* GsDlgStr;
@@ -77,6 +78,7 @@ typedef void (*GsDlgRunHook) (gboolean running, gpointer user_data);
 */
 #ifndef DIALOG_LIB
 GSDLG_API void gsdlg_set_run_hook(GsDlgRunHook cb);
+void glspi_init_gsdlg_module(lua_State *L, GsDlgRunHook hook, GtkWindow *toplevel);
 #endif
 
 

--- a/geanyprj/src/project.c
+++ b/geanyprj/src/project.c
@@ -224,8 +224,7 @@ void geany_project_regenerate_file_list(struct GeanyPrj *prj)
 	lst = get_file_list(prj->base_path, NULL, project_type_filter[prj->type], NULL);
 	geany_project_set_tags_from_list(prj, lst);
 
-	g_slist_foreach(lst, (GFunc) g_free, NULL);
-	g_slist_free(lst);
+	g_slist_free_full(lst, g_free);
 }
 
 

--- a/geanyprj/src/sidebar.c
+++ b/geanyprj/src/sidebar.c
@@ -82,8 +82,7 @@ static void open_selected_files(GList *list)
 		files = g_slist_append(files, fname);
 	}
 	document_open_files(files, FALSE, NULL, NULL);
-	g_slist_foreach(files, (GFunc)g_free, NULL);	/* free filenames */
-	g_slist_free(files);
+	g_slist_free_full(files, g_free); /* free filenames */
 }
 
 
@@ -97,8 +96,7 @@ static void on_open_clicked(G_GNUC_UNUSED GtkMenuItem *menuitem, G_GNUC_UNUSED g
 
 	list = gtk_tree_selection_get_selected_rows(treesel, &model);
 	open_selected_files(list);
-	g_list_foreach(list, (GFunc)gtk_tree_path_free, NULL);
-	g_list_free(list);
+	g_list_free_full(list, (GDestroyNotify)gtk_tree_path_free);
 }
 
 
@@ -146,8 +144,7 @@ static void on_remove_files(G_GNUC_UNUSED GtkMenuItem *menuitem, G_GNUC_UNUSED g
 
 	list = gtk_tree_selection_get_selected_rows(treesel, &model);
 	remove_selected_files(list);
-	g_list_foreach(list, (GFunc) gtk_tree_path_free, NULL);
-	g_list_free(list);
+	g_list_free_full(list, (GDestroyNotify)gtk_tree_path_free);
 }
 
 
@@ -429,8 +426,7 @@ void sidebar_refresh(void)
 		gtk_list_store_append(file_store, &iter);
 		gtk_list_store_set(file_store, &iter, FILEVIEW_COLUMN_NAME, tmp->data, -1);
 	}
-	g_slist_foreach(lst, (GFunc) g_free, NULL);
-	g_slist_free(lst);
+	g_slist_free_full(lst, g_free);
 }
 
 

--- a/git-changebar/src/gcb-plugin.c
+++ b/git-changebar/src/gcb-plugin.c
@@ -1618,7 +1618,9 @@ struct ConfigureWidgets {
   GtkWidget  *removed_color_button;
 };
 
-static void configure_widgets_free (ConfigureWidgets *cw)
+static void
+configure_widgets_free (ConfigureWidgets*  cw,
+                     GClosure *closure)
 {
   g_object_unref (cw->base);
   g_free (cw);

--- a/latex/src/bibtex.c
+++ b/latex/src/bibtex.c
@@ -79,6 +79,7 @@ void glatex_insert_bibtex_entry(G_GNUC_UNUSED GtkMenuItem * menuitem,
 		{
 			g_ptr_array_index(entry, i) = g_strdup("");
 		}
+		/* fall through */
 	case GLATEX_BIBTEX_TECHREPORT:
 		g_ptr_array_index(entry, GLATEX_BIBTEX_AUTHOR) = g_strdup("");
 		g_ptr_array_index(entry, GLATEX_BIBTEX_TITLE) = g_strdup("");

--- a/latex/src/latex.c
+++ b/latex/src/latex.c
@@ -985,8 +985,7 @@ glatex_insert_ref_activated(G_GNUC_UNUSED GtkMenuItem * menuitem,
 		model = gtk_combo_box_get_model(GTK_COMBO_BOX(textbox_ref));
 		gtk_tree_sortable_set_sort_column_id(GTK_TREE_SORTABLE(model),
 			0, GTK_SORT_ASCENDING);
-		g_slist_foreach(file_list, (GFunc) g_free, NULL);
-		g_slist_free(file_list);
+		g_slist_free_full(file_list, g_free);
 		if (dir != NULL)
 			g_free(dir);
 	}

--- a/latex/src/templates.c
+++ b/latex/src/templates.c
@@ -79,8 +79,7 @@ GPtrArray* glatex_init_custom_templates(void)
 
 	/* Iterating on all list items */
 	g_slist_foreach(file_list, (GFunc)glatex_init_cutom_template_item, templates);
- 	g_slist_foreach(file_list, (GFunc) g_free, NULL);
-	g_slist_free(file_list);
+	g_slist_free_full(file_list, g_free);
 
 	g_free(tmp_basedir);
 	return templates;

--- a/lineoperations/src/lo_prefs.c
+++ b/lineoperations/src/lo_prefs.c
@@ -123,7 +123,7 @@ lo_init_prefs(GeanyPlugin *plugin)
 
 /* Free config */
 void
-lo_free_info() {
+lo_free_info(void) {
 	g_free(lo_info->config_file);
 	g_free(lo_info);
 }

--- a/lineoperations/src/lo_prefs.h
+++ b/lineoperations/src/lo_prefs.h
@@ -54,6 +54,6 @@ lo_init_prefs(GeanyPlugin *plugin);
 
 /* Free config */
 void
-lo_free_info();
+lo_free_info(void);
 
 #endif

--- a/lipsum/src/lipsum.c
+++ b/lipsum/src/lipsum.c
@@ -148,9 +148,6 @@ plugin_init(G_GNUC_UNUSED GeanyData *data)
 	GtkWidget *menu_lipsum = NULL;
 	GKeyFile *config = g_key_file_new();
 	gchar *config_file = NULL;
-	gchar *config_file_old = NULL;
-	gchar *config_dir = NULL;
-	gchar *config_dir_old = NULL;
 	GeanyKeyGroup *key_group;
 
 
@@ -160,6 +157,9 @@ plugin_init(G_GNUC_UNUSED GeanyData *data)
 
 	#ifndef G_OS_WIN32
 	/* We try only to move if we are on not Windows platform */
+	gchar *config_file_old = NULL;
+	gchar *config_dir = NULL;
+	gchar *config_dir_old = NULL;
 	config_dir_old = g_build_filename(geany->app->configdir,
 		"plugins", "geanylipsum", NULL);
 	config_file_old = g_build_filename(config_dir_old,

--- a/lsp/src/lsp-autocomplete.c
+++ b/lsp/src/lsp-autocomplete.c
@@ -288,7 +288,7 @@ static void resolve_cb(GVariant *return_value, GError *error, gpointer user_data
 }
 
 
-LspAutocompleteSymbol *find_symbol(GeanyDocument *doc, const gchar *text)
+static LspAutocompleteSymbol *find_symbol(GeanyDocument *doc, const gchar *text)
 {
 	LspServer *srv = lsp_server_get(doc);
 	LspAutocompleteSymbol *sym = NULL;

--- a/lsp/src/lsp-log.c
+++ b/lsp/src/lsp-log.c
@@ -25,7 +25,7 @@
 
 #include <glib.h>
 
-
+#pragma GCC diagnostic ignored "-Wsuggest-attribute=format"
 static void log_print(LspLogInfo log, const gchar *fmt, ...)
 {
 	va_list args;
@@ -41,6 +41,7 @@ static void log_print(LspLogInfo log, const gchar *fmt, ...)
 
 	va_end(args);
 }
+#pragma GCC diagnostic pop
 
 
 LspLogInfo lsp_log_start(LspServerConfig *config)
@@ -110,7 +111,7 @@ void lsp_log(LspLogInfo log, LspLogType type, const gchar *method, GVariant *par
 	if (req_time)
 	{
 		GTimeSpan delta = g_date_time_difference(time, req_time);
-		delta_str = g_strdup_printf(" (%ld ms)", delta / 1000);
+		delta_str = g_strdup_printf(" (%lld ms)", delta / 1000);
 	}
 	else
 		delta_str = g_strdup("");

--- a/lsp/src/lsp-progress.c
+++ b/lsp/src/lsp-progress.c
@@ -187,7 +187,7 @@ void lsp_progress_process_notification(LspServer *srv, GVariant *params)
 		);
 		if (have_percentage)
 		{
-			g_snprintf(buf, 30, "%ld%%", percentage);
+			g_snprintf(buf, 30, "%lld%%", percentage);
 			message = buf;
 		}
 	}

--- a/lsp/src/lsp-symbol.c
+++ b/lsp/src/lsp-symbol.c
@@ -59,14 +59,6 @@ LspSymbol *lsp_symbol_new(const gchar *name, const gchar *detail, const gchar *s
 }
 
 
-LspSymbol *lsp_symbol_new_from_tag(TMTag *tag)
-{
-	LspSymbol *sym = g_slice_new0(LspSymbol);
-	sym->refcount = 1;
-	return sym;
-}
-
-
 static void symbol_destroy(LspSymbol *sym)
 {
 	g_free(sym->name);

--- a/projectorganizer/src/prjorg-project.c
+++ b/projectorganizer/src/prjorg-project.c
@@ -53,11 +53,7 @@ static GSList *s_idle_remove_funcs;
 
 static void clear_idle_queue(GSList **queue)
 {
-	GSList *elem;
-
-	foreach_slist(elem, *queue)
-		g_free(elem->data);
-	g_slist_free(*queue);
+	g_slist_free_full(*queue, g_free);
 	*queue = NULL;
 }
 
@@ -187,17 +183,13 @@ static gint prjorg_project_rescan_root(PrjOrgRoot *root)
 		}
 	}
 
-	g_slist_foreach(lst, (GFunc) g_free, NULL);
-	g_slist_free(lst);
+	g_slist_free_full(lst, g_free);
 
-	g_slist_foreach(pattern_list, (GFunc) g_pattern_spec_free, NULL);
-	g_slist_free(pattern_list);
+	g_slist_free_full(pattern_list, (GDestroyNotify) g_pattern_spec_free);
 
-	g_slist_foreach(ignored_dirs_list, (GFunc) g_pattern_spec_free, NULL);
-	g_slist_free(ignored_dirs_list);
+	g_slist_free_full(ignored_dirs_list, (GDestroyNotify) g_pattern_spec_free);
 
-	g_slist_foreach(ignored_file_list, (GFunc) g_pattern_spec_free, NULL);
-	g_slist_free(ignored_file_list);
+	g_slist_free_full(ignored_file_list, (GDestroyNotify) g_pattern_spec_free);
 
 	return filenum;
 }
@@ -314,7 +306,7 @@ static void regenerate_tags(PrjOrgRoot *root, gpointer user_data)
 }
 
 
-void rescan_project(gchar **session_files)
+static void rescan_project(gchar **session_files)
 {
 	GSList *elem;
 	gint filenum = 0;
@@ -806,6 +798,7 @@ void prjorg_project_close(void)
 
 	g_slist_foreach(prj_org->roots, (GFunc)close_root, NULL);
 	g_slist_free(prj_org->roots);
+
 
 	g_strfreev(prj_org->source_patterns);
 	g_strfreev(prj_org->header_patterns);

--- a/projectorganizer/src/prjorg-sidebar.c
+++ b/projectorganizer/src/prjorg-sidebar.c
@@ -1353,10 +1353,8 @@ static void load_project_root(PrjOrgRoot *root, GtkTreeIter *parent, GSList *hea
 			set_intro_message(_("Set file patterns under Project->Properties"));
 	}
 
-	g_slist_foreach(lst, (GFunc) g_free, NULL);
-	g_slist_free(lst);
-	g_slist_foreach(path_list, (GFunc) g_strfreev, NULL);
-	g_slist_free(path_list);
+	g_slist_free_full(lst, g_free);
+	g_slist_free_full(path_list, (GDestroyNotify) g_strfreev);
 }
 
 
@@ -1403,10 +1401,8 @@ static void load_project(void)
 
 	collapse();
 
-	g_slist_foreach(header_patterns, (GFunc) g_pattern_spec_free, NULL);
-	g_slist_free(header_patterns);
-	g_slist_foreach(source_patterns, (GFunc) g_pattern_spec_free, NULL);
-	g_slist_free(source_patterns);
+	g_slist_free_full(header_patterns, (GDestroyNotify) g_pattern_spec_free);
+	g_slist_free_full(source_patterns, (GDestroyNotify) g_pattern_spec_free);
 	g_object_unref(icon_dir);
 }
 

--- a/projectorganizer/src/prjorg-utils.c
+++ b/projectorganizer/src/prjorg-utils.c
@@ -384,8 +384,7 @@ gchar *find_header_source(GeanyDocument *doc)
 				SETPTR(elem->data, full_name);
 			}
 			found_name = try_find_header_source(doc->file_name, is_header, list, header_patterns, source_patterns);
-			g_slist_foreach(list, (GFunc) g_free, NULL);
-			g_slist_free(list);
+			g_slist_free_full(list, g_free);
 			g_free(utf8_doc_dir);
 			g_free(locale_doc_dir);
 			list = NULL;
@@ -412,10 +411,8 @@ gchar *find_header_source(GeanyDocument *doc)
 		}
 	}
 
-	g_slist_foreach(header_patterns, (GFunc) g_pattern_spec_free, NULL);
-	g_slist_free(header_patterns);
-	g_slist_foreach(source_patterns, (GFunc) g_pattern_spec_free, NULL);
-	g_slist_free(source_patterns);
+	g_slist_free_full(header_patterns, (GDestroyNotify) g_pattern_spec_free);
+	g_slist_free_full(source_patterns, (GDestroyNotify) g_pattern_spec_free);
 
 	return found_name;
 }

--- a/scope/src/break.c
+++ b/scope/src/break.c
@@ -697,6 +697,7 @@ void on_break_done(GArray *nodes)
 	switch (oper)
 	{
 		case '0' :
+		/* fall through */
 		case '1' :
 		{
 			GtkTreeIter iter;
@@ -708,7 +709,8 @@ void on_break_done(GArray *nodes)
 			}
 			break;
 		}
-		case '2' : prefix = "022";  /* and continue */
+		case '2' : prefix = "022";
+		/* fall through */
 		case '3' :
 		{
 			debug_send_format(N, "%s-break-info %s", prefix, token);

--- a/scope/src/conterm.c
+++ b/scope/src/conterm.c
@@ -220,7 +220,7 @@ static GtkTextTag *fd_tags[NFD];
 #define DC_DELTA 6144
 static guint dc_chars = 0;
 
-void context_output(int fd, const char *text, gint length)
+static void context_output(int fd, const char *text, gint length)
 {
 	static int last_fd = -1;
 	GtkTextIter end;
@@ -263,7 +263,7 @@ void context_output(int fd, const char *text, gint length)
 	gtk_text_view_scroll_mark_onscreen(debug_context, gtk_text_buffer_get_insert(context));
 }
 
-void context_output_nl(int fd, const char *text, gint length)
+static void context_output_nl(int fd, const char *text, gint length)
 {
 	dc_output(fd, text, length);
 	dc_output(fd, "\n", 1);

--- a/scope/src/debug.c
+++ b/scope/src/debug.c
@@ -204,7 +204,7 @@ static void create_send_source(void)
 	GSource *send_source = g_io_create_watch(send_channel, G_IO_OUT | G_IO_FAILURE);
 
 	g_io_channel_unref(send_channel);
-	g_source_set_callback(send_source, (GSourceFunc) send_commands_cb, NULL,
+	g_source_set_callback(send_source, G_SOURCE_FUNC(  send_commands_cb ), NULL,
 		send_source_destroy_cb);
 	send_source_id = g_source_attach(send_source, NULL);
 	/* cppcheck-suppress memleak symbolName=send_source
@@ -317,7 +317,8 @@ static void receive_output_cb(GString *string, GIOCondition condition,
 
 		switch (*term)
 		{
-			case '\n' : if (string->len >= 2 && term[-1] == '\r') term--;  /* falldown */
+			case '\n' : if (string->len >= 2 && term[-1] == '\r') term--;
+			/* fall through */
 			case '\r' : *term = '\0'; break;
 			case '\0' : error = "binary zero encountered"; break;
 			default : error = "line too long or incomplete";
@@ -561,6 +562,7 @@ void on_debug_terminate(const MenuItem *menu_item)
 			break;
 		}
 		case DS_READY :
+		/* fall through */
 		case DS_DEBUG :
 		{
 			if (menu_item && !debug_auto_exit)
@@ -568,8 +570,8 @@ void on_debug_terminate(const MenuItem *menu_item)
 				debug_send_command(N, "kill");
 				break;
 			}
-			/* falldown */
 		}
+		/* fall through */
 		default :
 		{
 			debug_send_command(N, "-gdb-exit");

--- a/scope/src/inspect.h
+++ b/scope/src/inspect.h
@@ -40,6 +40,12 @@ void inspects_update_state(DebugState state);
 void inspects_delete_all(void);
 void inspects_load(GKeyFile *config);
 void inspects_save(GKeyFile *config);
+gboolean on_inspect_drag_motion(G_GNUC_UNUSED GtkWidget *widget,
+	G_GNUC_UNUSED GdkDragContext *context, gint x, gint y, G_GNUC_UNUSED guint time,
+	G_GNUC_UNUSED gpointer gdata);
+gboolean on_inspect_button_press(GtkWidget *widget, GdkEventButton *event,
+	G_GNUC_UNUSED gpointer gdata);
+
 
 void inspect_init(void);
 void inspect_finalize(void);

--- a/scope/src/memory.c
+++ b/scope/src/memory.c
@@ -44,7 +44,7 @@ static void on_memory_bytes_edited(G_GNUC_UNUSED GtkCellRendererText *renderer, 
 	if (*new_text && (debug_state() & DS_VARIABLE))
 	{
 		GtkTreeIter iter;
-		const char *addr, *bytes;
+		const gchar *addr, *bytes;
 		guint i;
 
 		scp_tree_store_get_iter_from_string(store, &iter, path_str);
@@ -115,7 +115,7 @@ static const TreeCell memory_cells[] =
 };
 
 static guint pointer_size;
-static char *addr_format;
+static gchar *addr_format;
 #define MAX_BYTES_PER_LINE 128
 #define MAX_POINTER_SIZE 8
 
@@ -150,7 +150,7 @@ static void write_block(guint64 start, const char *contents, guint count, const 
 	while (memory_count < MAX_BYTES)
 	{
 		GtkTreeIter iter;
-		char *addr = g_strdup_printf(addr_format, start);
+		gchar *addr = g_strdup_printf(addr_format, start);
 		GString *bytes = g_string_sized_new(bytes_per_line * 3);
 		GString *ascii = g_string_new(" ");
 		gint n = 0;
@@ -300,7 +300,7 @@ static void on_memory_read(G_GNUC_UNUSED const MenuItem *menu_item)
 static void on_memory_copy(G_GNUC_UNUSED const MenuItem *menu_item)
 {
 	GtkTreeIter iter;
-	const char *addr, *bytes;
+	const gchar *addr, *bytes;
 	const gchar *ascii;
 	gchar *string;
 

--- a/scope/src/parse.c
+++ b/scope/src/parse.c
@@ -155,11 +155,16 @@ char *parse_string(char *text, char newline)
 			switch (*++text)
 			{
 				case '\\' :
+				/* fall through */
 				case '"' : break;
 				case 'n' :
+				/* fall through */
 				case 'N' : if (newline) { *text = newline; break; }
+				/* fall through */
 				case 't' :
+				/* fall through */
 				case 'T' : if (newline) { *text = '\t'; break; }
+				/* fall through */
 				default : text--;
 			}
 		}
@@ -282,6 +287,7 @@ static char *parse_value(char *text, gint mr_mode)
 		switch (*s)
 		{
 			case '"' :
+			/* fall through */
 			case '\'' :
 			{
 				const char *q = s;
@@ -346,6 +352,7 @@ static char *parse_value(char *text, gint mr_mode)
 				break;
 			}
 			case '{' :
+			/* fall through */
 			case ',' : start = t->str + t->len + 1 + (isspace(s[1]) != 0); break;
 			case '=' :
 			{
@@ -364,6 +371,7 @@ static char *parse_value(char *text, gint mr_mode)
 				continue;
 			}
 			case '.' : if (strncmp(s, "...", 3)) break;
+			/* fall through */
 			case '<' :
 			{
 				if (mr_mode == MR_EDITVC)

--- a/scope/src/parse.h
+++ b/scope/src/parse.h
@@ -54,9 +54,9 @@ void on_error(GArray *nodes);
 typedef struct _ParseLocation
 {
 	gchar *base_name;
-	const char *func;
-	const char *addr;
-	const char *file;
+	const gchar *func;
+	const gchar *addr;
+	const gchar *file;
 	gint line;
 } ParseLocation;
 

--- a/scope/src/plugme.c
+++ b/scope/src/plugme.c
@@ -29,8 +29,6 @@
 
 #include <geanyplugin.h>
 
-extern GeanyData *geany_data;
-
 /* This file must not depend on Scope */
 #include "plugme.h"
 

--- a/scope/src/store/scptreestore.c
+++ b/scope/src/store/scptreestore.c
@@ -1777,7 +1777,7 @@ gboolean scp_tree_store_traverse(ScpTreeStore *store, gboolean sublevels, GtkTre
 
 /* Class */
 
-static void scp_tree_store_tree_model_init(GtkTreeModelIface *iface)
+static void scp_tree_store_tree_model_init(GtkTreeModelIface *iface, gpointer iface_data)
 {
 	iface->get_flags = (GtkTreeModelFlags (*)(GtkTreeModel *)) scp_tree_store_get_flags;
 	iface->get_n_columns = (gint (*)(GtkTreeModel *)) scp_tree_store_get_n_columns;
@@ -1804,7 +1804,7 @@ static void scp_tree_store_tree_model_init(GtkTreeModelIface *iface)
 		scp_tree_store_iter_parent;
 }
 
-static void scp_tree_store_drag_source_init(GtkTreeDragSourceIface *iface)
+static void scp_tree_store_drag_source_init(GtkTreeDragSourceIface *iface, gpointer iface_data)
 {
 	iface->row_draggable = (gboolean (*)(GtkTreeDragSource *, GtkTreePath *))
 		scp_tree_store_row_draggable;
@@ -1814,7 +1814,7 @@ static void scp_tree_store_drag_source_init(GtkTreeDragSourceIface *iface)
 		GtkSelectionData *)) scp_tree_store_drag_data_get;
 }
 
-static void scp_tree_store_drag_dest_init(GtkTreeDragDestIface *iface)
+static void scp_tree_store_drag_dest_init(GtkTreeDragDestIface *iface, gpointer iface_data)
 {
 	iface->drag_data_received = (gboolean (*)(GtkTreeDragDest *, GtkTreePath *,
 		GtkSelectionData *)) scp_tree_store_drag_data_received;
@@ -1822,7 +1822,7 @@ static void scp_tree_store_drag_dest_init(GtkTreeDragDestIface *iface)
 		GtkSelectionData *)) scp_tree_store_row_drop_possible;
 }
 
-static void scp_tree_store_sortable_init(GtkTreeSortableIface *iface)
+static void scp_tree_store_sortable_init(GtkTreeSortableIface *iface, gpointer iface_data)
 {
 	iface->get_sort_column_id = (gboolean (*)(GtkTreeSortable *, gint *, GtkSortType *))
 		scp_tree_store_get_sort_column_id;
@@ -1836,7 +1836,7 @@ static void scp_tree_store_sortable_init(GtkTreeSortableIface *iface)
 		scp_tree_store_has_default_sort_func;
 }
 
-static void scp_tree_store_buildable_init(GtkBuildableIface *iface)
+static void scp_tree_store_buildable_init(GtkBuildableIface *iface, gpointer iface_data)
 {
 	iface->custom_tag_start = scp_tree_store_buildable_custom_tag_start;
 	iface->custom_finished = scp_tree_store_buildable_custom_finished;
@@ -1971,7 +1971,7 @@ static void scp_tree_store_finalize(GObject *object)
 	G_OBJECT_CLASS(scp_tree_store_parent_class)->finalize(object);
 }
 
-static void scp_tree_store_gobject_init(GObjectClass *class)
+static void scp_tree_store_gobject_init(GObjectClass *class, gpointer class_data)
 {
 	scp_tree_store_parent_class = g_type_class_peek_parent(class);
 	class->constructor = scp_tree_store_constructor;
@@ -1980,9 +1980,9 @@ static void scp_tree_store_gobject_init(GObjectClass *class)
 	class->set_property = scp_tree_store_set_property;
 }
 
-static void scp_tree_store_class_init(GObjectClass *class)
+static void scp_tree_store_class_init(GObjectClass *class, gpointer class_data)
 {
-	scp_tree_store_gobject_init(class);
+	scp_tree_store_gobject_init(class, NULL);
 	g_type_class_add_private(class, sizeof(ScpTreeStorePrivate));
 	g_assert(GTK_TREE_SORTABLE_DEFAULT_SORT_COLUMN_ID == -1);  /* headers[-1] = default */
 
@@ -2049,16 +2049,16 @@ void scp_tree_store_register_dynamic(void)
 		gpointer class = g_type_class_peek(type);
 		gpointer iface = g_type_interface_peek(class, GTK_TYPE_TREE_MODEL);
 
-		scp_tree_store_gobject_init((GObjectClass *) class);
-		scp_tree_store_tree_model_init((GtkTreeModelIface *) iface);
+		scp_tree_store_gobject_init((GObjectClass *) class, NULL);
+		scp_tree_store_tree_model_init((GtkTreeModelIface *) iface, NULL);
 		iface = g_type_interface_peek(class, GTK_TYPE_TREE_DRAG_SOURCE);
-		scp_tree_store_drag_source_init((GtkTreeDragSourceIface *) iface);
+		scp_tree_store_drag_source_init((GtkTreeDragSourceIface *) iface, NULL);
 		iface = g_type_interface_peek(class, GTK_TYPE_TREE_DRAG_DEST);
-		scp_tree_store_drag_dest_init((GtkTreeDragDestIface *) iface);
+		scp_tree_store_drag_dest_init((GtkTreeDragDestIface *) iface, NULL);
 		iface = g_type_interface_peek(class, GTK_TYPE_TREE_SORTABLE);
-		scp_tree_store_sortable_init((GtkTreeSortableIface *) iface);
+		scp_tree_store_sortable_init((GtkTreeSortableIface *) iface, NULL);
 		iface = g_type_interface_peek(class, GTK_TYPE_BUILDABLE);
-		scp_tree_store_buildable_init((GtkBuildableIface *) iface);
+		scp_tree_store_buildable_init((GtkBuildableIface *) iface, NULL);
 		scp_tree_store_type_id = type;
 	}
 }

--- a/scope/src/thread.c
+++ b/scope/src/thread.c
@@ -21,7 +21,9 @@
 # include "config.h"
 #endif
 
-#define _WIN32_WINNT 0x0501  /* for DebugBreakProcess(), must be before any #include-s */
+/* for DebugBreakProcess(), must be before any #include-s */
+/*#define _WIN32_WINNT 0x0501
+ * disabled as it should be uniformly set in CFLAG -D for the entire project */
 
 #include <ctype.h>
 #include <stdlib.h>
@@ -643,7 +645,7 @@ static void on_thread_selection_changed(GtkTreeSelection *selection,
 	{
 		const gchar *state;
 		gint line;
-		const char *addr;
+		const gchar *addr;
 
 		scp_tree_store_get(store, &iter, THREAD_ID, &thread_id, THREAD_STATE, &state,
 			THREAD_LINE, &line, THREAD_ADDR, &addr, -1);

--- a/scope/src/views.h
+++ b/scope/src/views.h
@@ -82,6 +82,9 @@ void view_seek_selected(GtkTreeSelection *selection, gboolean focus, SeekerType 
 void view_command_line(const gchar *text, const gchar *title, const gchar *seek,
 	gboolean seek_after);
 void views_update_state(DebugState state);
+gboolean on_command_dialog_configure(G_GNUC_UNUSED GtkWidget *widget,
+	G_GNUC_UNUSED GdkEventButton *event, G_GNUC_UNUSED gpointer gdata);
+gboolean view_command_active(void);
 
 void views_init(void);
 void views_finalize(void);

--- a/sendmail/src/sendmail.c
+++ b/sendmail/src/sendmail.c
@@ -359,9 +359,6 @@ GtkWidget *plugin_configure(GtkDialog *dialog)
 void plugin_init(GeanyData G_GNUC_UNUSED *data)
 {
 	GKeyFile *config = g_key_file_new();
-	gchar *config_file_old = NULL;
-	gchar *config_dir = NULL;
-	gchar *config_dir_old = NULL;
 	gchar *kb_label = _("Send file by mail");
 	GtkWidget *menu_mail = NULL;
 	GeanyKeyGroup *key_group;
@@ -371,6 +368,9 @@ void plugin_init(GeanyData G_GNUC_UNUSED *data)
 
 	#ifndef G_OS_WIN32
 	/* We try only to move if we are on not Windows platform */
+	gchar *config_file_old = NULL;
+	gchar *config_dir = NULL;
+	gchar *config_dir_old = NULL;
 	config_file_old = g_strconcat(geany->app->configdir, G_DIR_SEPARATOR_S,
 		"plugins", G_DIR_SEPARATOR_S,
 		"geanysendmail", G_DIR_SEPARATOR_S, "mail.conf", NULL);

--- a/utils/src/filelist.c
+++ b/utils/src/filelist.c
@@ -209,14 +209,11 @@ GSList *gp_filelist_scan_directory(guint *files, guint *folders, const gchar *se
 	filelist_scan_directory_int(searchdir, &params, 0);
 	g_hash_table_destroy(params.visited_paths);
 
-	g_slist_foreach(params.file_patterns, (GFunc) g_pattern_spec_free, NULL);
-	g_slist_free(params.file_patterns);
+	g_slist_free_full(params.file_patterns, (GDestroyNotify) g_pattern_spec_free);
 
-	g_slist_foreach(params.ignored_dirs_list, (GFunc) g_pattern_spec_free, NULL);
-	g_slist_free(params.ignored_dirs_list);
+	g_slist_free_full(params.ignored_dirs_list, (GDestroyNotify) g_pattern_spec_free);
 
-	g_slist_foreach(params.ignored_file_list, (GFunc) g_pattern_spec_free, NULL);
-	g_slist_free(params.ignored_file_list);
+	g_slist_free_full(params.ignored_file_list, (GDestroyNotify) g_pattern_spec_free);
 
 	if (files != NULL)
 	{
@@ -280,14 +277,11 @@ GSList *gp_filelist_scan_directory_full(guint *files, guint *folders, const gcha
 	filelist_scan_directory_int(searchdir, &params, flags);
 	g_hash_table_destroy(params.visited_paths);
 
-	g_slist_foreach(params.file_patterns, (GFunc) g_pattern_spec_free, NULL);
-	g_slist_free(params.file_patterns);
+	g_slist_free_full(params.file_patterns, (GDestroyNotify) g_pattern_spec_free);
 
-	g_slist_foreach(params.ignored_dirs_list, (GFunc) g_pattern_spec_free, NULL);
-	g_slist_free(params.ignored_dirs_list);
+	g_slist_free_full(params.ignored_dirs_list, (GDestroyNotify) g_pattern_spec_free);
 
-	g_slist_foreach(params.ignored_file_list, (GFunc) g_pattern_spec_free, NULL);
-	g_slist_free(params.ignored_file_list);
+	g_slist_free_full(params.ignored_file_list, (GDestroyNotify) g_pattern_spec_free);
 
 	if (files != NULL)
 	{
@@ -359,14 +353,11 @@ gboolean gp_filelist_filepath_matches_patterns(const gchar *filepath, gchar **fi
 		}
 	}
 
-	g_slist_foreach(file_patterns_list, (GFunc) g_pattern_spec_free, NULL);
-	g_slist_free(file_patterns_list);
+	g_slist_free_full(file_patterns_list, (GDestroyNotify) g_pattern_spec_free);
 
-	g_slist_foreach(ignored_dirs_list, (GFunc) g_pattern_spec_free, NULL);
-	g_slist_free(ignored_dirs_list);
+	g_slist_free_full(ignored_dirs_list, (GDestroyNotify) g_pattern_spec_free);
 
-	g_slist_foreach(ignored_file_list, (GFunc) g_pattern_spec_free, NULL);
-	g_slist_free(ignored_file_list);
+	g_slist_free_full(ignored_file_list, (GDestroyNotify) g_pattern_spec_free);
 
 	return match;
 }

--- a/workbench/src/search_projects.c
+++ b/workbench/src/search_projects.c
@@ -28,6 +28,7 @@
 #include "dialogs.h"
 #include "sidebar.h"
 #include "menu.h"
+#include "search_projects.h"
 
 
 typedef enum

--- a/workbench/src/sidebar.c
+++ b/workbench/src/sidebar.c
@@ -1647,7 +1647,7 @@ static void sidebar_set_context (SIDEBAR_CONTEXT *context, guint dataid, gpointe
 
 
 /* Internal call foreach function. Traverses the whole sidebar. */
-void sidebar_call_foreach_int(SB_CALLFOREACH_CONTEXT *foreach_cntxt,
+static void sidebar_call_foreach_int(SB_CALLFOREACH_CONTEXT *foreach_cntxt,
 							  GtkTreeIter *iter)
 {
 	guint currentid;

--- a/workbench/src/tm_control.c
+++ b/workbench/src/tm_control.c
@@ -27,6 +27,7 @@
 
 #include <geanyplugin.h>
 #include "idle_queue.h"
+#include "tm_control.h"
 
 extern GeanyData *geany_data;
 static GHashTable *wb_tm_file_table = NULL;

--- a/workbench/src/tm_control.h
+++ b/workbench/src/tm_control.h
@@ -21,8 +21,8 @@
 
 void wb_tm_control_init (void);
 void wb_tm_control_cleanup (void);
-void wb_tm_control_source_file_add(const gchar *filename);
-void wb_tm_control_source_file_remove(const gchar *filename);
+void wb_tm_control_source_file_add(gchar *filename);
+void wb_tm_control_source_file_remove(gchar *filename);
 void wb_tm_control_source_files_remove(GPtrArray *files);
 void wb_tm_control_source_files_new(GPtrArray *files);
 

--- a/workbench/src/wb_project.c
+++ b/workbench/src/wb_project.c
@@ -638,14 +638,11 @@ static GSList *wb_project_dir_scan_directory(WB_PROJECT_DIR *root, const gchar *
 		filelist = gp_filelist_scan_directory_callback
 						(searchdir, scan_mode_workbench_cb, &params);
 
-		g_slist_foreach(params.file_patterns_list, (GFunc) g_pattern_spec_free, NULL);
-		g_slist_free(params.file_patterns_list);
+		g_slist_free_full(params.file_patterns_list, (GDestroyNotify)g_pattern_spec_free);
 
-		g_slist_foreach(params.ignored_dirs_list, (GFunc) g_pattern_spec_free, NULL);
-		g_slist_free(params.ignored_dirs_list);
+		g_slist_free_full(params.ignored_dirs_list, (GDestroyNotify)g_pattern_spec_free);
 
-		g_slist_foreach(params.ignored_file_list, (GFunc) g_pattern_spec_free, NULL);
-		g_slist_free(params.ignored_file_list);
+		g_slist_free_full(params.ignored_file_list, (GDestroyNotify)g_pattern_spec_free);
 	}
 	else
 	{
@@ -697,8 +694,7 @@ static guint wb_project_dir_rescan_int(WB_PROJECT *prj, WB_PROJECT_DIR *root)
 		}
 	}
 
-	g_slist_foreach(lst, (GFunc) g_free, NULL);
-	g_slist_free(lst);
+	g_slist_free_full(lst, g_free);
 
 	return filenum;
 }
@@ -797,8 +793,7 @@ static void wb_project_dir_add_file_int(WB_PROJECT *prj, WB_PROJECT_DIR *root, c
 			}
 		}
 
-		g_slist_foreach(scanned, (GFunc) g_free, NULL);
-		g_slist_free(scanned);
+		g_slist_free_full(scanned, g_free);
 	}
 }
 


### PR DESCRIPTION
I've been testing my plugin in geany for windows. The geany-plugins repo apparently doesn't get a lot of windows maintenance as the windows build is noisy as hell.

I count 54 warnings in the windows build from master. That seems small, but the console spam is horrible after 50 builds in a day.

This changeset gets it down to 30.

I was unable to reduce it any further due to LSP's frequent use of aggregate-return and ignoring sign compares.

I have broken each commit up by each plugin, so you can back out any block you don't want to deal with right now.

Closes geany/geany-plugins#1588

One change that needs special highlighting.
```#define _WIN32_WINNT 0x0501``` was removed from scope/src/thread.c
This shouldn't matter because your build process should be setting _WIN32_WINNT for the entire build in CFLAG.

Closes geany/geany-plugins#1587
