### PR TITLE
[git-changebar] Marker unload fixes, and system color support

### DIFF
--- a/git-changebar/data/prefs.ui
+++ b/git-changebar/data/prefs.ui
@@ -5,7 +5,7 @@
   <object class="GtkVBox" id="base">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
-    <property name="spacing">6</property>
+    <property name="spacing">7</property>
     <child>
       <object class="GtkCheckButton" id="monitoring-check">
         <property name="label" translatable="yes">_Monitor repository for changes</property>
@@ -21,6 +21,23 @@
         <property name="expand">False</property>
         <property name="fill">True</property>
         <property name="position">0</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkCheckButton" id="system-colors">
+        <property name="label" translatable="yes">_Use System Colors</property>
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+        <property name="receives_default">False</property>
+        <property name="tooltip_text" translatable="yes">Use colors set in colorscheme for line_added, line_removed, line_changed</property>
+        <property name="use_underline">True</property>
+        <property name="xalign">0</property>
+        <property name="draw_indicator">True</property>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">1</property>
       </packing>
     </child>
     <child>
@@ -173,7 +190,7 @@
       <packing>
         <property name="expand">True</property>
         <property name="fill">True</property>
-        <property name="position">1</property>
+        <property name="position">2</property>
       </packing>
     </child>
   </object>

--- a/git-changebar/src/gcb-plugin.c
+++ b/git-changebar/src/gcb-plugin.c
@@ -31,6 +31,7 @@
 #include <geanyplugin.h>
 #include <geany.h>
 #include <document.h>
+#include <SciLexer.h>
 
 #ifdef LIBGIT2_VER_MINOR
 # define CHECK_LIBGIT2_VERSION(MAJOR, MINOR) \
@@ -187,6 +188,7 @@ static GAsyncQueue     *G_queue               = NULL;
 static GThread         *G_thread              = NULL;
 static gulong           G_source_id           = 0;
 static gboolean         G_monitoring_enabled  = TRUE;
+static gboolean         G_system_colors       = TRUE;
 static GtkWidget       *G_undo_menu_item      = NULL;
 static struct {
   gint    num;
@@ -212,6 +214,8 @@ static const struct {
                          gconstpointer  value);
 } G_settings_desc[] = {
   { "general", "monitor-repository", &G_monitoring_enabled,
+    read_setting_boolean, write_setting_boolean },
+  { "general", "system-colors", &G_system_colors,
     read_setting_boolean, write_setting_boolean },
   { "colors", "line-added", &G_markers[MARKER_LINE_ADDED].color,
     read_setting_color, write_setting_color },
@@ -1067,6 +1071,16 @@ on_editor_notify (GObject        *obj,
                   SCNotification *nt,
                   gpointer        user_data)
 {
+  /*geany doesnt emit a signal on colorscheme change*/
+   if(G_system_colors){
+    const GeanyLexerStyle * diffadd_style = highlighting_get_style   ( GEANY_FILETYPES_DIFF, SCE_DIFF_ADDED);
+    scintilla_send_message (editor->sci, SCI_MARKERSETBACK, G_markers[MARKER_LINE_ADDED].num, diffadd_style->foreground);
+    const GeanyLexerStyle * diffchg_style = highlighting_get_style   ( GEANY_FILETYPES_DIFF, SCE_DIFF_CHANGED);
+    scintilla_send_message (editor->sci, SCI_MARKERSETBACK, G_markers[MARKER_LINE_CHANGED].num, diffchg_style->foreground);
+    const GeanyLexerStyle * diffdel_style = highlighting_get_style   ( GEANY_FILETYPES_DIFF, SCE_DIFF_DELETED);
+    scintilla_send_message (editor->sci, SCI_MARKERSETBACK, G_markers[MARKER_LINE_REMOVED].num, diffdel_style->foreground);
+  }
+
   if (nt->nmhdr.code == SCN_CHARADDED ||
       (nt->nmhdr.code == SCN_MODIFIED &&
        nt->modificationType & (SC_MOD_INSERTTEXT | SC_MOD_DELETETEXT))) {
@@ -1615,6 +1629,7 @@ typedef struct ConfigureWidgets ConfigureWidgets;
 struct ConfigureWidgets {
   GtkWidget  *base;
   GtkWidget  *monitoring_check;
+  GtkWidget  *system_colors;
   GtkWidget  *added_color_button;
   GtkWidget  *changed_color_button;
   GtkWidget  *removed_color_button;
@@ -1656,6 +1671,7 @@ on_plugin_configure_response (GtkDialog        *dialog,
       GeanyDocument  *doc = document_get_current ();
       
       G_monitoring_enabled = gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (cw->monitoring_check));
+      G_system_colors = gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (cw->system_colors));
       gtk_color_button_get_color (GTK_COLOR_BUTTON (cw->added_color_button),
                                   &color);
       G_markers[MARKER_LINE_ADDED].color = color_to_int (&color);
@@ -1717,6 +1733,7 @@ plugin_configure (GtkDialog *dialog)
     } map[] = {
       { "base",                 &cw->base },
       { "monitoring-check",     &cw->monitoring_check },
+      { "system-colors",     &cw->system_colors },
       { "added-color-button",   &cw->added_color_button },
       { "changed-color-button", &cw->changed_color_button },
       { "removed-color-button", &cw->removed_color_button },
@@ -1729,6 +1746,8 @@ plugin_configure (GtkDialog *dialog)
     
     gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (cw->monitoring_check),
                                   G_monitoring_enabled);
+    gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (cw->system_colors),
+                                  G_system_colors);
     color_from_int (&color, G_markers[MARKER_LINE_ADDED].color);
     gtk_color_button_set_color (GTK_COLOR_BUTTON (cw->added_color_button),
                                 &color);

--- a/git-changebar/src/gcb-plugin.c
+++ b/git-changebar/src/gcb-plugin.c
@@ -648,6 +648,8 @@ release_resources (ScintillaObject *sci)
     
     for (j = 0; j < MARKER_COUNT; j++) {
       if (G_markers[j].num >= 0) {
+        scintilla_send_message (sci, SCI_MARKERDELETEALL,
+                                G_markers[j].num, 0);
         scintilla_send_message (sci, SCI_MARKERDEFINE,
                                 G_markers[j].num, SC_MARK_AVAILABLE);
       }


### PR DESCRIPTION
Why is this?
As noted in https://github.com/geany/geany-plugins/issues/1558, when git-changebar unloads, it doesn't cleanup all its markers.
As requested in the same ticket, git-changebar only has one color scheme, but geany supports many. Provide an option to allow git-changebar to use system colors.

As a note, since git-changebar uses markers, and colors are set for lines, I stole the foreground color from 
```
# Diff
line_added
line_removed
line_changed
```
to use as the marker background.
I also had to abuse editor-notify as geany doesn't emit any signals for [colorscheme-change](https://github.com/geany/geany/issues/4637). 

Fixes https://github.com/geany/geany-plugins/issues/1558
Contributed under GPL-2.0-or-later.
